### PR TITLE
Fix various consistency issues in JSON data files

### DIFF
--- a/hBP01.json
+++ b/hBP01.json
@@ -463,7 +463,7 @@
                 "description": "If you Center holomem has #ID, this Art gains +50 power."
             }
         ],
-        "extraEffect": "When this Holomen is downed, your life is reduced by 2",
+        "extraEffect": "When this holomem is downed, your life is reduced by 2.",
         "hasAlternativeArt": true
     },
     {
@@ -640,7 +640,7 @@
         "bloomLevel": "Debut",
         "hp": 90,
         "color": "Green",
-        "tag": " #JP #Gen3 #Kemomimi",
+        "tag": "#JP #Gen3 #Kemomimi",
         "skills": [
             {
                 "name": "こんぺこー!",
@@ -657,7 +657,7 @@
         "bloomLevel": "Debut",
         "hp": 60,
         "color": "Green",
-        "tag": " #JP #Gen3 #Kemomimi",
+        "tag": "#JP #Gen3 #Kemomimi",
         "collabEffect": "ギャラクシーアイドル　: If your Oshi holomem is 〈Usada Pekora〉, you may roll a die once:If it is even, send the top card of your cheer deck to your holomem.",
         "skills": [
             {
@@ -674,7 +674,7 @@
         "bloomLevel": "Debut",
         "hp": 150,
         "color": "Green",
-        "tag": " #JP #Gen3 #Kemomimi",
+        "tag": "#JP #Gen3 #Kemomimi",
         "skills": [
             {
                 "name": "無重力ジャンプ!",
@@ -689,7 +689,7 @@
         "bloomLevel": "1st",
         "hp": 90,
         "color": "Green",
-        "tag": " #JP #Gen3 #Kemomimi",
+        "tag": "#JP #Gen3 #Kemomimi",
         "bloomEffect": "成長した兎田べこらを: Send the top card of your cheer deck to your center Holomen or collab Holomen.",
         "skills": [
             {
@@ -705,7 +705,7 @@
         "bloomLevel": "1st",
         "hp": 120,
         "color": "Green",
-        "tag": " #JP #Gen3 #Kemomimi",
+        "tag": "#JP #Gen3 #Kemomimi",
         "skills": [
             {
                 "name": "白い砂浜と兎少女",
@@ -725,7 +725,7 @@
         "bloomLevel": "2nd",
         "hp": 200,
         "color": "Green",
-        "tag": " #JP #Gen3 #Kemomimi",
+        "tag": "#JP #Gen3 #Kemomimi",
         "bloomEffect": "ラプリンセスドレス: Restore 50 HP to this Holomen.",
         "skills": [
             {
@@ -743,7 +743,7 @@
         "bloomLevel": "Debut",
         "hp": 100,
         "color": "Green",
-        "tag": " #JP #Gen0 #Singing",
+        "tag": "#JP #Gen0 #Singing",
         "skills": [
             {
                 "name": "こんあずき～!",
@@ -758,7 +758,7 @@
         "rarity": "U",
         "bloomLevel": "Debut",
         "hp": 50,
-        "tag": " #JP #Gen0 #Singing",
+        "tag": "#JP #Gen0 #Singing",
         "color": "Green",
         "giftEffect": "While your Life is 3 or less, you may ignore Bloom level and Bloom this holomem to your hand's 2nd 〈AZKi〉.",
         "skills": [
@@ -775,7 +775,7 @@
         "bloomLevel": "1st",
         "hp": 100,
         "color": "Green",
-        "tag": " #JP #Gen0 #Singing",
+        "tag": "#JP #Gen0 #Singing",
         "bloomEffect": "開拓者のみんながいたから: You may choose 1~3 cheers from your stage, and reattach them to your holomem as you choose.",
         "skills": [
             {
@@ -792,7 +792,7 @@
         "hp": 220,
         "rarity": "RR",
         "color": "Green",
-        "tag": " #JP #Gen0 #Singing",
+        "tag": "#JP #Gen0 #Singing",
         "bloomEffect": "いのちの軌跡: Restore 40 HP to this holomem. You may roll a die once:If it is odd, you may send 1~3 green cheers from your archive to this holomem.",
         "skills": [
             {
@@ -874,7 +874,7 @@
                 "dmg": 70
             }
         ],
-        "extraEffect": "When this Holomen is downed, your life is reduced by 2",
+        "extraEffect": "When this holomem is downed, your life is reduced by 2.",
         "hasAlternativeArt": true
     },
     {
@@ -1154,7 +1154,7 @@
     },
     {
         "cardNumber": "hBP01-068",
-        "name": "Omaru Polkaa",
+        "name": "Omaru Polka",
         "rarity": "C",
         "bloomLevel": "Debut",
         "hp": 70,
@@ -1172,7 +1172,7 @@
     },
     {
         "cardNumber": "hBP01-069",
-        "name": "Omaru Polkaa",
+        "name": "Omaru Polka",
         "rarity": "C",
         "bloomLevel": "1st",
         "hp": 180,
@@ -1223,7 +1223,7 @@
                 "description": "This Arts gets +20 for each fan attached to all of your holomem."
             }
         ],
-        "extraEffect": "When this Holomen is downed, your life is reduced by 2",
+        "extraEffect": "When this holomem is downed, your life is reduced by 2.",
         "hasAlternativeArt": true
     },
     {
@@ -1565,7 +1565,7 @@
                 "description": "You may archive 1 [green cheer or blue cheer] from this holomem:Deal 30 Special Damage to 1 of your opponent's back holomem."
             }
         ],
-        "extraEffect": "When this Holomen is downed, your life is reduced by 2",
+        "extraEffect": "When this holomem is downed, your life is reduced by 2.",
         "hasAlternativeArt": true
     },
     {
@@ -1644,7 +1644,7 @@
         "bloomLevel": "Spot",
         "hp": 80,
         "color": "Colorless",
-        "tag": " #JP #Gen3 #Kemomimi",
+        "tag": "#JP #Gen3 #Kemomimi",
         "collabEffect": "それは「冒険」: You may roll a die once:If it is even, reveal a Buzz holomem from your deck, and add it to hand. Then, shuffle the deck.",
         "skills": [
             {
@@ -1652,7 +1652,7 @@
                 "dmg": 10
             }
         ],
-        "extraEffect": " This holomem cannot Bloom"
+        "extraEffect": "This holomem cannot Bloom."
     },
     {
         "cardNumber": "hBP01-097",
@@ -1661,7 +1661,7 @@
         "bloomLevel": "Spot",
         "hp": 80,
         "color": "Colorless",
-        "tag": " #JP #Gen3 #Half-Elf",
+        "tag": "#JP #Gen3 #Half-Elf",
         "collabEffect": "それは「愛と絆の物語」: Exchange your center holomem with 1 non-resting back holomem.",
         "skills": [
             {
@@ -1669,7 +1669,7 @@
                 "dmg": "20"
             }
         ],
-        "extraEffect": " This holomem cannot Bloom"
+        "extraEffect": "This holomem cannot Bloom."
     },
     {
         "cardNumber": "hBP01-098",
@@ -1678,7 +1678,7 @@
         "bloomLevel": "Spot",
         "hp": 90,
         "color": "Colorless",
-        "tag": " #JP #Gen3 #Alcohol",
+        "tag": "#JP #Gen3 #Alcohol",
         "collabEffect": "それは「俺」: You may send 1 cheer from your archive to your holomem.",
         "skills": [
             {
@@ -1686,7 +1686,7 @@
                 "dmg": 20
             }
         ],
-        "extraEffect": " This holomem cannot Bloom"
+        "extraEffect": "This holomem cannot Bloom."
     },
     {
         "cardNumber": "hBP01-099",
@@ -1695,7 +1695,7 @@
         "bloomLevel": "Spot",
         "hp": 90,
         "color": "Colorless",
-        "tag": " #JP #Gen3 #Painting #Sea",
+        "tag": "#JP #Gen3 #Painting #Sea",
         "collabEffect": "それは「エジンバラ城」: You may roll a die once:If it is odd, exchange your opponent's center holomem with 1 back holomem.",
         "skills": [
             {
@@ -1703,7 +1703,7 @@
                 "dmg": 10
             }
         ],
-        "extraEffect": " This holomem cannot Bloom"
+        "extraEffect": "This holomem cannot Bloom."
     },
     {
         "cardNumber": "hBP01-100",
@@ -1712,7 +1712,7 @@
         "bloomLevel": "Spot",
         "hp": 70,
         "color": "Colorless",
-        "tag": " #EN #Myth #Singing",
+        "tag": "#EN #Myth #Singing",
         "collabEffect": "ソウル収穫　: You may return 1~3 cheers from your archive to the cheer deck. Then, shuffle the cheer deck.",
         "skills": [
             {
@@ -1720,7 +1720,7 @@
                 "dmg": 30
             }
         ],
-        "extraEffect": " This holomem cannot Bloom"
+        "extraEffect": "This holomem cannot Bloom."
     },
     {
         "cardNumber": "hBP01-101",
@@ -1729,7 +1729,7 @@
         "bloomLevel": "Spot",
         "hp": 80,
         "color": "Colorless",
-        "tag": " #EN #Myth",
+        "tag": "#EN #Myth",
         "collabEffect": "ソウル収穫　: You may return 1 item from your archive to hand.",
         "skills": [
             {
@@ -1737,14 +1737,14 @@
                 "dmg": 20
             }
         ],
-        "extraEffect": " This holomem cannot Bloom"
+        "extraEffect": "This holomem cannot Bloom."
     },
     {
         "cardNumber": "hBP01-102",
         "name": "Idol Microphone",
         "type": "Support (Item)",
         "rarity": "U",
-        "limited": "Yes",
+        "limited": true,
         "ability": "This card can only be used if you have 6 or less cards in hand excluding this card. Look at the top 4 cards of your deck. Reveal any number of holomem with #Singing from among them, and add the revealed holomem to hand. Then, return the remaining cards to the bottom of the deck in any order."
     },
     {
@@ -1752,7 +1752,7 @@
         "name": "Gaming PC",
         "type": "Support (Item)",
         "rarity": "U",
-        "limited": "Yes",
+        "limited": true,
         "ability": "This card can only be used if you archive 1 of your holo Powers.Reveal 1 [Debut holomem or 1st holomem] other than Buzz from your deck with the same color as your Oshi holomem, and add it to hand. Then, shuffle the deck."
     },
     {
@@ -1767,7 +1767,7 @@
         "name": "Penlight",
         "type": "Support (Item)",
         "rarity": "U",
-        "limited": "Yes",
+        "limited": true,
         "ability": "This card can only be used if you archive 1 of your holo Powers. Reveal 1 cheer from your cheer deck with the same color as 1 of your holomem, and send it to your holomem. Then, shuffle the cheer deck."
     },
     {
@@ -1775,7 +1775,7 @@
         "name": "I leave the rest to you!",
         "type": "Support (Event)",
         "rarity": "U",
-        "limited": "Yes",
+        "limited": true,
         "ability": "Swap your center holomem with 1 non-resting back holomem."
     },
     {
@@ -1790,7 +1790,7 @@
         "name": "So, That Makes You My Enemy",
         "type": "Support (Event)",
         "rarity": "U",
-        "limited": "Yes",
+        "limited": true,
         "ability": "Swap your opponent's center holomem with 1 back holomem."
     },
     {
@@ -1798,7 +1798,7 @@
         "name": "Tale of the Moon and the Rabbit",
         "type": "Support (Event)",
         "rarity": "U",
-        "limited": "Yes",
+        "limited": true,
         "ability": "This card can only be used if you have 6 or less cards in hand excluding this card. Look at the top 4 cards of your deck. Reveal any number of 〈Usada Pekora〉 and/or 〈Moona Hoshinova〉 from among them, and add the revealed holomem to hand. Then, return the remaining cards to the bottom of the deck in any order."
     },
     {
@@ -1806,7 +1806,7 @@
         "name": "I'll smack you with a blunt weapon!",
         "type": "Support (Event)",
         "rarity": "U",
-        "limited": "Yes",
+        "limited": true,
         "ability": "Roll a die once:If it is 3 or less, archive 1 of your opponent's holomem's cheers.◆If your Oshi holomem is 〈Nanashi Mumei〉, you may Ability Shift [once per game] Archive 2 of your opponent's center holomem's cheers."
     },
     {
@@ -1814,7 +1814,7 @@
         "name": "hololive Indonesia Gen ３",
         "type": "Support (Event)",
         "rarity": "U",
-        "limited": "Yes",
+        "limited": true,
         "ability": "This card can only be used if you have 6 or less cards in hand excluding this card. Look at the top 4 cards of your deck. Reveal any number of holomem with #IDGen3 from among them, and add the revealed holomem to hand. Then, return the remaining cards to the bottom of the deck in any order."
     },
     {

--- a/hBP02.json
+++ b/hBP02.json
@@ -142,7 +142,7 @@
                 "dmg": "30"
             }
         ],
-        "extraEffect": "This Holomen can be included in your deck in any number of copies."
+        "extraEffect": "You may include any number of this holomem in your deck."
     },
     {
         "cardNumber": "hBP02-009",
@@ -248,7 +248,7 @@
                 "dmg": "20"
             }
         ],
-        "extraEffect": "This Holomen can be included in your deck in any number of copies.",
+        "extraEffect": "You may include any number of this holomem in your deck.",
         "hasHolomenRare": true,
         "imageSet": "hBP05"
     },
@@ -309,7 +309,7 @@
                 "description": "(Collab position only) For each other Holomen on your stage with the #Gen3 tag, this Arts gets +20. However, the number of Holomen counted is limited to 4.."
             }
         ],
-        "extraEffect": "When this Holomen is downed, your life is reduced by 2",
+        "extraEffect": "When this holomem is downed, your life is reduced by 2.",
         "hasAlternativeArt": true,
         "hasFullArt": true
     },
@@ -327,7 +327,7 @@
                 "dmg": "30"
             }
         ],
-        "extraEffect": "This Holomen can be included in your deck in any number of copies."
+        "extraEffect": "You may include any number of this holomem in your deck."
     },
     {
         "cardNumber": "hBP02-019",
@@ -431,7 +431,7 @@
                 "dmg": "10"
             }
         ],
-        "extraEffect": "This Holomen can be included in your deck in any number of copies."
+        "extraEffect": "You may include any number of this holomem in your deck."
     },
     {
         "cardNumber": "hBP02-025",
@@ -485,7 +485,7 @@
                 "description": "You may Archive the top card of your Deck. If it's a holomem, this Art gains +20 power. If it's a Support card, this Art gains +50 power."
             }
         ],
