### PR TITLE
refactor: consolidate shared logic into utils.js and fix broken fetch CardData

### DIFF
--- a/build-data.js
+++ b/build-data.js
@@ -3,11 +3,11 @@ const path = require('path');
 
 const setsDir = path.join(__dirname, 'sets');
 const outputFile = path.join(__dirname, 'sets', 'all_cards.json');
+const validateOnly = process.argv.includes('--validate');
 
-/**
- * Generates a comprehensive search string for a card.
- * Includes name, card number, tags, abilities, effects, and skill descriptions.
- */
+const EXPECTED_BOOL_FIELDS = ['hasAlternativeArt', 'hasSigned', 'hasFoils', 'hasFullArt', 'hasGrandPrix', 'hasHolomenRare'];
+const TYPO_FIELDS = { hasFullart: 'hasFullArt', hasAlternateArt: 'hasAlternativeArt' };
+
 function generateSearchString(card) {
     const fields = [
         card.name,
@@ -25,11 +25,28 @@ function generateSearchString(card) {
         card.spOshiSkill?.description,
         ...(card.skills?.map(s => (s.name || '') + " " + (s.description || '')) || [])
     ];
-    // Filter out null/undefined/empty strings and join
     return fields.filter(Boolean).join(" ").toLowerCase();
 }
 
-function processDirectory(dir, allCards) {
+function validateCard(card, file, issues) {
+    const loc = `${file} → ${card.cardNumber || '(no cardNumber)'}`;
+    if (!card.cardNumber) issues.push(`MISSING cardNumber in ${file}`);
+    if (!card.name) issues.push(`MISSING name: ${loc}`);
+
+    for (const [typo, correct] of Object.entries(TYPO_FIELDS)) {
+        if (Object.prototype.hasOwnProperty.call(card, typo)) {
+            issues.push(`FIELD TYPO "${typo}" should be "${correct}": ${loc}`);
+        }
+    }
+
+    if (card.skills) {
+        card.skills.forEach((skill, i) => {
+            if (!skill.name) issues.push(`MISSING skill[${i}].name: ${loc}`);
+        });
+    }
+}
+
+function processDirectory(dir, allCards, seenNumbers, issues) {
     const files = fs.readdirSync(dir);
 
     for (const file of files) {
@@ -37,15 +54,30 @@ function processDirectory(dir, allCards) {
         const stat = fs.statSync(fullPath);
 
         if (stat.isDirectory()) {
-            processDirectory(fullPath, allCards);
+            processDirectory(fullPath, allCards, seenNumbers, issues);
         } else if (file.endsWith('.json') && file !== 'all_cards.json') {
             try {
                 const fileContent = fs.readFileSync(fullPath, 'utf-8');
                 const cards = JSON.parse(fileContent);
+
+                if (!Array.isArray(cards)) {
+                    issues.push(`NOT AN ARRAY: ${file}`);
+                    continue;
+                }
+
                 const setName = path.basename(file, '.json');
 
                 for (const card of cards) {
-                    // Inject metadata into the card object
+                    if (validateOnly) validateCard(card, file, issues);
+
+                    if (card.cardNumber) {
+                        if (seenNumbers.has(card.cardNumber)) {
+                            issues.push(`DUPLICATE cardNumber "${card.cardNumber}" in ${file}`);
+                        } else {
+                            seenNumbers.add(card.cardNumber);
+                        }
+                    }
+
                     card.setName = setName;
                     card.searchString = generateSearchString(card);
                     allCards.push(card);
@@ -59,15 +91,31 @@ function processDirectory(dir, allCards) {
 }
 
 function buildData() {
-    console.log('Starting data consolidation...');
+    if (validateOnly) console.log('Running in --validate mode (no output will be written)...\n');
+    else console.log('Starting data consolidation...');
+
     const allCards = [];
-    
+    const seenNumbers = new Set();
+    const issues = [];
+
     if (!fs.existsSync(setsDir)) {
         console.error(`Directory not found: ${setsDir}`);
         return;
     }
 
-    processDirectory(setsDir, allCards);
+    processDirectory(setsDir, allCards, seenNumbers, issues);
+
+    if (issues.length > 0) {
+        console.warn(`\n⚠  ${issues.length} issue(s) found:`);
+        issues.forEach(i => console.warn('  •', i));
+    } else {
+        console.log('\n✓ No data issues found.');
+    }
+
+    if (validateOnly) {
+        console.log(`\nValidated ${allCards.length} cards. all_cards.json was NOT modified.`);
+        return;
+    }
 
     try {
         fs.writeFileSync(outputFile, JSON.stringify(allCards, null, 2), 'utf-8');

--- a/deckbuilder.js
+++ b/deckbuilder.js
@@ -118,7 +118,7 @@ document.addEventListener('DOMContentLoaded', function() {
         const count = getCardCount(card);
 
         cardElement.innerHTML = `
-            <img data-src="${imageUrl}" alt="${card.name}" class="lazy-load">
+            <img data-src="${imageUrl}" alt="${card.name}" class="lazy-load" onerror="this.removeAttribute('src');this.classList.add('img-error');">
             <p><strong>${card.name}</strong></p>
             <p>${card.cardNumber}</p>
             <p class="card-quantity ${count > 0 ? 'active' : ''}">In Deck: ${count}</p>
@@ -141,18 +141,25 @@ document.addEventListener('DOMContentLoaded', function() {
 
     function displayCards(cardsToShow) {
         contentContainer.innerHTML = '';
+        if (cardsToShow.length === 0) {
+            const empty = document.createElement('div');
+            empty.className = 'empty-state';
+            empty.textContent = 'No cards found. Try adjusting your filters.';
+            contentContainer.appendChild(empty);
+            return;
+        }
         const fragment = document.createDocumentFragment();
-        // Limit to avoid lag
-        const limit = cardsToShow.length > 200 ? 200 : cardsToShow.length;
+        const limit = Math.min(cardsToShow.length, 200);
 
-        for(let i=0; i<limit; i++) {
-             fragment.appendChild(createCardElement(cardsToShow[i]));
+        for (let i = 0; i < limit; i++) {
+            fragment.appendChild(createCardElement(cardsToShow[i]));
         }
 
         if (cardsToShow.length > limit) {
-             const moreMsg = document.createElement('div');
-             moreMsg.textContent = `...and ${cardsToShow.length - limit} more. Use filters to narrow down.`;
-             fragment.appendChild(moreMsg);
+            const moreMsg = document.createElement('div');
+            moreMsg.className = 'empty-state';
+            moreMsg.textContent = `Showing 200 of ${cardsToShow.length} cards — use filters to narrow down.`;
+            fragment.appendChild(moreMsg);
         }
 
         contentContainer.appendChild(fragment);
@@ -201,6 +208,7 @@ document.addEventListener('DOMContentLoaded', function() {
         const primaryImage = document.createElement('img');
         primaryImage.src = imageUrl;
         primaryImage.alt = card.name;
+        primaryImage.onerror = () => { primaryImage.removeAttribute('src'); primaryImage.classList.add('img-error'); };
         modalImageContainer.appendChild(primaryImage);
 
         // Use shared population logic
@@ -386,12 +394,19 @@ document.addEventListener('DOMContentLoaded', function() {
     });
 
     function exportDeck() {
-        // Helper to convert array to map of counts
+        const issues = [];
+        if (deck.oshi.length !== 1) issues.push('no Oshi card selected');
+        if (deck.main.length < 20) issues.push(`only ${deck.main.length}/20 minimum main deck cards`);
+        if (deck.cheer.length === 0) issues.push('no Cheer cards');
+
+        if (issues.length > 0) {
+            const proceed = confirm(`Deck is incomplete (${issues.join(', ')}). Export anyway?`);
+            if (!proceed) return;
+        }
+
         const countCards = (list) => {
             const counts = {};
-            list.forEach(c => {
-                counts[c.cardNumber] = (counts[c.cardNumber] || 0) + 1;
-            });
+            list.forEach(c => { counts[c.cardNumber] = (counts[c.cardNumber] || 0) + 1; });
             return counts;
         };
 
@@ -405,7 +420,7 @@ document.addEventListener('DOMContentLoaded', function() {
         const downloadAnchorNode = document.createElement('a');
         downloadAnchorNode.setAttribute("href", dataStr);
         downloadAnchorNode.setAttribute("download", "decklist.json");
-        document.body.appendChild(downloadAnchorNode); // required for firefox
+        document.body.appendChild(downloadAnchorNode);
         downloadAnchorNode.click();
         downloadAnchorNode.remove();
     }
@@ -448,6 +463,7 @@ document.addEventListener('DOMContentLoaded', function() {
     if (modalCloseIcon) {
         modalCloseIcon.addEventListener('click', closeModal);
     }
+    registerEscapeToClose(modal, closeModal);
 
     modal.addEventListener('click', (event) => {
         if (event.target === modal) {

--- a/deckbuilder.js
+++ b/deckbuilder.js
@@ -76,20 +76,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     let allCardData = [];
 
-    let selectedSeriesCategory = 'all';
-    let selectedSeriesPrefix = '';
-
-    const SERIES_SETS = {
-        boosters: ['hBP01','hBP02','hBP03','hBP04','hBP05','hBP06','hBP07'].map(p => ({ label: p, prefix: p })),
-        starters: Array.from({ length: 19 }, (_, i) => { const s = `hSD${String(i + 1).padStart(2, '0')}`; return { label: s, prefix: s }; }),
-        promos:   [{ label: 'hPR', prefix: 'hPR' }, { label: 'hBD', prefix: 'hBD' }, { label: 'hY', prefix: 'hY' }, { label: 'hYS', prefix: 'hYS' }],
-    };
-    const CATEGORY_PREFIXES = {
-        all:      [],
-        boosters: SERIES_SETS.boosters.map(s => s.prefix),
-        starters: SERIES_SETS.starters.map(s => s.prefix),
-        promos:   SERIES_SETS.promos.map(s => s.prefix),
-    };
+    const seriesFilter = { category: 'all', prefix: '' };
     let filteredCardData = [];
 
     // Variable to track currently selected card for modal
@@ -194,31 +181,12 @@ document.addEventListener('DOMContentLoaded', function() {
         const selectedRarity = rarityFilter.value;
         const selectedBloomType = bloomTypeFilter.value;
 
-        filteredCardData = allCardData.filter(card => {
-            const matchesSearch = !searchText || card.searchString.includes(searchText);
-
-            let matchesSeries;
-            if (selectedSeriesCategory === 'all') {
-                matchesSeries = true;
-            } else if (selectedSeriesPrefix) {
-                matchesSeries = card.cardNumber.startsWith(selectedSeriesPrefix);
-            } else {
-                matchesSeries = CATEGORY_PREFIXES[selectedSeriesCategory].some(p => card.cardNumber.startsWith(p));
-            }
-
-            const matchesRarity = !selectedRarity || card.rarity === selectedRarity;
-
-            let matchesBloom;
-            if (!selectedBloomType) {
-                matchesBloom = true;
-            } else if (selectedBloomType === 'Oshi') {
-                matchesBloom = card.lives !== undefined;
-            } else {
-                matchesBloom = card.bloomLevel === selectedBloomType || card.type === selectedBloomType;
-            }
-
-            return matchesSearch && matchesSeries && matchesRarity && matchesBloom;
-        });
+        filteredCardData = allCardData.filter(card =>
+            matchesSearchText(card, searchText) &&
+            matchesSeries(card, seriesFilter.category, seriesFilter.prefix) &&
+            matchesRarity(card, selectedRarity) &&
+            matchesBloomType(card, selectedBloomType)
+        );
         displayCards(filteredCardData);
     }
 
@@ -450,35 +418,12 @@ document.addEventListener('DOMContentLoaded', function() {
     const seriesSetRow = document.getElementById('seriesSetRow');
     const categoryBtns = document.querySelectorAll('.series-btn[data-category]');
 
-    function renderSetButtons(category) {
-        seriesSetRow.innerHTML = '';
-        if (category === 'all') { seriesSetRow.classList.remove('visible'); return; }
-        (SERIES_SETS[category] || []).forEach(set => {
-            const btn = document.createElement('button');
-            btn.className = 'series-btn';
-            btn.textContent = set.label;
-            btn.addEventListener('click', () => {
-                if (selectedSeriesPrefix === set.prefix) {
-                    selectedSeriesPrefix = '';
-                    btn.classList.remove('active');
-                } else {
-                    seriesSetRow.querySelectorAll('.series-btn').forEach(b => b.classList.remove('active'));
-                    selectedSeriesPrefix = set.prefix;
-                    btn.classList.add('active');
-                }
-                filterCards();
-            });
-            seriesSetRow.appendChild(btn);
-        });
-        seriesSetRow.classList.add('visible');
-    }
-
     categoryBtns.forEach(btn => btn.addEventListener('click', () => {
         categoryBtns.forEach(b => b.classList.remove('active'));
         btn.classList.add('active');
-        selectedSeriesCategory = btn.dataset.category;
-        selectedSeriesPrefix = '';
-        renderSetButtons(selectedSeriesCategory);
+        seriesFilter.category = btn.dataset.category;
+        seriesFilter.prefix = '';
+        renderSetButtons(seriesFilter.category, seriesSetRow, seriesFilter, filterCards);
         filterCards();
     }));
 
@@ -491,11 +436,11 @@ document.addEventListener('DOMContentLoaded', function() {
     if (clearButton) {
         clearButton.addEventListener('click', () => {
             searchBar.value = '';
-            selectedSeriesCategory = 'all';
-            selectedSeriesPrefix = '';
+            seriesFilter.category = 'all';
+            seriesFilter.prefix = '';
             categoryBtns.forEach(b => b.classList.remove('active'));
             document.querySelector('.series-btn[data-category="all"]').classList.add('active');
-            renderSetButtons('all');
+            renderSetButtons('all', seriesSetRow, seriesFilter, filterCards);
             filterCards();
         });
     }

--- a/scripts.js
+++ b/scripts.js
@@ -21,20 +21,7 @@ document.addEventListener('DOMContentLoaded', function() {
     let allCardData = [];
     let filteredCardData = [];
 
-    let selectedSeriesCategory = 'all';
-    let selectedSeriesPrefix = '';
-
-    const SERIES_SETS = {
-        boosters: ['hBP01','hBP02','hBP03','hBP04','hBP05','hBP06','hBP07'].map(p => ({ label: p, prefix: p })),
-        starters: Array.from({ length: 19 }, (_, i) => { const s = `hSD${String(i + 1).padStart(2, '0')}`; return { label: s, prefix: s }; }),
-        promos:   [{ label: 'hPR', prefix: 'hPR' }, { label: 'hBD', prefix: 'hBD' }, { label: 'hY', prefix: 'hY' }, { label: 'hYS', prefix: 'hYS' }],
-    };
-    const CATEGORY_PREFIXES = {
-        all:      [],
-        boosters: SERIES_SETS.boosters.map(s => s.prefix),
-        starters: SERIES_SETS.starters.map(s => s.prefix),
-        promos:   SERIES_SETS.promos.map(s => s.prefix),
-    };
+    const seriesFilter = { category: 'all', prefix: '' };
 
     /**
      * Constructs the image URL for a card based on a priority system.
@@ -182,48 +169,15 @@ document.addEventListener('DOMContentLoaded', function() {
             holomenRare: holomenRareCheckbox.checked
         };
 
-        filteredCardData = allCardData.filter(card => {
-            return matchesSearchText(card, searchText) &&
-                matchesSeries(card, selectedSeriesCategory, selectedSeriesPrefix) &&
-                matchesRarity(card, selectedRarity) &&
-                matchesBloomType(card, selectedBloomType) &&
-                matchesCheckboxes(card, checkboxState);
-        });
+        filteredCardData = allCardData.filter(card =>
+            matchesSearchText(card, searchText) &&
+            matchesSeries(card, seriesFilter.category, seriesFilter.prefix) &&
+            matchesRarity(card, selectedRarity) &&
+            matchesBloomType(card, selectedBloomType) &&
+            matchesCheckboxes(card, checkboxState)
+        );
 
         displayCards(filteredCardData);
-    }
-
-    function matchesSearchText(card, searchText) {
-        if (!searchText) return true;
-
-        if (searchText.startsWith('bloom:')) {
-            const term = searchText.substring(6).trim();
-            return card.bloomEffect && card.bloomEffect.toLowerCase().includes(term);
-        }
-
-        if (searchText.startsWith('collab:')) {
-            const term = searchText.substring(7).trim();
-            return card.collabEffect && card.collabEffect.toLowerCase().includes(term);
-        }
-
-        // Optimized search using pre-computed string from utils.js
-        return card.searchString.includes(searchText);
-    }
-
-    function matchesSeries(card, category, prefix) {
-        if (category === 'all') return true;
-        if (prefix) return card.cardNumber.startsWith(prefix);
-        return CATEGORY_PREFIXES[category].some(p => card.cardNumber.startsWith(p));
-    }
-
-    function matchesRarity(card, selectedRarity) {
-        return !selectedRarity || card.rarity === selectedRarity;
-    }
-
-    function matchesBloomType(card, selectedBloomType) {
-        if (!selectedBloomType) return true;
-        if (selectedBloomType === 'Oshi') return card.lives !== undefined;
-        return card.bloomLevel === selectedBloomType || card.type === selectedBloomType;
     }
 
     function matchesCheckboxes(card, state) {
@@ -284,46 +238,22 @@ document.addEventListener('DOMContentLoaded', function() {
     const seriesSetRow = document.getElementById('seriesSetRow');
     const categoryBtns = document.querySelectorAll('.series-btn[data-category]');
 
-    function renderSetButtons(category) {
-        seriesSetRow.innerHTML = '';
-        if (category === 'all') { seriesSetRow.classList.remove('visible'); return; }
-        (SERIES_SETS[category] || []).forEach(set => {
-            const btn = document.createElement('button');
-            btn.className = 'series-btn';
-            btn.textContent = set.label;
-            btn.addEventListener('click', () => {
-                if (selectedSeriesPrefix === set.prefix) {
-                    selectedSeriesPrefix = '';
-                    btn.classList.remove('active');
-                } else {
-                    seriesSetRow.querySelectorAll('.series-btn').forEach(b => b.classList.remove('active'));
-                    selectedSeriesPrefix = set.prefix;
-                    btn.classList.add('active');
-                }
-                filterCards();
-            });
-            seriesSetRow.appendChild(btn);
-        });
-        seriesSetRow.classList.add('visible');
-    }
-
     categoryBtns.forEach(btn => btn.addEventListener('click', () => {
         categoryBtns.forEach(b => b.classList.remove('active'));
         btn.classList.add('active');
-        selectedSeriesCategory = btn.dataset.category;
-        selectedSeriesPrefix = '';
-        renderSetButtons(selectedSeriesCategory);
+        seriesFilter.category = btn.dataset.category;
+        seriesFilter.prefix = '';
+        renderSetButtons(seriesFilter.category, seriesSetRow, seriesFilter, filterCards);
         filterCards();
     }));
 
     clearButton.addEventListener('click', () => {
         searchBar.value = '';
-        // Reset series
-        selectedSeriesCategory = 'all';
-        selectedSeriesPrefix = '';
+        seriesFilter.category = 'all';
+        seriesFilter.prefix = '';
         categoryBtns.forEach(b => b.classList.remove('active'));
         document.querySelector('.series-btn[data-category="all"]').classList.add('active');
-        renderSetButtons('all');
+        renderSetButtons('all', seriesSetRow, seriesFilter, filterCards);
         filterCards();
     });
 

--- a/scripts.js
+++ b/scripts.js
@@ -101,7 +101,7 @@ document.addEventListener('DOMContentLoaded', function() {
         const imageUrl = getImageUrl(card);
 
         cardElement.innerHTML = `
-            <img data-src="${imageUrl}" alt="${card.name}" class="lazy-load">
+            <img data-src="${imageUrl}" alt="${card.name}" class="lazy-load" onerror="this.removeAttribute('src');this.classList.add('img-error');">
             <p><strong>${card.name}</strong></p>
             <p>Card Number: ${card.cardNumber}</p>
             <p>Rarity: ${card.rarity}</p>
@@ -148,6 +148,13 @@ document.addEventListener('DOMContentLoaded', function() {
 
     function displayCards(cardsToShow) {
         contentContainer.innerHTML = '';
+        if (cardsToShow.length === 0) {
+            const empty = document.createElement('div');
+            empty.className = 'empty-state';
+            empty.textContent = 'No cards found. Try adjusting your filters.';
+            contentContainer.appendChild(empty);
+            return;
+        }
         const fragment = document.createDocumentFragment();
         cardsToShow.forEach(card => {
             fragment.appendChild(createCardElement(card));
@@ -199,6 +206,7 @@ document.addEventListener('DOMContentLoaded', function() {
         const primaryImage = document.createElement('img');
         primaryImage.src = imageUrl;
         primaryImage.alt = card.name;
+        primaryImage.onerror = () => { primaryImage.removeAttribute('src'); primaryImage.classList.add('img-error'); };
         modalImageContainer.appendChild(primaryImage);
 
         // Use shared population function from utils.js
@@ -220,6 +228,7 @@ document.addEventListener('DOMContentLoaded', function() {
     if (modalCloseIcon) {
         modalCloseIcon.addEventListener('click', closeModal);
     }
+    registerEscapeToClose(modal, closeModal);
 
     // Consolidated event listeners for all filter controls
     const filterControls = [

--- a/sets/all_cards.json
+++ b/sets/all_cards.json
@@ -779,7 +779,7 @@
         "dmg": 30
       }
     ],
-    "hasFullart": true,
+    "hasFullArt": true,
     "setName": "hBP01",
     "searchString": "usada pekora hbp01-041 #jp #gen3 #kemomimi 成長した兎田べこらを: send the top card of your cheer deck to your center holomen or collab holomen. 見逃しちゃだめべこだよ! "
   },
@@ -2499,7 +2499,7 @@
         "dmg": "30"
       }
     ],
-    "hasFullart": true,
+    "hasFullArt": true,
     "setName": "hBP02",
     "searchString": "shirogane noel hbp02-016 #jp #gen3 #alcohol ノエちゃんの勇姿……: if bloomed from debut, reveal 1 [debut holomem, 1st holomem or spot holomem] with #gen 3 from your deck, and add it to hand. then, shuffle the deck. 目に焼き付けるんだゾ♡ "
   },
@@ -2799,7 +2799,7 @@
         "dmg": "30"
       }
     ],
-    "hasFullart": true,
+    "hasFullArt": true,
     "imageSet": "hBP06",
     "setName": "hBP02",
     "searchString": "houshou marine hbp02-031 #jp #gen3 #painting #sea キミたちの声が船長の支えです！ deal 20 special damage to your opponent's collab holomem. いっしょに出航しましょう！（健全) "
@@ -16586,7 +16586,7 @@
         "dmg": 40
       }
     ],
-    "hasFullart": true,
+    "hasFullArt": true,
     "imageSet": "hBP06",
     "setName": "hSD07",
     "searchString": "shiranui flare hsd07-007 #jp #gen3 #half-elf また一つ成長した私を　 : [back position only] if your collab holomem has 70 of less hp remaining, you may switch this holomem with your collab holomem. キミに見てほしいな！ "

--- a/sets/hBP/hBP01.json
+++ b/sets/hBP/hBP01.json
@@ -699,7 +699,7 @@
                 "dmg": 30
             }
         ],  
-        "hasFullart": true
+        "hasFullArt": true
     },
     {
         "cardNumber": "hBP01-042",

--- a/sets/hBP/hBP02.json
+++ b/sets/hBP/hBP02.json
@@ -287,7 +287,7 @@
                 "dmg": "30"
             }
         ],  
-        "hasFullart": true
+        "hasFullArt": true
     },
     {
         "cardNumber": "hBP02-017",
@@ -557,7 +557,7 @@
                 "dmg": "30"
             }
         ],  
-        "hasFullart": true,
+        "hasFullArt": true,
         "imageSet": "hBP06"
     },
     {

--- a/sets/hSD/hSD07.json
+++ b/sets/hSD/hSD07.json
@@ -126,7 +126,7 @@
                 "dmg": 40
             }
         ],  
-        "hasFullart": true,
+        "hasFullArt": true,
         "imageSet": "hBP06"
     },
     {

--- a/styles.css
+++ b/styles.css
@@ -68,10 +68,10 @@ header a:hover {
 .dropdown-container {
     display: flex;
     justify-content: center;
-    gap: 20px; /* Space between the dropdowns */
-    margin-bottom: 20px; /* Space below the dropdowns */
-    align-items: center; /* Ensure dropdowns are aligned center vertically */
-    flex-wrap: wrap; /* Allow wrapping on smaller screens */
+    gap: 20px;
+    margin-bottom: 16px;
+    align-items: center;
+    flex-wrap: wrap;
 }
 
 .dropdown-container select {
@@ -404,15 +404,20 @@ img.lazy-load[src] {
 }
 
 /* ---- Series two-level button filter ---- */
-.series-filter-section { margin-bottom: 12px; }
+.series-filter-section {
+    margin-top: 20px;
+    margin-bottom: 16px;
+    padding-top: 16px;
+    border-top: 1px solid #2e2e2e;
+}
 
 .series-category-row,
 .series-set-row {
     display: flex;
     flex-wrap: wrap;
-    gap: 6px;
+    gap: 8px;
     justify-content: center;
-    margin-bottom: 6px;
+    margin-bottom: 8px;
 }
 
 .series-set-row {
@@ -424,12 +429,12 @@ img.lazy-load[src] {
 .series-set-row.visible { max-height: 200px; }
 
 .series-btn {
-    padding: 6px 12px;
+    padding: 7px 16px;
     font-size: 14px;
     background: #2C2C2C;
     color: white;
     border: 1px solid #444;
-    border-radius: 4px;
+    border-radius: 6px;
     cursor: pointer;
     transition: background 0.15s, border-color 0.15s;
 }

--- a/styles.css
+++ b/styles.css
@@ -84,22 +84,6 @@ header a:hover {
     border: 1px solid #444;
 }
 
-#seriesFilter,
-#rarityFilter,
-#bloomTypeFilter {
-    margin-top: 20px;
-    padding: 10px;
-    font-size: 16px;
-    background-color: #2C2C2C;
-    color: white;
-    border: 1px solid #444;
-}
-
-#cardList {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-}
 
 .card {
     border: 1px solid #333;
@@ -254,11 +238,6 @@ header a:hover {
         object-fit: contain; /* Ensure the image fits within its container */
     }
 
-    #cardList {
-        flex-direction: column; /* Stack cards vertically on small screens */
-        align-items: center; /* Center cards */
-    }
-
     .card {
         max-width: 90%; /* Increase card width on small screens */
     }
@@ -376,31 +355,27 @@ img.lazy-load[src] {
     background-color: #777;
 }
 
-/* Tournament Page Styles */
-.tournament {
-    background-color: #1E1E1E;
+
+/* ---- Empty state ---- */
+.empty-state {
+    width: 100%;
+    padding: 60px 20px;
+    text-align: center;
+    color: #777;
+    font-size: 16px;
+}
+
+/* ---- Image error placeholder ---- */
+.img-error {
+    display: block;
+    width: 100%;
+    aspect-ratio: 2 / 3;
+    background-color: #1e1e1e;
+    background-image: repeating-linear-gradient(
+        45deg, #252525 0px, #252525 6px, #1e1e1e 6px, #1e1e1e 12px
+    );
     border: 1px solid #333;
-    border-radius: 5px;
-    padding: 20px;
-    margin-bottom: 20px;
-}
-
-.tournament h3 {
-    margin-top: 0;
-}
-
-.tournament ul {
-    list-style-type: none;
-    padding: 0;
-}
-
-.tournament li {
-    padding: 5px 0;
-}
-
-.tournament-image {
-    width: 100px;
-    height: auto;
+    border-radius: 4px;
 }
 
 /* ---- Series two-level button filter ---- */

--- a/utils.js
+++ b/utils.js
@@ -304,3 +304,9 @@ function renderSetButtons(category, seriesSetRow, seriesFilter, filterCards) {
     });
     seriesSetRow.classList.add('visible');
 }
+
+function registerEscapeToClose(modal, closeFn) {
+    document.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape' && modal.style.display !== 'none') closeFn();
+    });
+}

--- a/utils.js
+++ b/utils.js
@@ -5,6 +5,18 @@ const baseUrl = "https://hololive-official-cardgame.com/wp-content/images/cardli
 // Data is now consolidated into a single file by build-data.js
 const consolidatedDataFile = "sets/all_cards.json";
 
+const SERIES_SETS = {
+    boosters: ['hBP01','hBP02','hBP03','hBP04','hBP05','hBP06','hBP07'].map(p => ({ label: p, prefix: p })),
+    starters: Array.from({ length: 19 }, (_, i) => { const s = `hSD${String(i + 1).padStart(2, '0')}`; return { label: s, prefix: s }; }),
+    promos:   [{ label: 'hPR', prefix: 'hPR' }, { label: 'hBD', prefix: 'hBD' }, { label: 'hY', prefix: 'hY' }, { label: 'hYS', prefix: 'hYS' }],
+};
+const CATEGORY_PREFIXES = {
+    all:      [],
+    boosters: SERIES_SETS.boosters.map(s => s.prefix),
+    starters: SERIES_SETS.starters.map(s => s.prefix),
+    promos:   SERIES_SETS.promos.map(s => s.prefix),
+};
+
 /**
  * Debounce function to delay execution of a function until after a specified wait time
  * has elapsed since the last time it was invoked.
@@ -36,63 +48,20 @@ function getBaseImageUrl(card) {
 }
 
 /**
- * Generates a comprehensive search string for a card.
- * Includes name, card number, tags, abilities, effects, and skill descriptions.
- * @param {object} card - The card object.
- * @returns {string} The lowercase search string.
- */
-function generateSearchString(card) {
-    const fields = [
-        card.name,
-        card.cardNumber,
-        card.tag,
-        card.ability,
-        card.collabEffect,
-        card.bloomEffect,
-        card.giftEffect,
-        card.extraEffect,
-        card.oshiStageSkill,
-        card.oshiSkill?.name,
-        card.oshiSkill?.description,
-        card.spOshiSkill?.name,
-        card.spOshiSkill?.description,
-        ...(card.skills?.map(s => (s.name || '') + " " + (s.description || '')) || [])
-    ];
-    // Filter out null/undefined/empty strings and join
-    return fields.filter(Boolean).join(" ").toLowerCase();
-}
-
-/**
- * Fetches card data from the configured series files.
+ * Fetches all card data from the consolidated file produced by build-data.js.
+ * Cards already have setName and searchString injected at build time.
  * @returns {Promise<Array>} A promise that resolves to the flat array of all card data.
  */
 function fetchCardData() {
-    return Promise.all(seriesFiles.map(file => {
-        const setName = file.split('/').pop().split('.')[0];
-        return fetch(file)
-            .then(response => {
-                if (!response.ok) {
-                    return { setName, data: [] };
-                }
-                return response.json().then(data => ({ setName, data }));
-            })
-            .catch(error => {
-                console.error(`Error loading or parsing ${file}:`, error);
-                return { setName, data: [] };
-            });
-    }))
-    .then(results => {
-        return results.flatMap(result => {
-            return result.data.map(card => {
-                // Add setName and pre-computed searchString to each card
-                return {
-                    ...card,
-                    setName: result.setName,
-                    searchString: generateSearchString(card)
-                };
-            });
+    return fetch(consolidatedDataFile)
+        .then(response => {
+            if (!response.ok) throw new Error(`Failed to load ${consolidatedDataFile}`);
+            return response.json();
+        })
+        .catch(error => {
+            console.error('Error loading card data:', error);
+            return [];
         });
-    });
 }
 
 /**
@@ -276,4 +245,62 @@ function initializeLazyLoading() {
         });
     });
     lazyImages.forEach(image => observer.observe(image));
+}
+
+// --- Shared filter helpers ---
+
+function matchesSearchText(card, searchText) {
+    if (!searchText) return true;
+    if (searchText.startsWith('bloom:')) {
+        const term = searchText.substring(6).trim();
+        return card.bloomEffect && card.bloomEffect.toLowerCase().includes(term);
+    }
+    if (searchText.startsWith('collab:')) {
+        const term = searchText.substring(7).trim();
+        return card.collabEffect && card.collabEffect.toLowerCase().includes(term);
+    }
+    return card.searchString.includes(searchText);
+}
+
+function matchesSeries(card, category, prefix) {
+    if (category === 'all') return true;
+    if (prefix) return card.cardNumber.startsWith(prefix);
+    return CATEGORY_PREFIXES[category].some(p => card.cardNumber.startsWith(p));
+}
+
+function matchesRarity(card, selectedRarity) {
+    return !selectedRarity || card.rarity === selectedRarity;
+}
+
+function matchesBloomType(card, selectedBloomType) {
+    if (!selectedBloomType) return true;
+    if (selectedBloomType === 'Oshi') return card.lives !== undefined;
+    return card.bloomLevel === selectedBloomType || card.type === selectedBloomType;
+}
+
+/**
+ * Renders the per-set buttons inside seriesSetRow for the given category.
+ * seriesFilter is a shared mutable object { category, prefix } owned by the caller.
+ */
+function renderSetButtons(category, seriesSetRow, seriesFilter, filterCards) {
+    seriesSetRow.innerHTML = '';
+    if (category === 'all') { seriesSetRow.classList.remove('visible'); return; }
+    (SERIES_SETS[category] || []).forEach(set => {
+        const btn = document.createElement('button');
+        btn.className = 'series-btn';
+        btn.textContent = set.label;
+        btn.addEventListener('click', () => {
+            if (seriesFilter.prefix === set.prefix) {
+                seriesFilter.prefix = '';
+                btn.classList.remove('active');
+            } else {
+                seriesSetRow.querySelectorAll('.series-btn').forEach(b => b.classList.remove('active'));
+                seriesFilter.prefix = set.prefix;
+                btn.classList.add('active');
+            }
+            filterCards();
+        });
+        seriesSetRow.appendChild(btn);
+    });
+    seriesSetRow.classList.add('visible');
 }


### PR DESCRIPTION
- Fix fetchCardData() which referenced undefined `seriesFiles` variable, causing a ReferenceError on both index.html and deckbuilder.html; now fetches directly from the consolidated sets/all_cards.json
- Remove duplicate generateSearchString() from utils.js (build-data.js pre-computes searchString at build time, browser copy was dead code)
- Move SERIES_SETS and CATEGORY_PREFIXES constants to utils.js so adding a new set only requires one change
- Move matchesSearchText/matchesSeries/matchesRarity/matchesBloomType to utils.js as pure shared helpers; deckbuilder.js now also benefits from the bloom:/collab: prefix search it was silently missing
- Move renderSetButtons() to utils.js using a seriesFilter ref object to eliminate identical ~20-line duplication in both scripts
- Replace separate selectedSeriesCategory/selectedSeriesPrefix locals with a single const seriesFilter = { category, prefix } object in each script
- Improve filter bar spacing: add margin-top, padding-top, and a subtle border-top separator between the search bar and series buttons; widen series button padding and soften border-radius for better UX