### PR TITLE
Enforce HTTPS for manualUrl in image loader

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -94,7 +94,8 @@ document.addEventListener('DOMContentLoaded', function() {
     function getImageUrl(card) {
         // Priority 1: Manual URL Override.
         if (card.manualUrl) {
-            return card.manualUrl;
+            // Enforce HTTPS for manual URLs to prevent mixed content issues.
+            return card.manualUrl.startsWith('http://') ? card.manualUrl.replace('http://', 'https://') : card.manualUrl;
         }
 
         const imageTypeConfigs = [{


### PR DESCRIPTION
The `getImageUrl` function in `scripts.js` allows for a `manualUrl` to be specified in the card data. This could potentially lead to mixed content issues if an `http://` URL is provided.

This change modifies the `getImageUrl` function to check for `http://` at the beginning of the `manualUrl` and replaces it with `https://` if found. This ensures that all manually specified images are loaded over a secure connection, preventing potential mixed content warnings in the browser.