-        "extraEffect": "When this Holomen is downed, your life is reduced by 2",
+        "extraEffect": "When this holomem is downed, your life is reduced by 2.",
         "hasAlternativeArt": true,
         "hasFullArt": true
     },
@@ -503,7 +503,7 @@
                 "dmg": "30"
             }
         ],
-        "extraEffect": "This Holomen can be included in your deck in any number of copies"
+        "extraEffect": "You may include any number of this holomem in your deck.
     },
     {
         "cardNumber": "hBP02-029",
@@ -614,7 +614,7 @@
                 "description": "If this holomem has a Tool or Mascot attached, deal 30 special damage to your opponent's Center or Collab holomem."
             }
         ],
-        "extraEffect": "When this Holomen is downed, your life is reduced by 2",
+        "extraEffect": "When this holomem is downed, your life is reduced by 2.",
         "hasAlternativeArt": true,
         "hasFullArt": true
     },
@@ -632,7 +632,7 @@
                 "dmg": "30"
             }
         ],
-        "extraEffect": "This Holomen can be included in your deck in any number of copies."
+        "extraEffect": "You may include any number of this holomem in your deck."
     },
     {
         "cardNumber": "hBP02-036",
@@ -729,7 +729,7 @@
         "hp": 230,
         "buzz": true,
         "color": "Blue",
-        "tag": " #JP #Gamers #Kemomimi #Singing",
+        "tag": "#JP #Gamers #Kemomimi #Singing",
         "giftEffect": "毒の愛　:(Center position only) All holomems named Nekomata Okayu on your stage deal +20 damage when they deal special damage to your opponent's Center holomem.",
         "skills": [
             {
@@ -738,7 +738,7 @@
                 "description": "You may archive 1 Blue Cheer from this holomem for the following effect: deal 20 special damage to your opponent's Center holomem and one of their Back holomems."
             }
         ],
-        "extraEffect": "When this Holomen is downed, your life is reduced by 2",
+        "extraEffect": "When this holomem is downed, your life is reduced by 2.",
         "hasAlternativeArt": true,
         "hasFullArt": true
     },
@@ -749,14 +749,14 @@
         "bloomLevel": "Debut",
         "hp": 130,
         "color": "Purple",
