### PR TITLE
feat: fix deckbuilder variant filters, deduplicate modal HTML, add deck import

### DIFF
--- a/deckbuilder.html
+++ b/deckbuilder.html
@@ -28,6 +28,8 @@
                 <div id="deckValidationStatus" class="invalid">Invalid Deck</div>
                 <button id="clearDeckBtn">Clear Deck</button>
                 <button id="exportDeckBtn">Export Deck (HoloDuel)</button>
+                <button id="importDeckBtn">Import Deck</button>
+                <input type="file" id="importDeckInput" accept=".json" style="display:none">
             </div>
 
             <div class="deck-lists">
@@ -105,9 +107,17 @@
                     <summary>Variants ▾</summary>
                     <div class="variants-inner">
                         <input type="checkbox" id="foilCheckbox">
-                        <label for="foilCheckbox">Foil</label>
+                        <label for="foilCheckbox">Show Foiled {S}</label>
+                        <input type="checkbox" id="fullArtCheckbox">
+                        <label for="fullArtCheckbox">Show FullArt {SR}</label>
                         <input type="checkbox" id="altArtCheckbox">
-                        <label for="altArtCheckbox">Alt Art</label>
+                        <label for="altArtCheckbox">Show Alternative Arts {OUR/UR}</label>
+                        <input type="checkbox" id="signedCheckbox">
+                        <label for="signedCheckbox">Show Signed {SEC}</label>
+                        <input type="checkbox" id="grandprixCheckbox">
+                        <label for="grandprixCheckbox">Show GrandPrix</label>
+                        <input type="checkbox" id="holomenRareCheckbox">
+                        <label for="holomenRareCheckbox">Show Holomen Rare {HR}</label>
                     </div>
                 </details>
 
@@ -120,48 +130,6 @@
                 <!-- Cards will be dynamically loaded here -->
             </div>
         </main>
-    </div>
-
-    <!-- Modal for Card Details (Same as index.html) -->
-    <div id="modal" class="modal">
-        <div class="modal-content">
-            <span id="modalCloseIcon" class="modal-close">&times;</span>
-            <div id="modalImageContainer" class="image-scroll">
-                <img id="modalImage" data-src="" alt="" class="lazy-load" loading="lazy">
-            </div>
-            <div id="modalText">
-                <h3 id="modalCardName"></h3>
-                <button id="modalAddBtn" class="add-btn" style="margin-bottom: 10px;">Add to Deck</button>
-                <p id="modalCardNumberContainer"><strong>Card Number:</strong> <span id="modalCardNumber"></span></p>
-                <p id="modalCardTagsContainer"><strong>Tags:</strong> <span id="modalCardTags"></span></p>
-                <p id="modalRarityContainer"><strong>Rarity:</strong> <span id="modalRarity"></span></p>
-                <p id="modalBloomLevelContainer"><strong>Bloom Level:</strong> <span id="modalBloomLevel"></span></p>
-                <p id="modalHPContainer"><strong>HP:</strong> <span id="modalHP"></span></p>
-                <p id="modalColorContainer"><strong>Color:</strong> <span id="modalColor"></span></p>
-                <p id="modalLivesContainer"><strong>Lives:</strong> <span id="modalLives"></span></p>
-                <p id="modalBuzzContainer"><strong>Buzz:</strong> <span id="modalBuzz"></span></p>
-                <p id="modalTypeContainer"><strong>Type:</strong> <span id="modalType"></span></p>
-                <p id="modalAbilityContainer"><strong>Ability:</strong> <span id="modalAbility"></span></p>
-                <p id="modalCollabEffectContainer"><strong>Collab Effect:</strong> <span id="modalCollabEffect"></span></p>
-                <p id="modalBloomEffectContainer"><strong>Bloom Effect:</strong> <span id="modalBloomEffect"></span></p>
-                <p id="modalGiftEffectContainer"><strong>Gift:</strong> <span id="modalGiftEffect"></span></p>
-                <div id="modalOshiSkill" class="hidden">
-                    <p><strong>Oshi Skill Name:</strong> <span id="modalOshiSkillName"></span></p>
-                    <p><strong>Power Cost:</strong> <span id="modalOshiSkillPower"></span></p>
-                    <p><strong>Description:</strong> <span id="modalOshiSkillDescription"></span></p>
-                </div>
-                <div id="modalSpOshiSkill" class="hidden">
-                    <p><strong>SP Oshi Skill Name:</strong> <span id="modalSpOshiSkillName"></span></p>
-                    <p><strong>Power Cost:</strong> <span id="modalSpOshiSkillPower"></span></p>
-                    <p><strong>Description:</strong> <span id="modalSpOshiSkillDescription"></span></p>
-                </div>
-                <div id="modalSkills" class="skills hidden">
-                    <h3>Skills</h3>
-                </div>
-                <p id="modalExtraEffectContainer"><strong>Extra Effect:</strong> <span id="modalExtraEffect"></span></p>
-                <p id="modalSourcesContainer"><strong>Sources:</strong> <span id="modalSources"></span></p>
-            </div>
-        </div>
     </div>
 
     <script src="utils.js"></script>

