### PR TITLE
Fix/bug fixes and improvements

### DIFF
--- a/deckbuilder.html
+++ b/deckbuilder.html
@@ -55,51 +55,19 @@
                     <button id="clearButton">Clear</button>
                 </div>
 
-                <!-- Filters (Simplified or same as index.html) -->
-                <div class="dropdown-container">
-                    <label for="seriesFilter">Series:</label>
-                    <select id="seriesFilter">
-                        <option value="">Select Series</option>
-                        <!-- Boosters -->
-                        <optgroup label="Boosters">
-                            <option value="hBP01">hBP01</option>
-                            <option value="hBP02">hBP02</option>
-                            <option value="hBP03">hBP03</option>
-                            <option value="hBP04">hBP04</option>
-                            <option value="hBP05">hBP05</option>
-                            <option value="hBP06">hBP06</option>
-                            <option value="hBP07">hBP07</option>
-                        </optgroup>
-                        <!-- Starter Sets -->
-                        <optgroup label="Starter Sets">
-                            <option value="hSD01">hSD01</option>
-                            <option value="hSD02">hSD02</option>
-                            <option value="hSD03">hSD03</option>
-                            <option value="hSD04">hSD04</option>
-                            <option value="hSD05">hSD05</option>
-                            <option value="hSD06">hSD06</option>
-                            <option value="hSD07">hSD07</option>
-                            <option value="hSD08">hSD08</option>
-                            <option value="hSD09">hSD09</option>
-                            <option value="hSD10">hSD10</option>
-                            <option value="hSD11">hSD11</option>
-                            <option value="hSD12">hSD12</option>
-                            <option value="hSD13">hSD13</option>
-                            <option value="hSD14">hSD14</option>
-                            <option value="hSD15">hSD15</option>
-                            <option value="hSD16">hSD16</option>
-                            <option value="hSD17">hSD17</option>
-                            <option value="hSD18">hSD18</option>
-                            <option value="hSD19">hSD19</option>
-                        </optgroup>
-                        <!-- Others -->
-                        <optgroup label="Others">
-                            <option value="hPR">hPR</option>
-                            <option value="hY">hY</option>
-                            <option value="hBD">hBD</option>
-                        </optgroup>
-                    </select>
+                <!-- Series Filter: two-level -->
+                <div class="series-filter-section">
+                    <div class="series-category-row">
+                        <button class="series-btn active" data-category="all">All</button>
+                        <button class="series-btn" data-category="boosters">Booster Packs</button>
+                        <button class="series-btn" data-category="starters">Starter Decks</button>
+                        <button class="series-btn" data-category="promos">Promos</button>
+                    </div>
+                    <div class="series-set-row" id="seriesSetRow"></div>
+                </div>
 
+                <!-- Rarity + Type dropdowns -->
+                <div class="dropdown-container">
                     <label for="rarityFilter">Rarity:</label>
                     <select id="rarityFilter">
                         <option value="">Select Rarity</option>
@@ -113,9 +81,10 @@
                         <option value="SY">AltArt-Cheer {SY}</option>
                     </select>
 
-                    <label for="bloomTypeFilter">Bloom/Support:</label>
+                    <label for="bloomTypeFilter">Type:</label>
                     <select id="bloomTypeFilter">
-                        <option value="">Select Bloom Level or Support</option>
+                        <option value="">All Types</option>
+                        <option value="Oshi">Oshi</option>
                         <option value="Debut">Debut</option>
                         <option value="1st">1st</option>
                         <option value="2nd">2nd</option>
@@ -131,11 +100,16 @@
                     </select>
                 </div>
 
