### PR TITLE
fix: load all hSD sets, harden error handling, remove dead code

### DIFF
--- a/deckbuilder.html
+++ b/deckbuilder.html
@@ -83,6 +83,14 @@
                             <option value="hSD09">hSD09</option>
                             <option value="hSD10">hSD10</option>
                             <option value="hSD11">hSD11</option>
+                            <option value="hSD12">hSD12</option>
+                            <option value="hSD13">hSD13</option>
+                            <option value="hSD14">hSD14</option>
+                            <option value="hSD15">hSD15</option>
+                            <option value="hSD16">hSD16</option>
+                            <option value="hSD17">hSD17</option>
+                            <option value="hSD18">hSD18</option>
+                            <option value="hSD19">hSD19</option>
                         </optgroup>
                         <!-- Others -->
                         <optgroup label="Others">

--- a/deckbuilder.js
+++ b/deckbuilder.js
@@ -9,7 +9,6 @@ document.addEventListener('DOMContentLoaded', function() {
     // Modal Elements
     const modal = document.getElementById('modal');
     const modalCloseIcon = document.getElementById('modalCloseIcon');
-    const modalImage = document.getElementById('modalImage');
     const modalCardName = document.getElementById('modalCardName');
     const modalAddBtn = document.getElementById('modalAddBtn');
 

--- a/index.html
+++ b/index.html
@@ -56,6 +56,12 @@
                     <option value="hSD11">hSD11</option>
                     <option value="hSD12">hSD12</option>
                     <option value="hSD13">hSD13</option>
+                    <option value="hSD14">hSD14</option>
+                    <option value="hSD15">hSD15</option>
+                    <option value="hSD16">hSD16</option>
+                    <option value="hSD17">hSD17</option>
+                    <option value="hSD18">hSD18</option>
+                    <option value="hSD19">hSD19</option>
                 </optgroup>
                 <!-- Others -->
                 <optgroup label="Others">

--- a/scripts.js
+++ b/scripts.js
@@ -284,7 +284,7 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     });
 
-    window.onscroll = function() {scrollFunction()};
+    window.addEventListener('scroll', scrollFunction);
 
     function scrollFunction() {
       if (document.body.scrollTop > 20 || document.documentElement.scrollTop > 20) {

--- a/tournaments.js
+++ b/tournaments.js
@@ -1,6 +1,9 @@
 document.addEventListener('DOMContentLoaded', function() {
     fetch('tournaments.json')
-        .then(response => response.json())
+        .then(response => {
+            if (!response.ok) throw new Error(`HTTP ${response.status}`);
+            return response.json();
+        })
         .then(data => {
             const tournamentsTableBody = document.querySelector('#tournamentsTable tbody');
             const fragment = document.createDocumentFragment();

--- a/tournaments/tournament-decks.js
+++ b/tournaments/tournament-decks.js
@@ -2,11 +2,16 @@ document.addEventListener('DOMContentLoaded', function() {
     const tournamentId = document.body.dataset.tournamentId;
     if (tournamentId) {
         fetch(`tournament-${tournamentId}.json`)
-            .then(response => response.json())
+            .then(response => {
+                if (!response.ok) throw new Error(`HTTP ${response.status}`);
+                return response.json();
+            })
             .then(data => {
-                document.getElementById('tournamentName').textContent = data.tournamentName;
+                const tournamentNameEl = document.getElementById('tournamentName');
+                if (tournamentNameEl) tournamentNameEl.textContent = data.tournamentName;
                 const tableBody = document.querySelector('#decksTable tbody');
                 const container = document.querySelector('.container');
+                if (!tableBody || !container) return;
 
                 if (data.description || data.format || data.prize) {
                     const infoContainer = document.createElement('div');
@@ -110,7 +115,7 @@ document.addEventListener('DOMContentLoaded', function() {
                      container.insertBefore(metagameContainer, table);
                 }
 
-                data.topDecks.forEach(deck => {
+                (data.topDecks || []).forEach(deck => {
                     const row = document.createElement('tr');
                     row.innerHTML = `
                         <td>${deck.rank}</td>

--- a/utils.js
+++ b/utils.js
@@ -3,7 +3,7 @@
 // Constants
 const baseUrl = "https://hololive-official-cardgame.com/wp-content/images/cardlist/";
 const seriesFiles = [
-    ...Array.from({ length: 13 }, (_, i) => `sets/hSD/hSD${(i + 1).toString().padStart(2, '0')}.json`),
+    ...Array.from({ length: 19 }, (_, i) => `sets/hSD/hSD${(i + 1).toString().padStart(2, '0')}.json`),
     ...Array.from({ length: 7 }, (_, i) => `sets/hBP/hBP${(i + 1).toString().padStart(2, '0')}.json`),
     'sets/hPR.json',
     'sets/hY01.json',


### PR DESCRIPTION
- utils.js: increase hSD file count 13→19 so hSD14-19 cards load
- index.html / deckbuilder.html: add missing hSD14-19 (and hSD12-13 in deckbuilder) to series filter dropdowns
- tournaments.js / tournament-decks.js: add response.ok guard before parsing JSON to prevent silent failures on HTTP errors
- tournament-decks.js: null-check DOM elements before use; guard against missing topDecks array to prevent runtime crashes
- scripts.js: replace window.onscroll assignment with addEventListener
- deckbuilder.js: remove unused modalImage variable