### PR TITLE
Add blank favicon data URI to prevent automatic 404 requests

### DIFF
--- a/deckbuilder.html
+++ b/deckbuilder.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Hololive TCG - Deck Builder</title>
+    <link rel="icon" href="data:,">
     <link rel="stylesheet" href="styles.css">
     <link rel="stylesheet" href="deckbuilder.css">
 </head>

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Hololive TCG - Card Index</title>
+    <link rel="icon" href="data:,">
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>

--- a/tournaments.html
+++ b/tournaments.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Hololive TCG - Tournaments</title>
+    <link rel="icon" href="data:,">
     <link rel="stylesheet" href="styles.css">
     <link rel="stylesheet" href="tournament.css">
 </head>

--- a/tournaments/exstreamer-cup-2025.html
+++ b/tournaments/exstreamer-cup-2025.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Hololive TCG - Exstreamer Cup 2025 Finals</title>
+    <link rel="icon" href="data:,">
     <link rel="stylesheet" href="../styles.css">
     <link rel="stylesheet" href="../tournament.css">
 </head>

--- a/tournaments/wgp-taiwan.html
+++ b/tournaments/wgp-taiwan.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Hololive TCG - WGP25-26 Taiwan Venue</title>
+    <link rel="icon" href="data:,">
     <link rel="stylesheet" href="../styles.css">
     <link rel="stylesheet" href="../tournament.css">
 </head>

--- a/tournaments/wgp25-26-chiba.html
+++ b/tournaments/wgp25-26-chiba.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Hololive TCG - WGP25-26 Chiba Venue</title>
+    <link rel="icon" href="data:,">
     <link rel="stylesheet" href="../styles.css">
     <link rel="stylesheet" href="../tournament.css">
 </head>


### PR DESCRIPTION
Add blank favicon data URI to prevent automatic 404 requests

Added `<link rel="icon" href="data:,">` to the head of all HTML files (`index.html`, `deckbuilder.html`, `tournaments.html`, and tournament sub-pages). This prevents modern web browsers from automatically attempting to fetch `/favicon.ico` on load, which was previously resulting in 404 errors in the web server logs since no such file existed in the project.

---
*PR created automatically by Jules for task [3012319187204611253](https://jules.google.com/task/3012319187204611253) started by @Yukino-hub*