--- a/deckbuilder.js
+++ b/deckbuilder.js
@@ -1,60 +1,23 @@
 document.addEventListener('DOMContentLoaded', function() {
+    injectModalHtml(true);
+
     const contentContainer = document.getElementById('contentContainer');
     const loadingIndicator = document.getElementById('loadingIndicator');
     const searchBar = document.getElementById('searchBar');
     const rarityFilter = document.getElementById('rarityFilter');
     const bloomTypeFilter = document.getElementById('bloomTypeFilter');
+    const altArtCheckbox = document.getElementById('altArtCheckbox');
+    const fullArtCheckbox = document.getElementById('fullArtCheckbox');
+    const foilCheckbox = document.getElementById('foilCheckbox');
+    const signedCheckbox = document.getElementById('signedCheckbox');
+    const grandprixCheckbox = document.getElementById('grandprixCheckbox');
+    const holomenRareCheckbox = document.getElementById('holomenRareCheckbox');
 
     // Modal Elements
     const modal = document.getElementById('modal');
     const modalCloseIcon = document.getElementById('modalCloseIcon');
     const modalCardName = document.getElementById('modalCardName');
     const modalAddBtn = document.getElementById('modalAddBtn');
-
-    // Modal Detail Elements
-    const modalCardNumberContainer = document.getElementById('modalCardNumberContainer');
-    const modalCardTagsContainer = document.getElementById('modalCardTagsContainer');
-    const modalRarityContainer = document.getElementById('modalRarityContainer');
-    const modalBloomLevelContainer = document.getElementById('modalBloomLevelContainer');
-    const modalHPContainer = document.getElementById('modalHPContainer');
-    const modalColorContainer = document.getElementById('modalColorContainer');
-    const modalLivesContainer = document.getElementById('modalLivesContainer');
-    const modalBuzzContainer = document.getElementById('modalBuzzContainer');
-    const modalTypeContainer = document.getElementById('modalTypeContainer');
-    const modalAbilityContainer = document.getElementById('modalAbilityContainer');
-    const modalCollabEffectContainer = document.getElementById('modalCollabEffectContainer');
-    const modalBloomEffectContainer = document.getElementById('modalBloomEffectContainer');
-    const modalGiftEffectContainer = document.getElementById('modalGiftEffectContainer');
-    const modalExtraEffectContainer = document.getElementById('modalExtraEffectContainer');
-    const modalSourcesContainer = document.getElementById('modalSourcesContainer');
-
-    const modalCardNumber = document.getElementById('modalCardNumber');
-    const modalCardTags = document.getElementById('modalCardTags');
-    const modalRarity = document.getElementById('modalRarity');
-    const modalBloomLevel = document.getElementById('modalBloomLevel');
-    const modalHP = document.getElementById('modalHP');
-    const modalColor = document.getElementById('modalColor');
-    const modalLives = document.getElementById('modalLives');
-    const modalBuzz = document.getElementById('modalBuzz');
-    const modalType = document.getElementById('modalType');
-    const modalAbility = document.getElementById('modalAbility');
-    const modalCollabEffect = document.getElementById('modalCollabEffect');
-    const modalBloomEffect = document.getElementById('modalBloomEffect');
-    const modalGiftEffect = document.getElementById('modalGiftEffect');
-    const modalExtraEffect = document.getElementById('modalExtraEffect');
-    const modalSources = document.getElementById('modalSources');
-
-    const modalOshiSkill = document.getElementById('modalOshiSkill');
-    const modalOshiSkillName = document.getElementById('modalOshiSkillName');
-    const modalOshiSkillPower = document.getElementById('modalOshiSkillPower');
-    const modalOshiSkillDescription = document.getElementById('modalOshiSkillDescription');
-
-    const modalSpOshiSkill = document.getElementById('modalSpOshiSkill');
-    const modalSpOshiSkillName = document.getElementById('modalSpOshiSkillName');
-    const modalSpOshiSkillPower = document.getElementById('modalSpOshiSkillPower');
-    const modalSpOshiSkillDescription = document.getElementById('modalSpOshiSkillDescription');
-
-    const modalSkills = document.getElementById('modalSkills');
 
     // Deck State
     const deck = {
@@ -73,6 +36,8 @@ document.addEventListener('DOMContentLoaded', function() {
     const cheerDeckListEl = document.getElementById('cheerDeckList');
     const clearDeckBtn = document.getElementById('clearDeckBtn');
     const exportDeckBtn = document.getElementById('exportDeckBtn');
+    const importDeckBtn = document.getElementById('importDeckBtn');
+    const importDeckInput = document.getElementById('importDeckInput');
 
     let allCardData = [];
 
@@ -187,12 +152,21 @@ document.addEventListener('DOMContentLoaded', function() {
         const searchText = searchBar.value.toLowerCase();
         const selectedRarity = rarityFilter.value;
         const selectedBloomType = bloomTypeFilter.value;
+        const checkboxState = {
+            altArt: altArtCheckbox?.checked,
+            fullArt: fullArtCheckbox?.checked,
+            foil: foilCheckbox?.checked,
+            signed: signedCheckbox?.checked,
+            grandprix: grandprixCheckbox?.checked,
+            holomenRare: holomenRareCheckbox?.checked,
+        };
 
         filteredCardData = allCardData.filter(card =>
             matchesSearchText(card, searchText) &&
             matchesSeries(card, seriesFilter.category, seriesFilter.prefix) &&
             matchesRarity(card, selectedRarity) &&
-            matchesBloomType(card, selectedBloomType)
+            matchesBloomType(card, selectedBloomType) &&
+            matchesCheckboxes(card, checkboxState)
         );
         displayCards(filteredCardData);
     }
@@ -425,8 +399,50 @@ document.addEventListener('DOMContentLoaded', function() {
         downloadAnchorNode.remove();
     }
 
+    function importDeck(event) {
+        const file = event.target.files[0];
+        if (!file) return;
+        const reader = new FileReader();
+        reader.onload = function(e) {
+            let data;
+            try { data = JSON.parse(e.target.result); } catch {
+                alert('Invalid JSON file.'); return;
+            }
+            if (!data.oshi && !data.deck && !data.cheer_deck) {
+                alert('Unrecognized deck format.'); return;
+            }
+            deck.oshi = []; deck.main = []; deck.cheer = [];
+            if (data.oshi) {
+                const oshiCard = allCardData.find(c => c.cardNumber === data.oshi);
+                if (oshiCard) deck.oshi.push(oshiCard);
+            }
+            if (data.deck) {
+                for (const [num, count] of Object.entries(data.deck)) {
+                    const card = allCardData.find(c => c.cardNumber === num);
+                    if (card) for (let i = 0; i < count; i++) deck.main.push(card);
+                }
+            }
+            if (data.cheer_deck) {
+                for (const [num, count] of Object.entries(data.cheer_deck)) {
+                    const card = allCardData.find(c => c.cardNumber === num);
+                    if (card) for (let i = 0; i < count; i++) deck.cheer.push(card);
+                }
+            }
+            updateDeckUI();
+            filteredCardData.forEach(c => updateCardGridQuantity(c));
+            event.target.value = '';
+        };
+        reader.readAsText(file);
+    }
+
     if (exportDeckBtn) {
         exportDeckBtn.addEventListener('click', exportDeck);
+    }
+    if (importDeckBtn) {
+        importDeckBtn.addEventListener('click', () => importDeckInput.click());
+    }
+    if (importDeckInput) {
+        importDeckInput.addEventListener('change', importDeck);
     }
 
     // Series filter button wiring
@@ -446,6 +462,8 @@ document.addEventListener('DOMContentLoaded', function() {
     searchBar.addEventListener('input', debounce(filterCards, 300));
     rarityFilter.addEventListener('change', filterCards);
     bloomTypeFilter.addEventListener('change', filterCards);
+    [altArtCheckbox, fullArtCheckbox, foilCheckbox, signedCheckbox, grandprixCheckbox, holomenRareCheckbox]
+        .forEach(cb => cb?.addEventListener('change', filterCards));
 
     const clearButton = document.getElementById('clearButton');
     if (clearButton) {

--- a/index.html
+++ b/index.html
@@ -103,47 +103,6 @@
         <div id="loadingIndicator">Loading...</div>
     </div>
 
-    <div id="modal" class="modal" onclick="closeModal(event)">
-        <div class="modal-content" onclick="event.stopPropagation()">
-            <span id="modalCloseIcon" class="modal-close">&times;</span>
-            <div id="modalImageContainer" class="image-scroll">
-                <img id="modalImage" data-src="" alt="" class="lazy-load" loading="lazy">
-            </div>
-            <div id="modalText">
-                <h3 id="modalCardName"></h3>
-                <p id="modalCardNumberContainer"><strong>Card Number:</strong> <span id="modalCardNumber"></span></p>
-                <p id="modalCardTagsContainer"><strong>Tags:</strong> <span id="modalCardTags"></span></p>
-                <p id="modalRarityContainer"><strong>Rarity:</strong> <span id="modalRarity"></span></p>
-                <p id="modalBloomLevelContainer"><strong>Bloom Level:</strong> <span id="modalBloomLevel"></span></p>
-                <p id="modalHPContainer"><strong>HP:</strong> <span id="modalHP"></span></p>
-                <p id="modalColorContainer"><strong>Color:</strong> <span id="modalColor"></span></p>
-                <p id="modalLivesContainer"><strong>Lives:</strong> <span id="modalLives"></span></p>
-                <p id="modalBuzzContainer"><strong>Buzz:</strong> <span id="modalBuzz"></span></p>
-                <p id="modalTypeContainer"><strong>Type:</strong> <span id="modalType"></span></p>
-                <p id="modalAbilityContainer"><strong>Ability:</strong> <span id="modalAbility"></span></p>
-                <p id="modalCollabEffectContainer"><strong>Collab Effect:</strong> <span id="modalCollabEffect"></span></p>
-                <p id="modalBloomEffectContainer"><strong>Bloom Effect:</strong> <span id="modalBloomEffect"></span></p>
-                <p id="modalGiftEffectContainer"><strong>Gift:</strong> <span id="modalGiftEffect"></span></p>
-                <p id="modalOshiStageSkillContainer" class="hidden"><strong>Oshi Stage Skill:</strong> <span id="modalOshiStageSkill"></span></p>
-                <div id="modalOshiSkill" class="hidden">
-                    <p><strong>Oshi Skill Name:</strong> <span id="modalOshiSkillName"></span></p>
-                    <p><strong>Power Cost:</strong> <span id="modalOshiSkillPower"></span></p>
-                    <p><strong>Description:</strong> <span id="modalOshiSkillDescription"></span></p>
-                </div>
-                <div id="modalSpOshiSkill" class="hidden">
-                    <p><strong>SP Oshi Skill Name:</strong> <span id="modalSpOshiSkillName"></span></p>
-                    <p><strong>Power Cost:</strong> <span id="modalSpOshiSkillPower"></span></p>
-                    <p><strong>Description:</strong> <span id="modalSpOshiSkillDescription"></span></p>
-                </div>
-                <div id="modalSkills" class="skills hidden">
-                    <h3>Skills</h3>
-                </div>
-                <p id="modalExtraEffectContainer"><strong>Extra Effect:</strong> <span id="modalExtraEffect"></span></p>
-                <p id="modalSourcesContainer"><strong>Sources:</strong> <span id="modalSources"></span></p>
-            </div>
-        </div>
-    </div>
-
    <script src="utils.js"></script>
    <script src="scripts.js"></script>
    <script src="navbar.js"></script>

--- a/scripts.js
+++ b/scripts.js
@@ -1,4 +1,6 @@
 document.addEventListener('DOMContentLoaded', function() {
+    injectModalHtml(false);
+
     const contentContainer = document.getElementById('contentContainer');
     const loadingIndicator = document.getElementById('loadingIndicator');
     const searchBar = document.getElementById('searchBar');
@@ -187,15 +189,6 @@ document.addEventListener('DOMContentLoaded', function() {
         displayCards(filteredCardData);
     }
 
-    function matchesCheckboxes(card, state) {
-        return (!state.altArt || card.hasAlternativeArt) &&
-            (!state.fullArt || card.hasFullArt) &&
-            (!state.foil || card.hasFoils) &&
-            (!state.signed || card.hasSigned) &&
-            (!state.grandprix || card.hasGrandPrix) &&
-            (!state.holomenRare || card.hasHolomenRare);
-    }
-
     function openModal(card) {
         const modalImageContainer = document.getElementById('modalImageContainer');
         modalImageContainer.innerHTML = '';
@@ -228,6 +221,7 @@ document.addEventListener('DOMContentLoaded', function() {
     if (modalCloseIcon) {
         modalCloseIcon.addEventListener('click', closeModal);
     }
+    modal.addEventListener('click', e => { if (e.target === modal) closeModal(e); });
     registerEscapeToClose(modal, closeModal);
 
     // Consolidated event listeners for all filter controls

--- a/utils.js
+++ b/utils.js
@@ -278,6 +278,65 @@ function matchesBloomType(card, selectedBloomType) {
     return card.bloomLevel === selectedBloomType || card.type === selectedBloomType;
 }
 
+function matchesCheckboxes(card, state) {
+    return (!state.altArt || card.hasAlternativeArt) &&
+        (!state.fullArt || card.hasFullArt) &&
+        (!state.foil || card.hasFoils) &&
+        (!state.signed || card.hasSigned) &&
+        (!state.grandprix || card.hasGrandPrix) &&
+        (!state.holomenRare || card.hasHolomenRare);
+}
+
+function injectModalHtml(includeAddBtn) {
+    const addBtnHtml = includeAddBtn
+        ? '<button id="modalAddBtn" class="add-btn" style="margin-bottom: 10px;">Add to Deck</button>'
+        : '';
+    const modal = document.createElement('div');
+    modal.id = 'modal';
+    modal.className = 'modal';
+    modal.innerHTML = `
+        <div class="modal-content" onclick="event.stopPropagation()">
+            <span id="modalCloseIcon" class="modal-close">&times;</span>
+            <div id="modalImageContainer" class="image-scroll">
+                <img id="modalImage" data-src="" alt="" class="lazy-load" loading="lazy">
+            </div>
+            <div id="modalText">
+                <h3 id="modalCardName"></h3>
+                ${addBtnHtml}
+                <p id="modalCardNumberContainer"><strong>Card Number:</strong> <span id="modalCardNumber"></span></p>
+                <p id="modalCardTagsContainer"><strong>Tags:</strong> <span id="modalCardTags"></span></p>
+                <p id="modalRarityContainer"><strong>Rarity:</strong> <span id="modalRarity"></span></p>
+                <p id="modalBloomLevelContainer"><strong>Bloom Level:</strong> <span id="modalBloomLevel"></span></p>
+                <p id="modalHPContainer"><strong>HP:</strong> <span id="modalHP"></span></p>
+                <p id="modalColorContainer"><strong>Color:</strong> <span id="modalColor"></span></p>
+                <p id="modalLivesContainer"><strong>Lives:</strong> <span id="modalLives"></span></p>
+                <p id="modalBuzzContainer"><strong>Buzz:</strong> <span id="modalBuzz"></span></p>
+                <p id="modalTypeContainer"><strong>Type:</strong> <span id="modalType"></span></p>
+                <p id="modalAbilityContainer"><strong>Ability:</strong> <span id="modalAbility"></span></p>
+                <p id="modalCollabEffectContainer"><strong>Collab Effect:</strong> <span id="modalCollabEffect"></span></p>
+                <p id="modalBloomEffectContainer"><strong>Bloom Effect:</strong> <span id="modalBloomEffect"></span></p>
+                <p id="modalGiftEffectContainer"><strong>Gift:</strong> <span id="modalGiftEffect"></span></p>
+                <p id="modalOshiStageSkillContainer" class="hidden"><strong>Oshi Stage Skill:</strong> <span id="modalOshiStageSkill"></span></p>
+                <div id="modalOshiSkill" class="hidden">
+                    <p><strong>Oshi Skill Name:</strong> <span id="modalOshiSkillName"></span></p>
+                    <p><strong>Power Cost:</strong> <span id="modalOshiSkillPower"></span></p>
+                    <p><strong>Description:</strong> <span id="modalOshiSkillDescription"></span></p>
+                </div>
+                <div id="modalSpOshiSkill" class="hidden">
+                    <p><strong>SP Oshi Skill Name:</strong> <span id="modalSpOshiSkillName"></span></p>
+                    <p><strong>Power Cost:</strong> <span id="modalSpOshiSkillPower"></span></p>
+                    <p><strong>Description:</strong> <span id="modalSpOshiSkillDescription"></span></p>
+                </div>
+                <div id="modalSkills" class="skills hidden">
+                    <h3>Skills</h3>
+                </div>
+                <p id="modalExtraEffectContainer"><strong>Extra Effect:</strong> <span id="modalExtraEffect"></span></p>
+                <p id="modalSourcesContainer"><strong>Sources:</strong> <span id="modalSources"></span></p>
+            </div>
+        </div>`;
+    document.body.appendChild(modal);
+}
+
 /**
  * Renders the per-set buttons inside seriesSetRow for the given category.
  * seriesFilter is a shared mutable object { category, prefix } owned by the caller.


### PR DESCRIPTION
- Move matchesCheckboxes to utils.js so deckbuilder can share it
- Expand deckbuilder variant checkboxes from 2 to 6 (matching index.html) and wire them into filterCards() so Foil/FullArt/AltArt/Signed/GrandPrix/ HolomenRare filters actually work
- Extract modal HTML into injectModalHtml() in utils.js, removing ~40 lines of duplicated markup from index.html and deckbuilder.html; also syncs the previously missing modalOshiStageSkillContainer into the deckbuilder modal
- Remove ~28 unused modal element const declarations from deckbuilder.js (populateModalCommon in utils.js queries them by ID directly)
- Add Import Deck button to deckbuilder that reads a HoloDuel-format JSON and restores Oshi, main deck, and cheer deck state