-        "tag": " #JP #Gen2",
+        "tag": "#JP #Gen2",
         "skills": [
             {
                 "name": "どうも～",
                 "dmg": "20"
             }
         ],
-        "extraEffect": "This Holomen can be included in your deck in any number of copies."
+        "extraEffect": "You may include any number of this holomem in your deck."
     },
     {
         "cardNumber": "hBP02-043",
@@ -765,7 +765,7 @@
         "bloomLevel": "Debut",
         "hp": 50,
         "color": "Purple",
-        "tag": " #JP #Gen2",
+        "tag": "#JP #Gen2",
         "collabEffect": "魔法見せてあげる　: You may roll a dice: If the result is 4 or more, reveal a card with #Magic from your deck and put it into your hand. Then shuffle your deck.",
         "skills": [
             {
@@ -781,7 +781,7 @@
         "bloomLevel": "1st",
         "hp": 170,
         "color": "Purple",
-        "tag": " #JP #Gen2",
+        "tag": "#JP #Gen2",
         "skills": [
             {
                 "name": "照れくさ",
@@ -801,7 +801,7 @@
         "bloomLevel": "1st",
         "hp": 130,
         "color": "Purple",
-        "tag": " #JP #Gen2",
+        "tag": "#JP #Gen2",
         "bloomEffect": "久しぶりの全体ライブーっ！！: Look at the top three cards of your Deck. Reveal one that is a Blue or Purple holomem and put it into your hand. Then put the remaining cards on the bottom of your deck in any order.",
         "skills": [
             {
@@ -818,7 +818,7 @@
         "bloomLevel": "1st",
         "hp": 130,
         "color": "Purple",
-        "tag": " #JP #Gen2",
+        "tag": "#JP #Gen2",
         "bloomEffect": "れ替えの魔法　: You may Archive a card from your hand for the following effect: return a card with #Magic from your Archive to your hand.",
         "skills": [
             {
@@ -836,7 +836,7 @@
         "bloomLevel": "2nd",
         "hp": 130,
         "color": "Purple",
-        "tag": " #JP #Gen2",
+        "tag": "#JP #Gen2",
         "bloomEffect": "いたずらの魔法:You may roll a dice: if the result is 4 or more, move 1 Cheer from one of your opponent's holomems to another.",
         "skills": [
             {
@@ -864,7 +864,7 @@
                 "dmg": "20"
             }
         ],
-        "extraEffect": "This Holomen can be included in your deck in any number of copies."
+        "extraEffect": "You may include any number of this holomem in your deck."
     },
     {
         "cardNumber": "hBP02-049",
@@ -971,7 +971,7 @@
                 "description": "If there are any holomems in your Archive, this Art gains +10 power."
             }
         ],
-        "extraEffect": "This Holomen can be included in your deck in any number of copies."
+        "extraEffect": "You may include any number of this holomem in your deck."
     },
     {
         "cardNumber": "hBP02-055",
@@ -1075,7 +1075,7 @@
                 "dmg": "80+"
             }
         ],
-        "extraEffect": "When this Holomen is downed, your life is reduced by 2",
+        "extraEffect": "When this holomem is downed, your life is reduced by 2.",
         "hasFullArt": true
     },
     {
@@ -1092,7 +1092,7 @@
                 "dmg": "10"
             }
         ],
-        "extraEffect": "This Holomen can be included in your deck in any number of copies."
+        "extraEffect": "You may include any number of this holomem in your deck."
     },
     {
         "cardNumber": "hBP02-062",
@@ -1143,7 +1143,7 @@
                 "description": "If there are 5 or more holomems with #Myth in your Archive, you may move 1 Cheer from this holomem to one of your other holomems. If there are 10 or more, this Art gains +50 power."
             }
         ],
-        "extraEffect": "When this Holomen is downed, your life is reduced by 2",
+        "extraEffect": "When this holomem is downed, your life is reduced by 2.",
         "hasAlternativeArt": true,
         "hasFullArt": true
     },
@@ -1154,14 +1154,14 @@
         "bloomLevel": "Debut",
         "hp": 90,
         "color": "Purple",
-        "tag": " #EN #Advent #Singing #Bird",
+        "tag": "#EN #Advent #Singing #Bird",
         "skills": [
             {
                 "name": "Hiya darlings!",
                 "dmg": "30"
             }
         ],
-        "extraEffect": "This Holomen can be included in your deck in any number of copies.",
+        "extraEffect": "You may include any number of this holomem in your deck.",
         "hasHolomenRare": true,
         "imageSet": "hBP05"
     },
@@ -1172,7 +1172,7 @@
         "bloomLevel": "1st",
         "hp": 150,
         "color": "Purple",
-        "tag": " #EN #Advent #Singing #Bird",
+        "tag": "#EN #Advent #Singing #Bird",
         "skills": [
             {
                 "name": "良い響きですね",
@@ -1192,7 +1192,7 @@
         "bloomLevel": "1st",
         "hp": 120,
         "color": "Purple",
-        "tag": " #EN #Advent #Singing #Bird",
+        "tag": "#EN #Advent #Singing #Bird",
         "bloomEffect": "ネリッサとお茶会　Look at the top three cards of your Deck. Reveal one that is a holomem with #Singing and put it into your hand. Then put the remaining cards on the bottom of your Deck in any order",
         "skills": [
             {
@@ -1209,7 +1209,7 @@
         "bloomLevel": "2nd",
         "hp": 210,
         "color": "Purple",
-        "tag": " #EN #Advent #Singing #Bird",
+        "tag": "#EN #Advent #Singing #Bird",
         "collabEffect": "音の魔人 The Arts of your Center and Collab holomems with #Singing gain +30 power until the end of the turn.",
         "skills": [
             {
@@ -1234,7 +1234,7 @@
                 "dmg": 20
             }
         ],
-        "extraEffect": "This Holomen cannot be Bloom",
+        "extraEffect": "This holomem cannot Bloom.",
         "hasFullArt": true
     },
     {
@@ -1252,7 +1252,7 @@
                 "dmg": 20
             }
         ],
-        "extraEffect": "This Holomen cannot be Bloom",
+        "extraEffect": "This holomem cannot Bloom.",
         "hasFullArt": true
     },
     {
@@ -1270,7 +1270,7 @@
                 "dmg": 20
             }
         ],
-        "extraEffect": "This Holomen cannot be Bloom",
+        "extraEffect": "This holomem cannot Bloom.",
         "hasFullArt": true
     },
     {
@@ -1288,7 +1288,7 @@
                 "dmg": 20
             }
         ],
-        "extraEffect": "This Holomen cannot be Bloom",
+        "extraEffect": "This holomem cannot Bloom.",
         "hasFullArt": true
     },
     {
@@ -1306,7 +1306,7 @@
                 "dmg": 20
             }
         ],
-        "extraEffect": "This Holomen cannot be Bloom",
+        "extraEffect": "This holomem cannot Bloom.",
         "hasFullArt": true
     },
     {
@@ -1324,7 +1324,7 @@
                 "dmg": 20
             }
         ],
-        "extraEffect": "This Holomen cannot be Bloom",
+        "extraEffect": "This holomem cannot Bloom.",
         "hasFullArt": true
     },
     {
@@ -1332,7 +1332,7 @@
         "name": "アイドルサインペン (Idol Felt Pen)",
         "type": "Support (Item)",
         "rarity": "U",
-        "limited": "Yes",
+        "limited": true,
         "ability": "This card can only be played if you have 6 or fewer cards in your hand, excluding this card. Look at the top four cards of your Deck. Reveal any number of them that are holomems with #Painting and put them into your hand. Then put the remaining cards on the bottom of your Deck in any order.",
         "hasFoils": true
     },
@@ -1349,7 +1349,7 @@
         "name": "レトロパソコン (Retro PC)",
         "type": "Support (Item)",
         "rarity": "C",
-        "limited": "Yes",
+        "limited": true,
         "ability": "This card can only be played if you have 3 or less LIFE. Return 1 holomem from your Archive to your hand.",
         "hasFoils": true
     },
@@ -1358,7 +1358,7 @@
         "name": "かなた建設 (Kanata Construction)",
         "type": "Support (Event)",
         "rarity": "U",
-        "limited": "Yes",
+        "limited": true,
         "ability": "This card can only be played if you have 6 or fewer cards in your hand, excluding this card. Look at the top four cards of your Deck. Reveal any number of them that are holomems named <Amane Kanata>, <AZKi>, or <Sakamata Chloe> and put them into your hand. Then put the remaining cards on the bottom of your Deck in any order.",
         "hasFoils": true
     },