-                <!-- Checkboxs (Reduced set for deck building maybe? Keep them for now) -->
-                <div>
-                    <input type="checkbox" id="foilCheckbox"> <label for="foilCheckbox">Foil</label>
-                    <input type="checkbox" id="altArtCheckbox"> <label for="altArtCheckbox">Alt Art</label>
-                </div>
+                <!-- Variants (collapsed by default) -->
+                <details class="variants-section">
+                    <summary>Variants ▾</summary>
+                    <div class="variants-inner">
+                        <input type="checkbox" id="foilCheckbox">
+                        <label for="foilCheckbox">Foil</label>
+                        <input type="checkbox" id="altArtCheckbox">
+                        <label for="altArtCheckbox">Alt Art</label>
+                    </div>
+                </details>
 
                 <!-- Loading indicator -->
                 <div id="loadingIndicator">Loading...</div>

--- a/deckbuilder.js
+++ b/deckbuilder.js
@@ -2,7 +2,6 @@ document.addEventListener('DOMContentLoaded', function() {
     const contentContainer = document.getElementById('contentContainer');
     const loadingIndicator = document.getElementById('loadingIndicator');
     const searchBar = document.getElementById('searchBar');
-    const seriesFilter = document.getElementById('seriesFilter');
     const rarityFilter = document.getElementById('rarityFilter');
     const bloomTypeFilter = document.getElementById('bloomTypeFilter');
 
@@ -76,6 +75,21 @@ document.addEventListener('DOMContentLoaded', function() {
     const exportDeckBtn = document.getElementById('exportDeckBtn');
 
     let allCardData = [];
+
+    let selectedSeriesCategory = 'all';
+    let selectedSeriesPrefix = '';
+
+    const SERIES_SETS = {
+        boosters: ['hBP01','hBP02','hBP03','hBP04','hBP05','hBP06','hBP07'].map(p => ({ label: p, prefix: p })),
+        starters: Array.from({ length: 19 }, (_, i) => { const s = `hSD${String(i + 1).padStart(2, '0')}`; return { label: s, prefix: s }; }),
+        promos:   [{ label: 'hPR', prefix: 'hPR' }, { label: 'hBD', prefix: 'hBD' }, { label: 'hY', prefix: 'hY' }, { label: 'hYS', prefix: 'hYS' }],
+    };
+    const CATEGORY_PREFIXES = {
+        all:      [],
+        boosters: SERIES_SETS.boosters.map(s => s.prefix),
+        starters: SERIES_SETS.starters.map(s => s.prefix),
+        promos:   SERIES_SETS.promos.map(s => s.prefix),
+    };
     let filteredCardData = [];
 
     // Variable to track currently selected card for modal
@@ -177,18 +191,33 @@ document.addEventListener('DOMContentLoaded', function() {
 
     function filterCards() {
         const searchText = searchBar.value.toLowerCase();
-        const selectedSeries = seriesFilter.value;
         const selectedRarity = rarityFilter.value;
         const selectedBloomType = bloomTypeFilter.value;
 
         filteredCardData = allCardData.filter(card => {
-             const matchesSearch = !searchText || card.searchString.includes(searchText);
+            const matchesSearch = !searchText || card.searchString.includes(searchText);
 
-             const matchesSeries = !selectedSeries || card.cardNumber.startsWith(selectedSeries);
-             const matchesRarity = !selectedRarity || card.rarity === selectedRarity;
-             const matchesBloom = !selectedBloomType || card.bloomLevel === selectedBloomType || card.type === selectedBloomType;
+            let matchesSeries;
+            if (selectedSeriesCategory === 'all') {
+                matchesSeries = true;
+            } else if (selectedSeriesPrefix) {
+                matchesSeries = card.cardNumber.startsWith(selectedSeriesPrefix);
+            } else {
+                matchesSeries = CATEGORY_PREFIXES[selectedSeriesCategory].some(p => card.cardNumber.startsWith(p));
+            }
 
-             return matchesSearch && matchesSeries && matchesRarity && matchesBloom;
+            const matchesRarity = !selectedRarity || card.rarity === selectedRarity;
+
+            let matchesBloom;
+            if (!selectedBloomType) {
+                matchesBloom = true;
+            } else if (selectedBloomType === 'Oshi') {
+                matchesBloom = card.lives !== undefined;
+            } else {
+                matchesBloom = card.bloomLevel === selectedBloomType || card.type === selectedBloomType;
+            }
+
+            return matchesSearch && matchesSeries && matchesRarity && matchesBloom;
         });
         displayCards(filteredCardData);
     }
@@ -417,11 +446,59 @@ document.addEventListener('DOMContentLoaded', function() {
         exportDeckBtn.addEventListener('click', exportDeck);
     }
 
+    // Series filter button wiring
+    const seriesSetRow = document.getElementById('seriesSetRow');
+    const categoryBtns = document.querySelectorAll('.series-btn[data-category]');
+
+    function renderSetButtons(category) {
+        seriesSetRow.innerHTML = '';
+        if (category === 'all') { seriesSetRow.classList.remove('visible'); return; }
+        (SERIES_SETS[category] || []).forEach(set => {
+            const btn = document.createElement('button');
+            btn.className = 'series-btn';
+            btn.textContent = set.label;
+            btn.addEventListener('click', () => {
+                if (selectedSeriesPrefix === set.prefix) {
+                    selectedSeriesPrefix = '';
+                    btn.classList.remove('active');
+                } else {
+                    seriesSetRow.querySelectorAll('.series-btn').forEach(b => b.classList.remove('active'));
+                    selectedSeriesPrefix = set.prefix;
+                    btn.classList.add('active');
+                }
+                filterCards();
+            });
+            seriesSetRow.appendChild(btn);
+        });
+        seriesSetRow.classList.add('visible');
+    }
+
+    categoryBtns.forEach(btn => btn.addEventListener('click', () => {
+        categoryBtns.forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        selectedSeriesCategory = btn.dataset.category;
+        selectedSeriesPrefix = '';
+        renderSetButtons(selectedSeriesCategory);
+        filterCards();
+    }));
+
     // Event Listeners
     searchBar.addEventListener('input', debounce(filterCards, 300));
-    seriesFilter.addEventListener('change', filterCards);
     rarityFilter.addEventListener('change', filterCards);
     bloomTypeFilter.addEventListener('change', filterCards);
+
+    const clearButton = document.getElementById('clearButton');
+    if (clearButton) {
+        clearButton.addEventListener('click', () => {
+            searchBar.value = '';
+            selectedSeriesCategory = 'all';
+            selectedSeriesPrefix = '';
+            categoryBtns.forEach(b => b.classList.remove('active'));
+            document.querySelector('.series-btn[data-category="all"]').classList.add('active');
+            renderSetButtons('all');
+            filterCards();
+        });
+    }
 
     if (modalCloseIcon) {
         modalCloseIcon.addEventListener('click', closeModal);

--- a/index.html
+++ b/index.html
@@ -23,55 +23,19 @@
             <input type="text" id="searchBar" placeholder="Search by Card Name/Numbers/Tags/Text ... Ex: Sora or Hbp01 or #Gen0 or bloom: or collab:" aria-label="Search">
             <button id="clearButton">Clear</button>
         </div>
-        <br><br>
-        
-        <!-- Dropdown Filters -->
+        <!-- Series Filter: two-level -->
+        <div class="series-filter-section">
+            <div class="series-category-row">
+                <button class="series-btn active" data-category="all">All</button>
+                <button class="series-btn" data-category="boosters">Booster Packs</button>
+                <button class="series-btn" data-category="starters">Starter Decks</button>
+                <button class="series-btn" data-category="promos">Promos</button>
+            </div>
+            <div class="series-set-row" id="seriesSetRow"></div>
+        </div>
+
+        <!-- Rarity + Type dropdowns -->
         <div class="dropdown-container">
-            <!-- Series Filter -->
-            <label for="seriesFilter">Series:</label>
-            <select id="seriesFilter">
-                <option value="">Select Series</option>
-                 <!-- Boosters -->
-                <optgroup label="Boosters">
-                    <option value="hBP01">hBP01</option>
-                    <option value="hBP02">hBP02</option>
-                    <option value="hBP03">hBP03</option>
-                    <option value="hBP04">hBP04</option>
-                    <option value="hBP05">hBP05</option>
-                    <option value="hBP06">hBP06</option>
-                    <option value="hBP07">hBP07</option>
-                </optgroup>
-                <!-- Starter Sets -->
-                <optgroup label="Starter Sets">
-                    <option value="hSD01">hSD01</option>
-                    <option value="hSD02">hSD02</option>
-                    <option value="hSD03">hSD03</option>
-                    <option value="hSD04">hSD04</option>
-                    <option value="hSD05">hSD05</option>
-                    <option value="hSD06">hSD06</option>
-                    <option value="hSD07">hSD07</option>
-                    <option value="hSD08">hSD08</option>
-                    <option value="hSD09">hSD09</option>
-                    <option value="hSD10">hSD10</option>
-                    <option value="hSD11">hSD11</option>
-                    <option value="hSD12">hSD12</option>
-                    <option value="hSD13">hSD13</option>
-                    <option value="hSD14">hSD14</option>
-                    <option value="hSD15">hSD15</option>
-                    <option value="hSD16">hSD16</option>
-                    <option value="hSD17">hSD17</option>
-                    <option value="hSD18">hSD18</option>
-                    <option value="hSD19">hSD19</option>
-                </optgroup>
-                <!-- Others -->
-                <optgroup label="Others">
-                    <option value="hPR">hPR</option>
-                    <option value="hY">hY</option>
-                    <option value="hBD">hBD</option>
-                </optgroup>
-            </select>
-            
-            <!-- Rarity Filter -->
             <label for="rarityFilter">Rarity:</label>
             <select id="rarityFilter">
                 <option value="">Select Rarity</option>
@@ -80,20 +44,19 @@
                 <option value="R">Rare {R}</option>
                 <option value="RR">Double Rare {RR}</option>
                 <option value="OSR">Oshi Super Rare {OSR}</option>
-                 <option value="HR">Holomen Rare {HR}</option>
+                <option value="HR">Holomen Rare {HR}</option>
                 <option value="P">Promo {P}</option>
                 <option value="SY">AltArt-Cheer {SY}</option>
             </select>
-            
-            <!-- Bloom Type Filter -->
-            <label for="bloomTypeFilter">Bloom/Support:</label>
+
+            <label for="bloomTypeFilter">Type:</label>
             <select id="bloomTypeFilter">
-                <option value="">Select Bloom Level or Support</option>
+                <option value="">All Types</option>
+                <option value="Oshi">Oshi</option>
                 <option value="Debut">Debut</option>
                 <option value="1st">1st</option>
                 <option value="2nd">2nd</option>
                 <option value="Spot">Spot</option>
-                <!-- Others -->
                 <optgroup label="Support">
                     <option value="Support (Item)">Support (Item)</option>
                     <option value="Support (Tool)">Support (Tool)</option>
@@ -104,28 +67,25 @@
                 </optgroup>
             </select>
         </div>
-        
-        <!-- Checkboxs for Alternative Arts -->
-        <div>
 
-    <input type="checkbox" id="foilCheckbox">
-    <label for="foilCheckbox">Show Foiled {S}</label>
-            
-    <input type="checkbox" id="fullArtCheckbox">
-    <label for="fullArtCheckbox">Show FullArt {SR}</label>
-  
-    <input type="checkbox" id="altArtCheckbox">
-    <label for="altArtCheckbox">Show Alternative Arts {OUR/UR}</label>
-
-    <input type="checkbox" id="signedCheckbox">
-    <label for="signedCheckbox">Show Signed {SEC}</label>
-
-    <input type="checkbox" id="grandprixCheckbox">
-    <label for="grandprixCheckbox">Show GrandPrix</label>
-            
-    <input type="checkbox" id="holomenRareCheckbox">
-    <label for="holomenRareCheckbox">Show Holomen Rare {HR}</label>
-    </div>
+        <!-- Variants (collapsed by default) -->
+        <details class="variants-section">
+            <summary>Variants ▾</summary>
+            <div class="variants-inner">
+                <input type="checkbox" id="foilCheckbox">
+                <label for="foilCheckbox">Show Foiled {S}</label>
+                <input type="checkbox" id="fullArtCheckbox">
+                <label for="fullArtCheckbox">Show FullArt {SR}</label>
+                <input type="checkbox" id="altArtCheckbox">
+                <label for="altArtCheckbox">Show Alternative Arts {OUR/UR}</label>
+                <input type="checkbox" id="signedCheckbox">
+                <label for="signedCheckbox">Show Signed {SEC}</label>
+                <input type="checkbox" id="grandprixCheckbox">
+                <label for="grandprixCheckbox">Show GrandPrix</label>
+                <input type="checkbox" id="holomenRareCheckbox">
+                <label for="holomenRareCheckbox">Show Holomen Rare {HR}</label>
+            </div>
+        </details>
 
         <!-- Tag display section -->
         <div class="tags-section">

--- a/index.html
+++ b/index.html
@@ -88,11 +88,10 @@
         </details>
 
         <!-- Tag display section -->
-        <div class="tags-section">
-            <label class="tags-label">Available Tags:</label>
-            <button id="toggleTagsBtn">Show</button>
-            <div id="tagsContainer" class="hidden"></div>
-        </div>
+        <details class="variants-section">
+            <summary>Available Tags ▾</summary>
+            <div id="tagsContainer" class="variants-inner"></div>
+        </details>
         
     <!-- Content container for dynamically loaded cards -->
         <div id="contentContainer">

--- a/scripts.js
+++ b/scripts.js
@@ -2,7 +2,6 @@ document.addEventListener('DOMContentLoaded', function() {
     const contentContainer = document.getElementById('contentContainer');
     const loadingIndicator = document.getElementById('loadingIndicator');
     const searchBar = document.getElementById('searchBar');
-    const seriesFilter = document.getElementById('seriesFilter');
     const rarityFilter = document.getElementById('rarityFilter');
     const bloomTypeFilter = document.getElementById('bloomTypeFilter');
     const altArtCheckbox = document.getElementById('altArtCheckbox');
@@ -22,6 +21,21 @@ document.addEventListener('DOMContentLoaded', function() {
 
     let allCardData = [];
     let filteredCardData = [];
+
+    let selectedSeriesCategory = 'all';
+    let selectedSeriesPrefix = '';
+
+    const SERIES_SETS = {
+        boosters: ['hBP01','hBP02','hBP03','hBP04','hBP05','hBP06','hBP07'].map(p => ({ label: p, prefix: p })),
+        starters: Array.from({ length: 19 }, (_, i) => { const s = `hSD${String(i + 1).padStart(2, '0')}`; return { label: s, prefix: s }; }),
+        promos:   [{ label: 'hPR', prefix: 'hPR' }, { label: 'hBD', prefix: 'hBD' }, { label: 'hY', prefix: 'hY' }, { label: 'hYS', prefix: 'hYS' }],
+    };
+    const CATEGORY_PREFIXES = {
+        all:      [],
+        boosters: SERIES_SETS.boosters.map(s => s.prefix),
+        starters: SERIES_SETS.starters.map(s => s.prefix),
+        promos:   SERIES_SETS.promos.map(s => s.prefix),
+    };
 
     /**
      * Constructs the image URL for a card based on a priority system.
@@ -158,7 +172,6 @@ document.addEventListener('DOMContentLoaded', function() {
 
     function filterCards() {
         const searchText = searchBar.value.toLowerCase();
-        const selectedSeries = seriesFilter.value;
         const selectedRarity = rarityFilter.value;
         const selectedBloomType = bloomTypeFilter.value;
         const checkboxState = {
@@ -172,7 +185,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
         filteredCardData = allCardData.filter(card => {
             return matchesSearchText(card, searchText) &&
-                matchesSeries(card, selectedSeries) &&
+                matchesSeries(card, selectedSeriesCategory, selectedSeriesPrefix) &&
                 matchesRarity(card, selectedRarity) &&
                 matchesBloomType(card, selectedBloomType) &&
                 matchesCheckboxes(card, checkboxState);
@@ -198,8 +211,10 @@ document.addEventListener('DOMContentLoaded', function() {
         return card.searchString.includes(searchText);
     }
 
-    function matchesSeries(card, selectedSeries) {
-        return !selectedSeries || card.cardNumber.startsWith(selectedSeries);
+    function matchesSeries(card, category, prefix) {
+        if (category === 'all') return true;
+        if (prefix) return card.cardNumber.startsWith(prefix);
+        return CATEGORY_PREFIXES[category].some(p => card.cardNumber.startsWith(p));
     }
 
     function matchesRarity(card, selectedRarity) {
@@ -207,7 +222,9 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     function matchesBloomType(card, selectedBloomType) {
-        return !selectedBloomType || card.bloomLevel === selectedBloomType || card.type === selectedBloomType;
+        if (!selectedBloomType) return true;
+        if (selectedBloomType === 'Oshi') return card.lives !== undefined;
+        return card.bloomLevel === selectedBloomType || card.type === selectedBloomType;
     }
 
     function matchesCheckboxes(card, state) {
@@ -254,7 +271,7 @@ document.addEventListener('DOMContentLoaded', function() {
     // Consolidated event listeners for all filter controls
     const filterControls = [
         altArtCheckbox, signedCheckbox, foilCheckbox, fullArtCheckbox, grandprixCheckbox, holomenRareCheckbox,
-        seriesFilter, rarityFilter, bloomTypeFilter
+        rarityFilter, bloomTypeFilter
     ];
 
     filterControls.forEach(control => {
@@ -264,8 +281,50 @@ document.addEventListener('DOMContentLoaded', function() {
     // Apply debounce to the search bar input to improve performance
     searchBar.addEventListener('input', debounce(filterCards, 300));
 
+    // Series filter button wiring
+    const seriesSetRow = document.getElementById('seriesSetRow');
+    const categoryBtns = document.querySelectorAll('.series-btn[data-category]');
+
+    function renderSetButtons(category) {
+        seriesSetRow.innerHTML = '';
+        if (category === 'all') { seriesSetRow.classList.remove('visible'); return; }
+        (SERIES_SETS[category] || []).forEach(set => {
+            const btn = document.createElement('button');
+            btn.className = 'series-btn';
+            btn.textContent = set.label;
+            btn.addEventListener('click', () => {
+                if (selectedSeriesPrefix === set.prefix) {
+                    selectedSeriesPrefix = '';
+                    btn.classList.remove('active');
+                } else {
+                    seriesSetRow.querySelectorAll('.series-btn').forEach(b => b.classList.remove('active'));
+                    selectedSeriesPrefix = set.prefix;
+                    btn.classList.add('active');
+                }
+                filterCards();
+            });
+            seriesSetRow.appendChild(btn);
+        });
+        seriesSetRow.classList.add('visible');
+    }
+
+    categoryBtns.forEach(btn => btn.addEventListener('click', () => {
+        categoryBtns.forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        selectedSeriesCategory = btn.dataset.category;
+        selectedSeriesPrefix = '';
+        renderSetButtons(selectedSeriesCategory);
+        filterCards();
+    }));
+
     clearButton.addEventListener('click', () => {
         searchBar.value = '';
+        // Reset series
+        selectedSeriesCategory = 'all';
+        selectedSeriesPrefix = '';
+        categoryBtns.forEach(b => b.classList.remove('active'));
+        document.querySelector('.series-btn[data-category="all"]').classList.add('active');
+        renderSetButtons('all');
         filterCards();
     });
 

--- a/scripts.js
+++ b/scripts.js
@@ -13,7 +13,6 @@ document.addEventListener('DOMContentLoaded', function() {
 
     const tagsContainer = document.getElementById('tagsContainer');
     const clearButton = document.getElementById('clearButton');
-    const toggleTagsBtn = document.getElementById('toggleTagsBtn');
 
     const modal = document.getElementById('modal');
     const modalCloseIcon = document.getElementById('modalCloseIcon');
@@ -326,15 +325,6 @@ document.addEventListener('DOMContentLoaded', function() {
         document.querySelector('.series-btn[data-category="all"]').classList.add('active');
         renderSetButtons('all');
         filterCards();
-    });
-
-    toggleTagsBtn.addEventListener('click', () => {
-        tagsContainer.classList.toggle('hidden');
-        if (tagsContainer.classList.contains('hidden')) {
-            toggleTagsBtn.textContent = 'Show';
-        } else {
-            toggleTagsBtn.textContent = 'Hide';
-        }
     });
 
     modal.addEventListener('click', (event) => {

--- a/styles.css
+++ b/styles.css
@@ -277,6 +277,16 @@ header a:hover {
         width: 100%; /* Full width for each dropdown on small screens */
         margin-bottom: 10px; /* Space between dropdowns */
     }
+
+    .series-category-row,
+    .series-set-row {
+        justify-content: flex-start;
+    }
+
+    .series-btn {
+        font-size: 13px;
+        padding: 5px 8px;
+    }
 }
 html {
     scroll-behavior: smooth;
@@ -391,4 +401,61 @@ img.lazy-load[src] {
 .tournament-image {
     width: 100px;
     height: auto;
+}
+
+/* ---- Series two-level button filter ---- */
+.series-filter-section { margin-bottom: 12px; }
+
+.series-category-row,
+.series-set-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    justify-content: center;
+    margin-bottom: 6px;
+}
+
+.series-set-row {
+    max-height: 0;
+    overflow: hidden;
+    transition: max-height 0.25s ease;
+}
+
+.series-set-row.visible { max-height: 200px; }
+
+.series-btn {
+    padding: 6px 12px;
+    font-size: 14px;
+    background: #2C2C2C;
+    color: white;
+    border: 1px solid #444;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: background 0.15s, border-color 0.15s;
+}
+
+.series-btn:hover { background: #3a3a3a; }
+.series-btn.active { background: #1E90FF; border-color: #1E90FF; }
+
+/* ---- Variants collapsible ---- */
+.variants-section { margin-bottom: 12px; }
+
+.variants-section summary {
+    cursor: pointer;
+    font-size: 14px;
+    color: #ccc;
+    user-select: none;
+    list-style: none;
+    display: inline-block;
+    padding: 4px 0;
+}
+
+.variants-section summary::-webkit-details-marker { display: none; }
+
+.variants-inner {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px 16px;
+    padding: 8px 4px 0;
+    align-items: center;
 }


### PR DESCRIPTION
## Summary
### Bug fixes
- `utils.js`: load all 19 hSD sets (was capped at 13)
- `index.html` / `deckbuilder.html`: add missing hSD14–19 dropdown options
- `tournaments.js` / `tournament-decks.js`: add `response.ok` guard before parsing JSON
- `tournament-decks.js`: null-check DOM elements; guard against missing `topDecks`
- `scripts.js`: replace `window.onscroll =` with `addEventListener`
- `deckbuilder.js`: remove unused `modalImage` variable
### Filter bar redesign
- **Series**: 29-item dropdown → two-level button hierarchy (category → specific set row)
- **Type dropdown**: added "Oshi" option (detected via `card.lives`)
- **Variants**: alt-art checkboxes moved into a collapsible `<details>` section
- **Available Tags**: replaced manual Show/Hide button + JS toggle with a matching `<details>` element
- Applied to both `index.html` and `deckbuilder.html`