### PR TITLE
chore: ignore tools/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.md
 *.sql
 claude-docs/
+tools/
 


### PR DESCRIPTION
## What

Adds `tools/` to `.gitignore` so local build/utility scripts are not tracked.

## Why

The `tools/` directory holds local-only helpers (e.g. a Python script to rebuild `sets/all_cards.json` from the per-set JSON files). These are developer-side utilities that shouldn't be committed to the repo.

## Notes for reviewer

- Only `.gitignore` changes in this PR.
- `tools/status/hBP08_status.csv` is still tracked from before; it will be removed from git separately.