@@ -1376,7 +1376,7 @@
         "name": "秘密結社holoX (Secret Society holoX)",
         "type": "Support (Event)",
         "rarity": "U",
-        "limited": "Yes",
+        "limited": true,
         "ability": "This card can only be played if you have 6 or fewer cards in your hand, excluding this card. Look at the top four cards of your Deck. Reveal any number of them that are holomems with #holoX and put them into your hand. Then put the remaining cards on the bottom of your Deck in any order.",
         "hasFoils": true
     },
@@ -1385,7 +1385,7 @@
         "name": "ホロライブインドネシア2期生 (hololive ID 2nd Generation)",
         "type": "Support (Event)",
         "rarity": "U",
-        "limited": "Yes",
+        "limited": true,
         "ability": "This card can only be played if you have 6 or fewer cards in your hand, excluding this card. Look at the top four cards of your Deck. Reveal any number of them that are holomems with #IDGen2 and put them into your hand. Then put the remaining cards on the bottom of your Deck in any order.",
         "hasFoils": true
     },
@@ -1394,7 +1394,7 @@
         "name": "ホロライブゲーマーズ (hololive GAMERS)",
         "type": "Support (Event)",
         "rarity": "U",
-        "limited": "Yes",
+        "limited": true,
         "ability": "This card can only be played if you have 6 or fewer cards in your hand, excluding this card. Look at the top four cards of your Deck.Look at the top four cards of your Deck. Reveal any number of them that are holomems with #Gamers and put them into your hand. Then put the remaining cards on the bottom of your Deck in any order.",
         "hasFoils": true
     },
@@ -1412,7 +1412,7 @@
         "name": "みっころね24 (Mikkorone24)",
         "type": "Support (Event)",
         "rarity": "U",
-        "limited": "Yes",
+        "limited": true,
         "ability": "Draw 2 cards, then roll a dice. If the result is 3, 5, or 6, reveal a Debut holomem from your deck and put into your hand, then shuffle your deck. If the result is 2 or 4, draw a card.",
         "hasFoils": true,
         "hasSigned" : true
@@ -1422,7 +1422,7 @@
         "name": "HOLOLIVE FANTASY",
         "type": "Support (Event)",
         "rarity": "U",
-        "limited": "Yes",
+        "limited": true,
         "ability": "This card can only be played if you have 6 or fewer cards in your hand, excluding this card. Look at the top four cards of your Deck. Reveal any number of them that are holomems with #Gen3 and put them into your hand. Then put the remaining cards on the bottom of your Deck in any order.",
         "hasFoils": true
     },

--- a/hBP03.json
+++ b/hBP03.json
@@ -162,7 +162,7 @@
                 "description": "If there are no <Luknight> attached to any holomems on your Stage, reveal a <Luknight> from your deck and attach it to any of your holomems. Then shuffle your deck."
             }
         ],
-        "extraEffect": "This Holomen can be included in your deck in any number of copies."
+        "extraEffect": "You may include any number of this holomem in your deck."
     },
     {
         "cardNumber": "hBP03-010",
@@ -288,7 +288,7 @@
                 "dmg": "30"
             }
         ],
-        "extraEffect": "This Holomen can be included in your deck in any number of copies."
+        "extraEffect": "You may include any number of this holomem in your deck."
     },
     {
         "cardNumber": "hBP03-017",
@@ -398,7 +398,7 @@
             }
         ],
         "hasFullArt": true,
-        "extraEffect": "When this Holomen is downed, your life is reduced by 2"
+        "extraEffect": "When this holomem is downed, your life is reduced by 2."
     },
     {
         "cardNumber": "hBP03-023",
@@ -418,7 +418,7 @@
             }
         ],
         "hasFullArt": true,
-        "extraEffect": "When this Holomen is downed, your life is reduced by 2"
+        "extraEffect": "When this holomem is downed, your life is reduced by 2."
     },
     {
         "cardNumber": "hBP03-024",
@@ -453,7 +453,7 @@
                 "dmg": "30"
             }
         ],
-        "extraEffect": "This Holomen can be included in your deck in any number of copies."
+        "extraEffect": "You may include any number of this holomem in your deck."
     },
     {
         "cardNumber": "hBP03-026",
@@ -564,7 +564,7 @@
                 "dmg": "30"
             }
         ],
-        "extraEffect": "This Holomen can be included in your deck in any number of copies."
+        "extraEffect": "You may include any number of this holomem in your deck."
     },
     {
         "cardNumber": "hBP03-032",
@@ -616,7 +616,7 @@
                 "description": "You may roll a dice: if the result is odd, deal 20 special damage to your opponent's Center and Collab holomems. If the result is even, this Art gains +40 power."
             }
         ],
-        "extraEffect": "When this Holomen is downed, your life is reduced by 2",
+        "extraEffect": "When this holomem is downed, your life is reduced by 2.",
         "hasAlternativeArt": true,
         "hasFullArt": true
     },
@@ -637,7 +637,7 @@
             }
         ],
         "hasFullArt": true,
-        "extraEffect": "When this Holomen is downed, your life is reduced by 2"
+        "extraEffect": "When this holomem is downed, your life is reduced by 2."
     },
     {
         "cardNumber": "hBP03-036",
@@ -671,7 +671,7 @@
                 "description": "If there is a Fuwawa Abyssgard in your Center position, this Art can be used with no Cheer requirement."
             }
         ],
-        "extraEffect": "This Holomen can be included in your deck in any number of copies."
+        "extraEffect": "You may include any number of this holomem in your deck."
     },
     {
         "cardNumber": "hBP03-038",
@@ -707,7 +707,7 @@
                 "description": "[Collab Position only] If your Center holomem is Fuwawa Abyssgard, this Art gains +30 power."
             }
         ],
-        "extraEffect": "When this Holomen is downed, your life is reduced by 2",
+        "extraEffect": "When this holomem is downed, your life is reduced by 2.",
         "hasFullArt": true
     },
     {
@@ -724,7 +724,7 @@
                 "dmg": "30"
             }
         ],
-        "extraEffect": "This Holomen can be included in your deck in any number of copies."
+        "extraEffect": "You may include any number of this holomem in your deck."
     },
     {
         "cardNumber": "hBP03-041",
@@ -792,7 +792,7 @@
         "bloomLevel": "1st",
         "hp": 150,
         "color": "Blue",
-        "tag": " #JP #Gen0 #singing",
+        "tag": "#JP #Gen0 #singing",
         "bloomEffect": "プラネットステージ: Look at the top four cards of your Deck. Reveal 1 [Hoshimachi Suisei] from among them and put it into your hand. Then put the remaining cards on the bottom of your Deck in any order.",
         "skills": [
             {
@@ -810,7 +810,7 @@
         "bloomLevel": "1st",
         "hp": 230,
         "color": "Blue",
-        "tag": " #ID #IDGen3",
+        "tag": "#ID #IDGen3",
         "buzz": true,
         "bloomEffect": "ブルーレイン: You may Archive 1 Cheer from one of your holomems with #ID for the following effect: deal 30 damage to your opponent's Back holomems, split into units of 10 damage placed however you like. holomems Downed with this effect do not reduce LIFE.",
         "skills": [
@@ -821,7 +821,7 @@
             }
         ],
         "hasFullArt": true,
-        "extraEffect": "When this Holomen is downed, your life is reduced by 2"
+        "extraEffect": "When this holomem is downed, your life is reduced by 2."
     },
     {
         "cardNumber": "hBP03-046",
@@ -830,7 +830,7 @@
         "bloomLevel": "Debut",
         "hp": 100,
         "color": "Blue",
-        "tag": " #DEV_IS #ReGLOSS #Painting",
+        "tag": "#DEV_IS #ReGLOSS #Painting",
         "skills": [
             {
                 "name": "可愛い女の子かと思った？",
@@ -841,7 +841,7 @@
                 "dmg": "40"
             }
         ],
-        "extraEffect": "This Holomen can be included in your deck in any number of copies."
+        "extraEffect": "You may include any number of this holomem in your deck."
     },
     {
         "cardNumber": "hBP03-047",
@@ -850,7 +850,7 @@
         "bloomLevel": "1st",
         "hp": 170,
         "color": "Blue",
-        "tag": " #DEV_IS #ReGLOSS #Painting",
+        "tag": "#DEV_IS #ReGLOSS #Painting",
         "skills": [
             {
                 "name": "アフタヌーンティーデートのその後に…　",
@@ -866,7 +866,7 @@
         "bloomLevel": "1st",
         "hp": 130,
         "color": "Blue",
-        "tag": " #DEV_IS #ReGLOSS #Painting",
+        "tag": "#DEV_IS #ReGLOSS #Painting",
         "skills": [
             {
                 "name": "僕、カッコいいでしょ？",
@@ -897,7 +897,7 @@
                 "description": "Deal 10 special damage to your opponent's Center holomem or one of their Back holomems for each of your differently-named Back holomems with #ReGLOSS."
             }
         ],
-        "extraEffect": "When this Holomen is downed, your life is reduced by 2",
+        "extraEffect": "When this holomem is downed, your life is reduced by 2.",
         "hasFullArt": true
     },
     {
@@ -936,7 +936,7 @@
                 "dmg": "30"
             }
         ],
-        "extraEffect": "This Holomen can be included in your deck in any number of copies."
+        "extraEffect": "You may include any number of this holomem in your deck."
     },
     {
         "cardNumber": "hBP03-052",
@@ -1051,7 +1051,7 @@
                 "dmg": "30"
             }
         ],
