### PR TITLE
feat: Add button to hide and show tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,6 +114,7 @@
         <!-- Tag display section -->
         <div class="tags-section">
             <label class="tags-label">Available Tags:</label>
+            <button id="toggleTagsBtn">Hide</button>
             <div id="tagsContainer"></div>
         </div>
         

--- a/scripts.js
+++ b/scripts.js
@@ -14,6 +14,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     const tagsContainer = document.getElementById('tagsContainer');
     const clearButton = document.getElementById('clearButton');
+    const toggleTagsBtn = document.getElementById('toggleTagsBtn');
 
     const modal = document.getElementById('modal');
     const modalCloseIcon = document.getElementById('modalCloseIcon');
@@ -477,6 +478,15 @@ document.addEventListener('DOMContentLoaded', function() {
     clearButton.addEventListener('click', () => {
         searchBar.value = '';
         filterCards();
+    });
+
+    toggleTagsBtn.addEventListener('click', () => {
+        tagsContainer.classList.toggle('hidden');
+        if (tagsContainer.classList.contains('hidden')) {
+            toggleTagsBtn.textContent = 'Show';
+        } else {
+            toggleTagsBtn.textContent = 'Hide';
+        }
     });
 
     modal.addEventListener('click', (event) => {

--- a/styles.css
+++ b/styles.css
@@ -327,6 +327,25 @@ img.lazy-load[src] {
     background-color: #1E90FF;
 }
 
+#toggleTagsBtn {
+    padding: 5px 10px;
+    font-size: 14px;
+    cursor: pointer;
+    background-color: #555;
+    color: white;
+    border: none;
+    border-radius: 5px;
+    margin-left: 10px;
+}
+
+#toggleTagsBtn:hover {
+    background-color: #777;
+}
+
+#tagsContainer.hidden {
+    display: none;
+}
+
 #backToTopBtn {
     display: none;
     position: fixed;


### PR DESCRIPTION
This commit introduces a new button that allows users to toggle the visibility of the "Available Tags" section.

The following changes were made:
- Added a button with the ID `toggleTagsBtn` to `index.html`.
- Added styles for the new button in `styles.css`.
- Added a more specific CSS rule to handle hiding the tags container to avoid specificity issues.
- Added JavaScript to `scripts.js` to handle the click event on the toggle button, which toggles the `hidden` class on the `tagsContainer` and updates the button text.