### PR TITLE
feat: Hide tags by default

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,8 +114,8 @@
         <!-- Tag display section -->
         <div class="tags-section">
             <label class="tags-label">Available Tags:</label>
-            <button id="toggleTagsBtn">Hide</button>
-            <div id="tagsContainer"></div>
+            <button id="toggleTagsBtn">Show</button>
+            <div id="tagsContainer" class="hidden"></div>
         </div>
         
     <!-- Content container for dynamically loaded cards -->


### PR DESCRIPTION
The tags section is now hidden by default. The user can click the 'Show' button to display them.