-        "extraEffect": "This Holomen can be included in your deck in any number of copies."
+        "extraEffect": "You may include any number of this holomem in your deck."
     },
     {
         "cardNumber": "hBP03-058",
@@ -1125,7 +1125,7 @@
                 "dmg": "60"
             }
         ],
-        "extraEffect": "This Holomen can be included in your deck in any number of copies."
+        "extraEffect": "You may include any number of this holomem in your deck."
     },
     {
         "cardNumber": "hBP03-062",
@@ -1232,7 +1232,7 @@
                 "dmg": "30"
             }
         ],
-        "extraEffect": "This Holomen can be included in your deck in any number of copies."
+        "extraEffect": "You may include any number of this holomem in your deck."
     },
     {
         "cardNumber": "hBP03-068",
@@ -1345,7 +1345,7 @@
                 "description": "You may move 1 Cheer from this holomem to one of your holomems named Inugami Korone."
             }
         ],
-        "extraEffect": "This Holomen can be included in your deck in any number of copies."
+        "extraEffect": "You may include any number of this holomem in your deck."
     },
     {
         "cardNumber": "hBP03-074",
@@ -1474,7 +1474,7 @@
                 "dmg": 50
             }
         ],
-        "extraEffect": "This Holomen can be included in your deck in any number of copies."
+        "extraEffect": "You may include any number of this holomem in your deck."
     },
     {
         "cardNumber": "hBP03-081",
@@ -1525,7 +1525,7 @@
                 "dmg": 120
             }
         ],
-        "extraEffect": "When this Holomen is downed, your life is reduced by 2",
+        "extraEffect": "When this holomem is downed, your life is reduced by 2.",
         "hasFullArt": true
     },
     {
@@ -1533,7 +1533,7 @@
         "name": "Gorgeous PC",
         "type": "Support (Item)",
         "rarity": "U",
-        "limited": "Yes",
+        "limited": true,
         "ability": "To play this card, you must Archive one holo power. Reveal a 1st Bloom holomem that is the same color as your Oshi holomem from your Deck and put it into your hand. Then shuffle your Deck.",
         "hasFoils": true
     },
@@ -1542,7 +1542,7 @@
         "name": "Super PC",
         "type": "Support (Event)",
         "rarity": "U",
-        "limited": "Yes",
+        "limited": true,
         "ability": "Look at the top four cards of your deck. Reveal up to 1 Debut holomem and up to 1 1st Bloom holomem from among them and put them into your hand. Then put the remaining cards on the bottom of your Deck in any order.",
         "hasFoils": true
     },
@@ -1551,7 +1551,7 @@
         "name": "Dual Monitor PC",
         "type": "Support (Item)",
         "rarity": "C",
-        "ability": "Reveal 1-2 Debut holomems with the Extra text 「You may put any number of copies of this holomem in your Deck」 from your Deck and put them on your Stage. Then shuffle your Deck.",
+        "ability": "Reveal 1-2 Debut holomems with the Extra text \"You may include any number of this holomem in your deck.\" from your Deck and put them on your Stage. Then shuffle your Deck.",
         "hasFoils": true
     },
     {
@@ -1575,7 +1575,7 @@
         "name": "Fan Meeting",
         "type": "Support (Event)",
         "rarity": "U",
-        "limited": "Yes",
+        "limited": true,
         "ability": "Reveal 1 Fan from your Deck and put it into your hand. Then shuffle your Deck.",
         "hasFoils": true
     },
@@ -1601,7 +1601,7 @@
         "name": "hololive 0th Generation",
         "type": "Support (Event)",
         "rarity": "U",
-        "limited": "Yes",
+        "limited": true,
         "ability": "This card can only be played if you have 6 or fewer cards in your hand, excluding this card.Look at the top four cards of your Deck. Reveal any number of them that are holomems with #Gen0 and put them into your hand. Then put the remaining cards on the bottom of your Deck in any order.",
         "hasFoils": true
     },
@@ -1610,7 +1610,7 @@
         "name": "hololive 4th Gen",
         "type": "Support (Event)",
         "rarity": "U",
-        "limited": "Yes",
+        "limited": true,
         "ability": "This card can only be played if you have 6 or fewer cards in your hand, excluding this card. Look at the top four cards of your Deck. Reveal any number of them that are holomems with #Gen4 and put them into your hand. Then put the remaining cards on the bottom of your Deck in any order.",
         "hasFoils": true
     },
@@ -1619,7 +1619,7 @@
         "name": "FPS stream",
         "type": "Support (Event)",
         "rarity": "U",
-        "limited": "Yes",
+        "limited": true,
         "ability": "This card can only be played if you have 6 or fewer cards in your hand, excluding this card. Look at the top four cards of your Deck. Reveal any number of them that are holomems with #Shooter and put them into your hand. Then put the remaining cards on the bottom of your Deck in any order.",
         "hasFoils": true
     },

--- a/hBP04.json
+++ b/hBP04.json
@@ -137,7 +137,7 @@
         "color": "White",
         "bloomLevel": "Debut",
         "hp": 100,
-        "extraEffect": "You may put any number of copies of this holomem in your deck.",
+        "extraEffect": "You may include any number of this holomem in your deck.",
         "skills": [
             {
                 "name": "こんこよ～",
@@ -271,7 +271,7 @@
         "bloomLevel": "1st",
         "hp": 230,
         "buzz": true,
-        "extraEffect": "When this holomem is downed, take 2 Life Damage.",
+        "extraEffect": "When this holomem is downed, your life is reduced by 2.",
         "skills": [
             {
                 "name": "The Race Queen",
@@ -290,7 +290,7 @@
         "color": "White",
         "bloomLevel": "Debut",
         "hp": 100,
-        "extraEffect": "You may put any number of copies of this holomem in your deck.",
+        "extraEffect": "You may include any number of this holomem in your deck.",
         "skills": [
             {
                 "name": "チアオーラ",
@@ -362,7 +362,7 @@
         "color": "Green",
         "bloomLevel": "Debut",
         "hp": 110,
-        "extraEffect": "You may put any number of copies of this holomem in your deck.",
+        "extraEffect": "You may include any number of this holomem in your deck.",
         "skills": [
             {
                 "name": "儒烏風亭一門は前座見習い！",
@@ -518,7 +518,7 @@
         "color": "Green",
         "bloomLevel": "Debut",
         "hp": 100,
-        "extraEffect": "You may put any number of copies of this holomem in your deck.",
+        "extraEffect": "You may include any number of this holomem in your deck.",
         "skills": [
             {
                 "name": "正義の調べ",
@@ -589,7 +589,7 @@
         "color": "Red",
         "bloomLevel": "Debut",
         "hp": 100,
-        "extraEffect": "You may put any number of copies of this holomem in your deck.",
+        "extraEffect": "You may include any number of this holomem in your deck.",
         "skills": [
             {
                 "name": "こんりり",
@@ -728,7 +728,7 @@
         "color": "Red",
         "bloomLevel": "Debut",
         "hp": 120,
-        "extraEffect": "You may put any number of copies of this holomem in your deck.",
+        "extraEffect": "You may include any number of this holomem in your deck.",
         "skills": [
             {
                 "name": "おはエラ",
@@ -786,7 +786,7 @@
         "bloomLevel": "1st",
         "hp": 240,
         "buzz": true,
-        "extraEffect": "When this holomem is downed, take 2 Life Damage.",
+        "extraEffect": "When this holomem is downed, your life is reduced by 2.",
         "skills": [
             {
                 "name": "holoh3ro",
@@ -812,7 +812,7 @@
         "color": "Blue",
         "bloomLevel": "Debut",
         "hp": 90,
-        "extraEffect": "You may put any number of copies of this holomem in your deck.",
+        "extraEffect": "You may include any number of this holomem in your deck.",
         "skills": [
             {
                 "name": "こんらみ～",
@@ -949,7 +949,7 @@
         "color": "Blue",
         "bloomLevel": "Debut",
         "hp": 110,
-        "extraEffect": "You may put any number of copies of this holomem in your deck.",
+        "extraEffect": "You may include any number of this holomem in your deck.",
         "skills": [
             {
                 "name": "しおり～ん！",
@@ -1008,7 +1008,7 @@
         "hp": 230,
         "buzz": true,
         "bloomEffect": "禁断の知識 : Send the top card of your cheer deck to one of your holomem with #EN.",
-        "extraEffect": "When this holomem is downed, take 2 Life Damage.",
+        "extraEffect": "When this holomem is downed, your life is reduced by 2.",
         "skills": [
             {
                 "name": "思い出の栞",
@@ -1028,7 +1028,7 @@
         "color": "Purple",
         "bloomLevel": "Debut",
         "hp": 100,
-        "extraEffect": "You may put any number of copies of this holomem in your deck.",
+        "extraEffect": "You may include any number of this holomem in your deck.",
         "skills": [
             {
                 "name": "貴様ら、刮目せよ！！",
@@ -1145,7 +1145,7 @@
         "hp": 240,
         "buzz": true,
         "bloomEffect": "エールリバース : You may send 1 cheer from your opponent's archive to their center holomem.",
-        "extraEffect": "When this holomem is downed, take 2 Life Damage.",
+        "extraEffect": "When this holomem is downed, your life is reduced by 2.",
         "skills": [
             {
                 "name": "ゲーム配信中",
@@ -1185,7 +1185,7 @@
         "hp": 240,
         "buzz": true,
         "giftEffect": "永遠の休息 : [Center or collab position only] While this Holomem is attached with <Mori Calliope's Scythe> or <Death-sensei>, your center Holomem with the #Myth trait gets +30 to its Arts.",
-        "extraEffect": "When this holomem is downed, take 2 Life Damage.",
+        "extraEffect": "When this holomem is downed, your life is reduced by 2.",
         "skills": [
             {
                 "name": "最期の一杯",
@@ -1205,7 +1205,7 @@
         "bloomLevel": "Debut",
         "hp": 110,
         "giftEffect": "キラキラ コセキ！ : During your opponent's turn, when this Holomem is downed, draw 1 card.",
-        "extraEffect": "You may put any number of copies of this holomem in your deck.",
+        "extraEffect": "You may include any number of this holomem in your deck.",
         "skills": [
             {
                 "name": "ボンビジュー！",
@@ -1278,7 +1278,7 @@
         "color": "Yellow",
         "bloomLevel": "Debut",
         "hp": 130,
-        "extraEffect": "You may put any number of copies of this holomem in your deck.",
+        "extraEffect": "You may include any number of this holomem in your deck.",
         "skills": [
             {
                 "name": "あじまる！ あじまる！",
@@ -1401,7 +1401,7 @@
         "color": "Yellow",
         "bloomLevel": "Debut",
         "hp": 100,
-        "extraEffect": "You may put any number of copies of this holomem in your deck.",
+        "extraEffect": "You may include any number of this holomem in your deck.",
         "skills": [
             {
                 "name": "おはよー！",
@@ -1514,7 +1514,7 @@
         "bloomLevel": "Debut",
         "hp": 120,
         "giftEffect": "わっしょ～い! : If this holomem is downed during your opponent's turn, you may move 1 cheer from this holomem to one of your other holomem.",
-        "extraEffect": "You may put any number of copies of this holomem in your deck.",
+        "extraEffect": "You may include any number of this holomem in your deck.",
         "skills": [
             {
                 "name": "ホロライブの清楚担当",
@@ -1591,7 +1591,7 @@
         "color": "Yellow",
         "bloomLevel": "Debut",
         "hp": 90,
-        "extraEffect": "You may put any number of copies of this holomem in your deck.",
+        "extraEffect": "You may include any number of this holomem in your deck.",
         "skills": [
             {
                 "name": "こんねね～",
@@ -1673,7 +1673,7 @@
         "bloomLevel": "Spot",
         "hp": 140,
         "giftEffect": "『緋色の女王』: [Collab position only] Whenever your Debut holomem takes damage while in the center position, it takes -20 damage.",
-        "extraEffect": "This holomem cannot bloom.",
+        "extraEffect": "This holomem cannot Bloom.",
         "skills": [
             {
                 "name": "ERB",
@@ -1691,7 +1691,7 @@
         "bloomLevel": "Spot",
         "hp": 130,
         "giftEffect": "え？ でも面白かったじゃん！ : If this holomem is downed during your opponent's turn, send the top card of your cheer deck to any of your holomem.",
-        "extraEffect": "This holomem cannot bloom.",
+        "extraEffect": "This holomem cannot Bloom.",
         "skills": [
             {
                 "name": "怒らないでよ!",
@@ -1706,7 +1706,7 @@
         "cardNumber": "hBP04-089",
         "rarity": "U",
         "type": "Support (Item)",
-        "limited": "Yes",
+        "limited": true,
         "ability": "This card cannot be played unless you have 2 or more Holomem on your stage that each have a single, different color. Choose two Holomem on your stage that each have a single, different color. Search your deck for a 1st Holomem that is the same color as each of the chosen Holomem (excluding Buzz), reveal them, and add them to your hand. Then, shuffle your deck..",
         "hasFoils": true
     },
@@ -1715,7 +1715,7 @@
         "cardNumber": "hBP04-090",
         "rarity": "U",
         "type": "Support (Item)",
-        "limited": "Yes",
+        "limited": true,
         "ability": "This card can only be played if you have 6 or fewer cards in your hand, excluding this card. Look at the top four cards of your deck. Reveal up to one holomem and up to one Tool, Mascot, or Fan from among them and add them into your hand. Then put the remaining cards on the bottom of your deck in any order.",
         "hasFoils": true
     },
@@ -1733,7 +1733,7 @@
         "cardNumber": "hBP04-092",
         "rarity": "U",
         "type": "Support (Event)",
-        "limited": "Yes",
+        "limited": true,
         "ability": "This card can only be played if you have 6 or fewer cards in your hand, excluding this card. Look at the top four cards of your deck.You may Reveal any number of them that are holomem with #Gen5 and add them into your hand. Then put the remaining cards on the bottom of your deck in any order.",
         "hasFoils": true
     },
@@ -1742,7 +1742,7 @@
         "cardNumber": "hBP04-093",
         "rarity": "U",
         "type": "Support (Event)",
-        "limited": "Yes",
+        "limited": true,
         "ability": "This card can only be played if you have 6 or fewer cards in your hand, excluding this card. Look at the top four cards of your deck.You may Reveal any number of them that are holomem with #Gen2 and add them into your hand. Then put the remaining cards on the bottom of your deck in any order.",
         "hasFoils": true
     },
@@ -1760,7 +1760,7 @@
         "cardNumber": "hBP04-095",
         "rarity": "U",
         "type": "Support (Event)",
-        "limited": "Yes",
+        "limited": true,
         "ability": "Reveal 1 Mascot from your deck and add it into your hand. Then shuffle your deck.",
         "hasFoils": true
     },
@@ -1769,7 +1769,7 @@
         "cardNumber": "hBP04-096",
         "rarity": "U",
         "type": "Support (Event)",
-        "limited": "Yes",
+        "limited": true,
         "ability": "This card can only be played if you have 6 or fewer cards in your hand, excluding this card. Look at the top four cards of your deck.You may Reveal any number of them that are holomem with #Advent and add them into your hand. Then put the remaining cards on the bottom of your deck in any order.",
         "hasFoils": true
     },

--- a/hBP05.json
+++ b/hBP05.json
@@ -321,7 +321,7 @@
         "bloomLevel": "1st",
         "hp": 240,
         "buzz": true,
-        "extraEffect": "If this holomem is downed, you get Life-2",
+        "extraEffect": "When this holomem is downed, your life is reduced by 2.",
         "skills": [
             {
                 "name": "レトロロマン",
@@ -464,7 +464,7 @@
         "bloomLevel": "1st",
         "hp": 250,
         "buzz": true,
-        "extraEffect": "If this holomem is downed, you get Life-2",
+        "extraEffect": "When this holomem is downed, your life is reduced by 2.",
         "skills": [
             {
                 "name": "あずきんちでゆっくりしよ",
@@ -546,7 +546,7 @@
         "hp": 250,
         "buzz": true,
         "giftEffect": "ちょっと頑張りました : [Center position only][once per turn]When your Oshi holomem <Shishiro Botan> or a <Shishiro Botan> on your stage deals 30 or more Special Damage to your opponent's holomem, draw 1 card from your deck.",
-        "extraEffect": "If this holomem is downed, you get Life-2",
+        "extraEffect": "When this holomem is downed, your life is reduced by 2.",
         "skills": [
             {
                 "name": "ここからが俺たちのスタートだ",
@@ -992,7 +992,7 @@
         "hp": 250,
         "buzz": true,
         "giftEffect": "モゴジャ～～ン！！！: [Center position only]When you use your Oshi skill \"Moco-chan!\", send the top card of your cheer deck to your holomem with #Advent.",
-        "extraEffect": "If this holomem is downed, you get Life-2",
+        "extraEffect": "When this holomem is downed, your life is reduced by 2.",
         "skills": [
             {
                 "name": "キーボードクラッシャー",
@@ -1421,7 +1421,7 @@
         "bloomLevel": "1st",
         "hp": 250,
         "buzz": true,
-        "extraEffect": "If this holomem is downed, you get Life-2",
+        "extraEffect": "When this holomem is downed, your life is reduced by 2.",
         "skills": [
             {
                 "name": "君と色違いのリュック",
@@ -1488,7 +1488,7 @@
         "cardNumber": "hBP05-077",
         "rarity": "U",
         "type": "Support (Event)",
-        "limited": "Yes",
+        "limited": true,
         "ability": "This card can only be used if you have 6 or less cards in hand excluding this card. Look at the top 4 cards of your deck. Reveal any number of <Shirakami Fubuki>, <Shiranui Flare>, <Tsunomaki Watame>, and or <Omaru Polka> from among them, and add the revealed holomem to hand. Then, return the remaining cards to the bottom of the deck in any order.",
         "hasFoils" :true
     },
@@ -1497,7 +1497,7 @@
         "cardNumber": "hBP05-078",
         "rarity": "U",
         "type": "Support (Event)",
-        "limited": "Yes",
+        "limited": true,
         "ability": "This card can only be used if you have 6 or less cards in hand excluding this card. Look at the top 4 cards of your deck. Reveal any number of holomem with #Alcohol from among them, and add the revealed holomem to hand. Then, return the remaining cards to the bottom of the deck in any order.",
         "hasFoils" :true
     },
@@ -1506,7 +1506,7 @@
         "cardNumber": "hBP05-079",
         "rarity": "U",
         "type": "Support (Event)",
-        "limited": "Yes",
+        "limited": true,
         "ability": "Draw 2 cards. If your holomem was downed during your opponent's previous turn, and you have less Life than your opponent, send 1 cheer from your archive to your holomem.",
         "hasFoils" :true
     },
@@ -1515,7 +1515,7 @@
         "cardNumber": "hBP05-080",
         "rarity": "U",
         "type": "Support (Event)",
-        "limited": "Yes",
+        "limited": true,
         "ability": "Draw 2 cards from your deck. Then, look at the top 5 cards of your deck. Reveal 1 1st holomem from among them, and add the revealed card to hand. Then, return the remaining cards to the bottom of the deck in any order.",
         "hasFullArt" :true,
         "hasSigned" : true

--- a/hPR.json
+++ b/hPR.json
@@ -13,7 +13,7 @@
                 "dmg": "10"
             }
         ],
-        "extraEffect": "This Holomen cannot be Bloom",
+        "extraEffect": "This holomem cannot Bloom.",
         "source": "Sakura Miko first album 'flower rhapsody' limited edition"
     },
     {
@@ -22,7 +22,7 @@
         "type": "Support (Event)",
         "rarity": "P",
         "ability": "This card can only be played if you have 6 or fewer cards in your hand, excluding this card. Look at the top four cards of your Deck. Reveal any number of them that are holomems with #ReGLOSS and put them into your hand. Then put the remaining cards on the bottom of your Deck in any order.",
-        "limited": "Yes",
+        "limited": true,
         "source": "ReGLOSS first album 'ReGLOSS' CD bonus",
         "manualUrl": "https://hololive-official-cardgame.com/wp-content/images/cardlist/hPR/hPR-002.png"
     },

--- a/hSD01.json
+++ b/hSD01.json
@@ -6,29 +6,29 @@
         "lives": 5,
         "color": "White",
         "oshiSkill": {
-            "name": "リプレイスメント (\"Replacement\")",
+            "name": "リプレイスメント (Replacement)",
             "power": 1,
             "description": "[Once per turn] Swap one cheer card from your stage to one of your Holomen."
         },
         "spOshiSkill": {
-            "name": "じゃあ敵だね (\"then you're an enemy\")",
+            "name": "じゃあ敵だね (then you're an enemy)",
             "power": 2,
             "description": "[Once per game] Switch your opponent's center Holomen with one of their back Holomen. Then, for the duration of this turn, your white center Holomen's arts increase by 50."
         }
     },
     {
         "cardNumber": "hSD01-002",
-        "name": "Azki",
+        "name": "AZKi",
         "rarity": "OSR",
         "lives": 6,
         "color": "Green",
         "oshiSkill": {
-            "name": "左手に地図 (\"Map on the left\")",
+            "name": "左手に地図 (Map on the left)",
             "power": 3,
             "description": "[Once per turn] Usable when rolling a die with your Holomen's ability: Declare one number on the die, and treat the next rolled number as the declared number."
         },
         "spOshiSkill": {
-            "name": "手にマイク (\"Mic On the Right\")",
+            "name": "手にマイク (Mic On the Right)",
             "power": 3,
             "description": "[Once per game] Send any number of archived cheer cards to one Green Holomen."
         }
@@ -101,15 +101,15 @@
             {
                 "name": "SorAZ シンパシー",
                 "dmg": "60+",
-                "description": "When you have the Holomen 'AZKI' on your stage, this art gains +50."
+                "description": "When you have the Holomen 'AZKi' on your stage, this art gains +50."
             }
         ],
-        "extraEffect": "When this Holomen is downed, your life is reduced by 2"
+        "extraEffect": "When this holomem is downed, your life is reduced by 2."
     },
 
       {
         "cardNumber": "hSD01-007",
-        "name": "Iris",
+        "name": "IRyS",
         "rarity": "C",
         "bloomLevel": "Debut",
         "hp": 50,
@@ -126,7 +126,7 @@
     
     {
         "cardNumber": "hSD01-008",
-        "name": "Azki",
+        "name": "AZKi",
         "rarity": "C",
         "bloomLevel": "Debut",
         "hp": 70,
@@ -141,7 +141,7 @@
     },
   {
         "cardNumber": "hSD01-009",
-        "name": "Azki",
+        "name": "AZKi",
         "rarity": "R",
         "bloomLevel": "Debut",
         "hp": 60,
@@ -158,7 +158,7 @@
     
     {
         "cardNumber": "hSD01-010",
-        "name": "Azki",
+        "name": "AZKi",
         "rarity": "U",
         "bloomLevel": "1st",
         "hp": 160,
@@ -173,7 +173,7 @@
     },
      {
         "cardNumber": "hSD01-011",
-        "name": "Azki",
+        "name": "AZKi",
         "rarity": "RR",
         "bloomLevel": "2nd",
         "hp": 190,
@@ -211,7 +211,7 @@
     
     {
         "cardNumber": "hSD01-013",
-        "name": "SorAz",
+        "name": "SorAZ",
         "rarity": "R",
         "bloomLevel": "1st",
         "hp": 130,
@@ -224,7 +224,7 @@
                 "description": "You may roll a die once: If the result is odd, send the top card of your cheer deck to this Holomen. If the result is even, draw one card from your deck."
             }
         ],
-        "extraEffect": "This Holomen is also treated as 'Tokino Sora' and 'AZKI'"
+        "extraEffect": "This Holomen is also treated as 'Tokino Sora' and 'AZKi'"
     },
     {
         "cardNumber": "hSD01-014",
@@ -240,7 +240,7 @@
                 "dmg": 30
             }
         ],
-        "extraEffect": "This Holomen cannot be Bloom"
+        "extraEffect": "This holomem cannot Bloom."
     },
     {
         "cardNumber": "hSD01-015",
@@ -250,14 +250,14 @@
         "color": "Colorless",
         "bloomLevel": "Spot",
         "tag": "#JP #HoloX #Kemomimi",
-        "collabEffect": "SoAzKo: When collaborating with 'Tokino Sora,' draw one card from your deck. When collaborating with 'AZKI,' send the top card of your cheer deck to your center Holomen",
+        "collabEffect": "SoAzKo: When collaborating with 'Tokino Sora,' draw one card from your deck. When collaborating with 'AZKi,' send the top card of your cheer deck to your center Holomen",
         "skills": [
             {
                 "name": "ピュアピュアピュア~",
                 "dmg": 10
             }
         ],
-        "extraEffect": "This Holomen cannot be Bloom"
+        "extraEffect": "This holomem cannot Bloom."
     },
     {
         "cardNumber": "hSD01-016",
@@ -304,6 +304,6 @@
         "rarity": "C",
         "type": "Support (Event)",
         "limited" : true,
-        "ability": "You can only use this card if you have 6 or fewer cards in your hand, excluding this one. Look at the top 4 cards of your deck. Reveal any number of 'Tokino Sora' and 'AZKI' cards from among them and add the revealed Holomen to your hand. Then, return the remaining cards to the bottom of your deck in any order."
+        "ability": "You can only use this card if you have 6 or fewer cards in your hand, excluding this one. Look at the top 4 cards of your deck. Reveal any number of 'Tokino Sora' and 'AZKi' cards from among them and add the revealed Holomen to your hand. Then, return the remaining cards to the bottom of your deck in any order."
     }
 ]

--- a/hSD02.json
+++ b/hSD02.json
@@ -30,7 +30,7 @@
                 "dmg": 30
             }
         ],
-        "extraEffect": "You may put any number of copies of this holomem in your Deck."
+        "extraEffect": "You may include any number of this holomem in your deck."
     },
     {
         "cardNumber": "hSD02-003",
@@ -135,7 +135,7 @@
                 "description": "You may Archive one card from your hand for the following effect: deal 50 special damage to your opponent's Center or Collab holomem."
             }
         ],
-        "extraEffect": "When this holomem is Downed, lose 2 LIFE."
+        "extraEffect": "When this holomem is downed, your life is reduced by 2."
     },
     {
         "cardNumber": "hSD02-009",
@@ -174,7 +174,7 @@
                 "dmg": 20
             }
         ],
-        "extraEffect": "This Holomen cannot be Bloom"
+        "extraEffect": "This holomem cannot Bloom."
     },
     {
         "cardNumber": "hSD02-011",
@@ -191,7 +191,7 @@
                 "dmg": 10
             }
         ],
-        "extraEffect": "This Holomen cannot be Bloom"
+        "extraEffect": "This holomem cannot Bloom."
     },
     {
         "cardNumber": "hSD02-012",

--- a/hSD03.json
+++ b/hSD03.json
@@ -30,7 +30,7 @@
                 "dmg": 30
             }
         ],
-        "extraEffect": "You may put any number of copies of this holomem in your Deck."
+        "extraEffect": "You may include any number of this holomem in your deck."
     },
     {
         "cardNumber": "hSD03-003",
@@ -135,7 +135,7 @@
                 "dmg": 60
             }
         ],
-        "extraEffect": "When this holomem is Downed, lose 2 LIFE."
+        "extraEffect": "When this holomem is downed, your life is reduced by 2."
     },
     {
         "cardNumber": "hSD03-009",
@@ -174,7 +174,7 @@
                 "dmg": 30
             }
         ],
-        "extraEffect": "This Holomen cannot be Bloom"
+        "extraEffect": "This holomem cannot Bloom."
     },
     {
         "cardNumber": "hSD03-011",
@@ -195,7 +195,7 @@
                 "description": "If you have 2 or less cards in your hand, draw from your Deck until you have 3 cards in your hand."
             }
         ],
-        "extraEffect": "This Holomen cannot be Bloom"
+        "extraEffect": "This holomem cannot Bloom."
     },
     {
         "cardNumber": "hSD03-012",

--- a/hSD04.json
+++ b/hSD04.json
@@ -30,7 +30,7 @@
                 "dmg": 30
             }
         ],
-        "extraEffect": "You may put any number of copies of this holomem in your Deck."
+        "extraEffect": "You may include any number of this holomem in your deck."
     },
     {
         "cardNumber": "hSD04-003",
@@ -135,7 +135,7 @@
                 "description": "You may return one Event with #Food from your Archive to your hand: if you do, this Art gains +20 power."
             }
         ],
-        "extraEffect": "When this holomem is Downed, lose 2 LIFE."
+        "extraEffect": "When this holomem is downed, your life is reduced by 2."
     },
     {
         "cardNumber": "hSD04-009",
@@ -174,7 +174,7 @@
                 "dmg": 20
             }
         ],
-        "extraEffect": "This Holomen cannot be Bloom"
+        "extraEffect": "This holomem cannot Bloom."
     },
     {
         "cardNumber": "hSD04-011",
@@ -191,7 +191,7 @@
                 "dmg": 10
             }
         ],
-        "extraEffect": "This Holomen cannot be Bloom"
+        "extraEffect": "This holomem cannot Bloom."
     },
     {
         "cardNumber": "hSD04-012",

--- a/hSD05.json
+++ b/hSD05.json
@@ -30,7 +30,7 @@
                 "dmg": 30
             }
         ],
-        "extraEffect": "You may put any number of copies of this holomem in your Deck."
+        "extraEffect": "You may include any number of this holomem in your deck."
     },
     {
         "cardNumber": "hSD05-003",
@@ -134,7 +134,7 @@
                 "description": "During this turn, the arts of one Debut Holomem with #ReGLOSS on your stage gains +40."
             }
         ],
-        "extraEffect": "When this holomem is Downed, lose 2 LIFE."
+        "extraEffect": "When this holomem is downed, your life is reduced by 2."
     },
     {
         "cardNumber": "hSD05-009",

--- a/hSD06.json
+++ b/hSD06.json
@@ -95,7 +95,7 @@
                 "dmg": 50
             }
         ],
-        "extraEffect": "When this holomem is Downed, lose 2 LIFE."
+        "extraEffect": "When this holomem is downed, your life is reduced by 2."
     },
     {
         "cardNumber": "hSD06-007",

--- a/hSD07.json
+++ b/hSD07.json
@@ -34,7 +34,7 @@
                 "dmg": 60
             }
         ],
-        "extraEffect": "You may put any number of copies of this holomem in your Deck.",
+        "extraEffect": "You may include any number of this holomem in your deck.",
         "hasHolomenRare": true,
         "imageSet": "hBP05"
     },
@@ -143,7 +143,7 @@
                 "description": "You may attach 1 Elfriend from your Archive to this holomem."
             }
         ],
-        "extraEffect": "When this holomem is Downed, lose 2 LIFE."
+        "extraEffect": "When this holomem is downed, your life is reduced by 2."
     },
     {
         "cardNumber": "hSD07-009",

--- a/hY.json
+++ b/hY.json
@@ -109,7 +109,7 @@
     },
      {
         "cardNumber": "hY02-006",
-        "name": "Green Cheer (Azki)",
+        "name": "Green Cheer (AZKi)",
         "rarity": "SY",
         "imageSet": "hBP05"
     },


### PR DESCRIPTION
This commit addresses several inconsistencies found in the JSON data files that power the card index website.

- Standardized character names to a single canonical spelling and capitalization (e.g., 'Azki' -> 'AZKi', 'Iris' -> 'IRyS').
- Corrected the data type of the 'limited' property from a string ("Yes") to a boolean (true) for consistency.
- Trimmed leading whitespace from 'tag' properties to ensure accurate filtering.
- Standardized the format of bilingual skill names in 'oshiSkill' and 'spOshiSkill' objects.
- Unified the phrasing and punctuation of various 'extraEffect' texts for recurring effects like 'cannot bloom', 'any number of copies', and 'downed' penalties.
- Fixed a malformed string in an 'ability' description that was referencing an 'extraEffect'.

These changes improve the overall data quality, which should lead to more reliable and consistent behavior on the website.