### PR TITLE
data: backfill Art costs and Baton Touch into card sets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 *.sql
 claude-docs/
 tools/
-
+Simulator/

--- a/sets/all_cards.json
+++ b/sets/all_cards.json
@@ -174,11 +174,13 @@
     "skills": [
       {
         "name": "こんかなた〜",
+        "cost": "1 White",
         "dmg": "40",
         "description": "This Arts can only target the opponent's center holomem."
       }
     ],
     "extraEffect": "You may include any number of this holomem in the deck.",
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "amane kanata hbp01-009 #jp #gen4 #singing you may include any number of this holomem in the deck. こんかなた〜 this arts can only target the opponent's center holomem."
   },
@@ -194,9 +196,11 @@
     "skills": [
       {
         "name": "行ってきまーす",
+        "cost": "1 any color",
         "dmg": "20"
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "amane kanata hbp01-010 #jp #gen4 #singing お出かけ天使 : during this turn, your center holomem gets arts+10. then, if your center holomem has #gen 4, your center holomem gets arts+20. 行ってきまーす "
   },
@@ -211,9 +215,11 @@
     "skills": [
       {
         "name": "塩対応かなたそ",
+        "cost": "1 White",
         "dmg": "20"
       }
     ],
+    "batonTouch": 0,
     "setName": "hBP01",
     "searchString": "amane kanata hbp01-011 #jp #gen4 #singing 塩対応かなたそ "
   },
@@ -229,9 +235,11 @@
     "skills": [
       {
         "name": "い~っぱい応援して!",
+        "cost": "1 any color",
         "dmg": "40"
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "amane kanata hbp01-012 #jp #gen4 #singing アイドルかなたそを : you may roll a die once:if it is 3 or less, reveal 1 mascot from your deck, and attach it to your holomem. then, shuffle the deck. い~っぱい応援して! "
   },
@@ -247,9 +255,11 @@
     "skills": [
       {
         "name": "エンジェルステージ",
+        "cost": "1 White, 1 any color",
         "dmg": "50"
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "amane kanata hbp01-013 #jp #gen4 #singing 天使のお仕事 :deal 30 special damage to your opponent's center holomem. however, your opponent's life does not reduce even if downed. エンジェルステージ "
   },
@@ -265,11 +275,13 @@
     "skills": [
       {
         "name": "+漆黒の翼+",
+        "cost": "3 White",
         "dmg": "100",
         "description": "If your opponent's holomem is downed by this Arts, and the dealt Damage was greater than the remaining HP by 50 or more, your opponent gets Life-1.."
       }
     ],
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP01",
     "searchString": "amane kanata hbp01-014 #jp #gen4 #singing 堕ちた天使 : deal 50 special damage to your opponent's center holomem. +漆黒の翼+ if your opponent's holomem is downed by this arts, and the dealt damage was greater than the remaining hp by 50 or more, your opponent gets life-1.."
   },
@@ -284,10 +296,12 @@
     "skills": [
       {
         "name": "Oh, Hi",
+        "cost": "1 White",
         "dmg": "10+",
         "description": "If you have used a Support Card this turn, this Arts gets +20.0"
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "nanashi mumei hbp01-015 #en #promise #bird #painting oh, hi if you have used a support card this turn, this arts gets +20.0"
   },
@@ -303,9 +317,11 @@
     "skills": [
       {
         "name": "リラックスタイム",
+        "cost": "1 any color",
         "dmg": "10"
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "nanashi mumei hbp01-016 #en #promise #bird #painting 白いキャンバス: if your center holomem has #promise, draw 1 card from your deck. リラックスタイム "
   },
@@ -320,13 +336,16 @@
     "skills": [
       {
         "name": "一緒にお出かけ",
+        "cost": "1 White",
         "dmg": "20"
       },
       {
         "name": "コーヒーブレイク",
+        "cost": "1 White, 1 any color",
         "dmg": "60"
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "nanashi mumei hbp01-017 #en #promise #bird #painting 一緒にお出かけ  コーヒーブレイク "
   },
@@ -341,10 +360,12 @@
     "skills": [
       {
         "name": "思い出の欠片",
+        "cost": "1 White",
         "dmg": "20+",
         "description": "You may reveal the top card of your deck:If the revealed card has #Promise, this Arts gets +20. Then, add the revealed card to hand."
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "nanashi mumei hbp01-018 #en #promise #bird #painting 思い出の欠片 you may reveal the top card of your deck:if the revealed card has #promise, this arts gets +20. then, add the revealed card to hand."
   },
@@ -360,9 +381,11 @@
     "skills": [
       {
         "name": "いつも応援してくれてありがとう!",
+        "cost": "1 any color",
         "dmg": "30"
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "nanashi mumei hbp01-019 #en #promise #bird #painting みんなと歌って踊りたい! : if bloomed from debut, reveal 1 [debut holomem or 1st holomem] other than buzz from your deck with #promise, and add it to hand. then, shuffle the deck. いつも応援してくれてありがとう! "
   },
@@ -378,10 +401,12 @@
     "skills": [
       {
         "name": "みんな一緒に",
+        "cost": "1 White, 2 any color",
         "dmg": "70",
         "description": "During this turn, your center holomem and collab holomem get Arts+10 for each of your back holomem.."
       }
     ],
+    "batonTouch": 2,
     "setName": "hBP01",
     "searchString": "nanashi mumei hbp01-020 #en #promise #bird #painting あの日の約束 : reveal 1 holomem with #promise from your deck, and add it to hand. then, shuffle the deck. みんな一緒に during this turn, your center holomem and collab holomem get arts+10 for each of your back holomem.."
   },
@@ -396,6 +421,7 @@
     "skills": [
       {
         "name": "みんな～こんそめ～",
+        "cost": "1 White",
         "dmg": "30"
       }
     ],
@@ -415,9 +441,11 @@
     "skills": [
       {
         "name": "みんな～こんそめ～",
-        "dmg": "30"
+        "cost": "1 any color",
+        "dmg": "40"
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "tokino sora hbp01-022 #jp #gen0 #singing 楽しむ準備はできてる！？ : draw 1 card from your deck. みんな～こんそめ～ "
   },
@@ -433,11 +461,13 @@
     "skills": [
       {
         "name": "止まらねえぞ",
+        "cost": "2 White, 1 any color",
         "dmg": "80",
         "description": "You may roll a die once:If it is odd, use this Arts once more on the same holomem (This Arts may be repeated until that holomem is downed)."
       }
     ],
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP01",
     "searchString": "tokino sora hbp01-023 #jp #gen0 #singing 私たちは前に向かって･･!: draw 2 cards from your deck. 止まらねえぞ you may roll a die once:if it is odd, use this arts once more on the same holomem (this arts may be repeated until that holomem is downed)."
   },
@@ -474,13 +504,16 @@
     "skills": [
       {
         "name": "温泉は飲まないでね！",
+        "cost": "1 White",
         "dmg": "40"
       },
       {
         "name": "温泉でくつろぐ一日を",
+        "cost": "1 White, 1 any color",
         "dmg": "60"
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "vestia zeta hbp01-025 #id #idgen3 温泉は飲まないでね！  温泉でくつろぐ一日を "
   },
@@ -496,9 +529,11 @@
     "skills": [
       {
         "name": "ステージみんな「私のもの」",
+        "cost": "1 any color",
         "dmg": "30"
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "vestia zeta hbp01-026 #id #idgen3 新たな運命: if bloomed from debut, reveal 1 [debut holomem or 1st holomem] other than buzz from your deck with #id gen 3, and add it to hand. then, shuffle the deck. ステージみんな「私のもの」 "
   },
@@ -515,12 +550,14 @@
     "skills": [
       {
         "name": "アクセスコード: ID",
+        "cost": "1 White, 2 any color",
         "dmg": "70+",
         "description": "If you Center holomem has #ID, this Art gains +50 power."
       }
     ],
     "extraEffect": "When this holomem is downed, your life is reduced by 2.",
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP01",
     "searchString": "vestia zeta hbp01-027 #id #idgen3 v.7: [once per turn] [collab position only]if your holomem would take damage from your opponent, you may roll a die once:if it is odd, that damage is not taken. when this holomem is downed, your life is reduced by 2. アクセスコード: id if you center holomem has #id, this art gains +50 power."
   },
@@ -555,9 +592,11 @@
     "skills": [
       {
         "name": "清楚なネフィリムです！",
+        "cost": "1 White, 1 any color",
         "dmg": "50"
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "irys hbp01-029 #en #promise #singing 清楚なネフィリムです！ "
   },
@@ -573,9 +612,11 @@
     "skills": [
       {
         "name": "一生懸命歌うから見ててね!",
+        "cost": "1 any color",
         "dmg": "40"
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "irys hbp01-030 #en #promise #singing ステージを希望で包もう！: during this turn, your [center holomem and collab holomem] with #promise get arts+30.. 一生懸命歌うから見ててね! "
   },
@@ -591,10 +632,12 @@
     "skills": [
       {
         "name": "約束の力",
+        "cost": "1 White, 2 any color",
         "dmg": "50",
         "description": "This Arts gets +20 for each of your holomem with #Promise."
       }
     ],
+    "batonTouch": 2,
     "setName": "hBP01",
     "searchString": "irys hbp01-031 #en #promise #singing 希望の庭園: look at your holo power. reveal 1 card from among them, and add it to hand. then, put the top card of your deck to holo power. 約束の力 this arts gets +20 for each of your holomem with #promise."
   },
@@ -632,9 +675,11 @@
     "skills": [
       {
         "name": "アフターパーティ",
+        "cost": "1 Green",
         "dmg": "20"
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "aki rosenthal hbp01-033 #jp #gen1 #half-elf #alcohol ヒーリングランウェイ: you may roll a die once:if it is odd, restore 20 hp to 1 of your green holomem.. アフターパーティ "
   },
@@ -649,13 +694,16 @@
     "skills": [
       {
         "name": "あらあら",
+        "cost": "1 Green",
         "dmg": "30"
       },
       {
         "name": "むぎゅむぎゅ雑談",
+        "cost": "1 Green, 1 any color",
         "dmg": "50"
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "aki rosenthal hbp01-034 #jp #gen1 #half-elf #alcohol あらあら  むぎゅむぎゅ雑談 "
   },
@@ -671,10 +719,12 @@
     "skills": [
       {
         "name": "アキロゼ幻想曲",
+        "cost": "1 Green",
         "dmg": "40",
         "description": "If a tool is attached to this holomem, send the top card of your cheer deck to your holomem."
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "aki rosenthal hbp01-035 #jp #gen1 #half-elf #alcohol ブレーメンの音楽祭: you may attach 1 tool from your archive to your holomem. アキロゼ幻想曲 if a tool is attached to this holomem, send the top card of your cheer deck to your holomem."
   },
@@ -690,9 +740,11 @@
     "skills": [
       {
         "name": "今日もがんばローゼ!",
+        "cost": "1 any color",
         "dmg": "30"
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "aki rosenthal hbp01-036 #jp #gen1 #half-elf #alcohol ロゼ隊のみんな応援しててね!: restore 20 hp to 1 of your holomem. 今日もがんばローゼ! "
   },
@@ -708,10 +760,12 @@
     "skills": [
       {
         "name": "秘密の合鍵",
+        "cost": "3 Green",
         "dmg": "70+",
         "description": "If a tool is attached to this holomem, this Arts gets +50.."
       }
     ],
+    "batonTouch": 2,
     "setName": "hBP01",
     "searchString": "aki rosenthal hbp01-037 #jp #gen1 #half-elf #alcohol ゴシックドール: send the top card of your cheer deck to your holomem. if a tool is attached to this holomem, restore 40 hp to this holomem. 秘密の合鍵 if a tool is attached to this holomem, this arts gets +50.."
   },
@@ -748,10 +802,12 @@
     "skills": [
       {
         "name": "こんぺこー!",
-        "dmg": "20+",
+        "cost": "1 any color",
+        "dmg": "30",
         "description": "Roll a die once: If the result is even, this art gains +20"
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "usada pekora hbp01-039 #jp #gen3 #kemomimi ギャラクシーアイドル　: if your oshi holomem is 〈usada pekora〉, you may roll a die once:if it is even, send the top card of your cheer deck to your holomem. こんぺこー! roll a die once: if the result is even, this art gains +20"
   },
@@ -766,9 +822,11 @@
     "skills": [
       {
         "name": "無重力ジャンプ!",
-        "dmg": 30
+        "cost": "1 Green, 1 any color",
+        "dmg": "60"
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "usada pekora hbp01-040 #jp #gen3 #kemomimi 無重力ジャンプ! "
   },
@@ -805,14 +863,17 @@
     "skills": [
       {
         "name": "白い砂浜と兎少女",
+        "cost": "1 Green",
         "dmg": 40
       },
       {
         "name": "きtらあああ",
+        "cost": "2 Green",
         "dmg": "50+",
         "description": "You may roll a die once:This Arts gets +10x the number rolled."
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "usada pekora hbp01-042 #jp #gen3 #kemomimi 白い砂浜と兎少女  きtらあああ you may roll a die once:this arts gets +10x the number rolled."
   },
@@ -828,11 +889,13 @@
     "skills": [
       {
         "name": "全人類兎化計画",
+        "cost": "3 Green, 1 any color",
         "dmg": "60+",
         "description": "Roll a die three times, for each total of 1 on the rolled dice, this art +10."
       }
     ],
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP01",
     "searchString": "usada pekora hbp01-043 #jp #gen3 #kemomimi ラプリンセスドレス: restore 50 hp to this holomen. 全人類兎化計画 roll a die three times, for each total of 1 on the rolled dice, this art +10."
   },
@@ -870,9 +933,11 @@
     "skills": [
       {
         "name": "海辺の街できみと～!",
+        "cost": "1 Green",
         "dmg": "20"
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "azki hbp01-045 #jp #gen0 #singing while your life is 3 or less, you may ignore bloom level and bloom this holomem to your hand's 2nd 〈azki〉. 海辺の街できみと～! "
   },
@@ -888,10 +953,12 @@
     "skills": [
       {
         "name": "こんな素敵な世界に来れました!",
+        "cost": "1 any color",
         "dmg": "30",
         "description": "Roll a die three times, for each total of 1 on the rolled dice, this art +10."
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "azki hbp01-046 #jp #gen0 #singing 開拓者のみんながいたから: you may choose 1~3 cheers from your stage, and reattach them to your holomem as you choose. こんな素敵な世界に来れました! roll a die three times, for each total of 1 on the rolled dice, this art +10."
   },
@@ -907,10 +974,12 @@
     "skills": [
       {
         "name": "新たな地図!",
+        "cost": "3 Green, 1 any color",
         "dmg": "120"
       }
     ],
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP01",
     "searchString": "azki hbp01-047 #jp #gen0 #singing いのちの軌跡: restore 40 hp to this holomem. you may roll a die once:if it is odd, you may send 1~3 green cheers from your archive to this holomem. 新たな地図! "
   },
@@ -945,13 +1014,16 @@
     "skills": [
       {
         "name": "とれたてナス",
+        "cost": "1 Green",
         "dmg": "30"
       },
       {
         "name": "おひとついかがでござるか？",
-        "dmg": "350"
+        "cost": "1 Green, 1 any color",
+        "dmg": "50"
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "kazama iroha hbp01-049 #jp #holox とれたてナス  おひとついかがでござるか？ "
   },
@@ -967,10 +1039,12 @@
     "skills": [
       {
         "name": "元気を全力でお届けします!",
+        "cost": "1 Green, 1 any color",
         "dmg": "20",
         "description": "Send the top card of your cheer deck to your holomem with #HoloX other than 〈Kazama Iroha〉."
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "kazama iroha hbp01-050 #jp #holox 用心棒: [collab position only], your opponent's holomem's arts can only target your collab holomem. however, it excludes special damage. 元気を全力でお届けします! send the top card of your cheer deck to your holomem with #holox other than 〈kazama iroha〉."
   },
@@ -986,16 +1060,19 @@
     "skills": [
       {
         "name": "エールを束ねて",
+        "cost": "1 Green, 1 any color",
         "dmg": "50+",
         "description": "[Collab Position only] This Arts gets +20 for each of this holomem's cheer. However, only up to 5 cheers are counted."
       },
       {
         "name": "風華の輝き",
+        "cost": "1 Green, 2 any color",
         "dmg": 70
       }
     ],
     "extraEffect": "When this holomem is downed, your life is reduced by 2.",
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP01",
     "searchString": "kazama iroha hbp01-051 #jp #holox when this holomem is downed, your life is reduced by 2. エールを束ねて [collab position only] this arts gets +20 for each of this holomem's cheer. however, only up to 5 cheers are counted. 風華の輝き "
   },
@@ -1031,9 +1108,11 @@
     "skills": [
       {
         "name": "あなたの愛しの宇宙人",
+        "cost": "2 any color",
         "dmg": "50"
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "airani iofifteen hbp01-053 #id #idgen1 #painting あなたの愛しの宇宙人 "
   },
@@ -1049,9 +1128,11 @@
     "skills": [
       {
         "name": "楽しみにしてるよ!!",
+        "cost": "1 any color",
         "dmg": "30"
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "airani iofifteen hbp01-054 #id #idgen1 #painting 緑の光が広がる海: send the top card of your cheer deck to your holomem with #id other than 〈airani iofifteen〉. 楽しみにしてるよ!! "
   },
@@ -1067,10 +1148,12 @@
     "skills": [
       {
         "name": "リレーションスカイ",
+        "cost": "1 Green, 2 any color",
         "dmg": "100",
         "description": "IfIf your stage has a holomem with #ID other than 〈Airani Iofifteen〉, this Arts gets +50."
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "airani iofifteen hbp01-055 #id #idgen1 #painting area 15: you may send 1 cheer each from your archive to 1~3 of your holomem with #id. リレーションスカイ ifif your stage has a holomem with #id other than 〈airani iofifteen〉, this arts gets +50."
   },
@@ -1106,10 +1189,12 @@
     "skills": [
       {
         "name": "漆黒の翼で誘おう",
+        "cost": "1 Red",
         "dmg": "20",
         "description": "Deal 10 Special Damage to your opponent's collab holomem."
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "takane lui hbp01-057 #jp #holox #bird #alcohol アポイント: deal 10 special damage to your opponent's collab holomem. 漆黒の翼で誘おう deal 10 special damage to your opponent's collab holomem."
   },
@@ -1124,13 +1209,16 @@
     "skills": [
       {
         "name": "こんルイルイ",
+        "cost": "1 Red",
         "dmg": "30"
       },
       {
         "name": "おつルイルイ",
+        "cost": "1 Red, 1 any color",
         "dmg": "50"
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "takane lui hbp01-058 #jp #holox #bird #alcohol こんルイルイ  おつルイルイ "
   },
@@ -1145,14 +1233,17 @@
     "skills": [
       {
         "name": "パーティーへようこそ",
+        "cost": "1 Red",
         "dmg": 30
       },
       {
         "name": "Lui's Party",
+        "cost": "2 Red",
         "dmg": 50,
         "description": "You may archive 1 card from your hand:Reveal 1 1st holomem other than Buzz from your deck, and add it to hand. Then, shuffle the deck."
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "takane lui hbp01-059 #jp #holox #bird #alcohol パーティーへようこそ  lui's party you may archive 1 card from your hand:reveal 1 1st holomem other than buzz from your deck, and add it to hand. then, shuffle the deck."
   },
@@ -1168,9 +1259,11 @@
     "skills": [
       {
         "name": "しっかりついてきてよね!!",
+        "cost": "1 any color",
         "dmg": "40"
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "takane lui hbp01-060 #jp #holox #bird #alcohol 本当にみんなのおかげ!!: if bloomed from debut, you may archive 1 card from your hand:draw 2 cards from your deck. しっかりついてきてよね!! "
   },
@@ -1186,10 +1279,12 @@
     "skills": [
       {
         "name": "ホークレイヴ",
+        "cost": "2 Red, 1 any color",
         "dmg": "60",
         "description": "You may archive 1~5 cards from your hand:Deal 20 Special Damage for each archived card to your opponent's center holomem or collab holomem.."
       }
     ],
+    "batonTouch": 2,
     "setName": "hBP01",
     "searchString": "takane lui hbp01-061 #jp #holox #bird #alcohol 組織の司令塔: you may return 1~2 holomem with #holox from your archive to hand. ホークレイヴ you may archive 1~5 cards from your hand:deal 20 special damage for each archived card to your opponent's center holomem or collab holomem.."
   },
@@ -1226,9 +1321,11 @@
     "skills": [
       {
         "name": "もふもふタイム",
+        "cost": "1 Red",
         "dmg": "20"
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "takanashi kiara hbp01-063 #en #myth #bird if your center holomem has #bird, you may archive 1 card from your hand:reveal 1 mascot from your deck, and add it to hand. then, shuffle the deck. もふもふタイム "
   },
@@ -1243,9 +1340,11 @@
     "skills": [
       {
         "name": "auf Wiedersehen",
+        "cost": "1 Red",
         "dmg": "20"
       }
     ],
+    "batonTouch": 0,
     "setName": "hBP01",
     "searchString": "takanashi kiara hbp01-064 #en #myth #bird auf wiedersehen "
   },
@@ -1261,9 +1360,11 @@
     "skills": [
       {
         "name": "盛り上げたいとおもいます！",
+        "cost": "1 any color",
         "dmg": "40"
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "takanashi kiara hbp01-065 #en #myth #bird look at the top three cards of your deck. reveal one that is a holomem and put it into your hand. then archive the remaining cards. 盛り上げたいとおもいます！ "
   },
@@ -1278,14 +1379,17 @@
     "skills": [
       {
         "name": "不死鳥の剣姫",
+        "cost": "1 Red",
         "dmg": "50"
       },
       {
         "name": "跪きなさい。",
+        "cost": "2 Red",
         "dmg": "40",
         "description": "You may archive 1 holomem that is stacked to this holomem:Deal 40 Special Damage to your opponent's collab holomem."
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "takanashi kiara hbp01-066 #en #myth #bird 不死鳥の剣姫  跪きなさい。 you may archive 1 holomem that is stacked to this holomem:deal 40 special damage to your opponent's collab holomem."
   },
@@ -1300,15 +1404,18 @@
     "skills": [
       {
         "name": "焔色の導き",
+        "cost": "2 Red",
         "dmg": "70"
       },
       {
         "name": "マジェスティック・フェニックス",
+        "cost": "3 Red",
         "dmg": "80+",
         "description": "This Arts gets +10 for each holomem in your archive. Then, return 6 holomem from your archive to deck and shuffle it."
       }
     ],
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP01",
     "searchString": "takanashi kiara hbp01-067 #en #myth #bird 焔色の導き  マジェスティック・フェニックス this arts gets +10 for each holomem in your archive. then, return 6 holomem from your archive to deck and shuffle it."
   },
@@ -1345,13 +1452,16 @@
     "skills": [
       {
         "name": "おはぽる",
+        "cost": "1 Red",
         "dmg": "20"
       },
       {
         "name": "おそぽる",
+        "cost": "1 Red, 1 any color",
         "dmg": "40"
       }
     ],
+    "batonTouch": 0,
     "setName": "hBP01",
     "searchString": "omaru polka hbp01-069 #jp #gen5 #kemomimi おはぽる  おそぽる "
   },
@@ -1367,10 +1477,12 @@
     "skills": [
       {
         "name": "共依存",
+        "cost": "1 Red, 1 any color",
         "dmg": "70",
         "description": "This Arts can only be used if a 〈Zain〉is attached to this holomem."
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "omaru polka hbp01-070 #jp #gen5 #kemomimi 宴の始まりだ!: reveal 1 fan from your deck, and add it to hand. then, shuffle the deck. 共依存 this arts can only be used if a 〈zain〉is attached to this holomem."
   },
@@ -1387,12 +1499,14 @@
     "skills": [
       {
         "name": "ポルカサーカス",
-        "dmg": "60+",
+        "cost": "1 Red, 1 any color",
+        "dmg": "50+",
         "description": "This Arts gets +20 for each fan attached to all of your holomem."
       }
     ],
     "extraEffect": "When this holomem is downed, your life is reduced by 2.",
     "hasAlternativeArt": true,
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "omaru polka hbp01-071 #jp #gen5 #kemomimi ポルカイリュージョン!: you may return 1〈zain〉from your archive to hand. when this holomem is downed, your life is reduced by 2. ポルカサーカス this arts gets +20 for each fan attached to all of your holomem."
   },
@@ -1428,9 +1542,11 @@
     "skills": [
       {
         "name": "WITNESS ME!!",
+        "cost": "1 Red, 1 any color",
         "dmg": "60"
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "hakos baelz hbp01-073 #en #promise #kemomimi witness me!! "
   },
@@ -1446,9 +1562,11 @@
     "skills": [
       {
         "name": "楽しい時間の始まりだ!",
+        "cost": "1 any color",
         "dmg": "30"
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "hakos baelz hbp01-074 #en #promise #kemomimi ネズミアイドルがいよいよ登場!: if bloomed from debut, you may return 1 [debut holomem or 1st holomem] from archive to hand:if the returned card has #en, deal 20 special damage to your opponent's collab holomem. 楽しい時間の始まりだ! "
   },
@@ -1464,9 +1582,11 @@
     "skills": [
       {
         "name": "Disorder!",
+        "cost": "1 Red, 1 any color",
         "dmg": "100"
       }
     ],
+    "batonTouch": 2,
     "setName": "hBP01",
     "searchString": "hakos baelz hbp01-075 #en #promise #kemomimi カオスシャッフル: each player returns all cards from their hand to the bottom of their deck in any order. next, each player draws 1 card from their deck for each card returned to the deck. disorder! "
   },
@@ -1505,9 +1625,11 @@
     "skills": [
       {
         "name": "新しい衣装",
+        "cost": "1 Blue",
         "dmg": "30"
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "hoshimachi suisei hbp01-077 #jp #gen0 #singing 煌きのワードローブ　: if your oshi holomem is 〈hoshimachi suisei〉, you may archive 1 blue cheer from this holomem:draw 2 cards from your deck. 新しい衣装 "
   },
@@ -1522,13 +1644,16 @@
     "skills": [
       {
         "name": "ストリートスナップ",
+        "cost": "1 Blue",
         "dmg": "30"
       },
       {
         "name": "木漏れ日のひと時",
+        "cost": "1 Blue, 1 any color",
         "dmg": "50"
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "hoshimachi suisei hbp01-078 #jp #gen0 #singing ストリートスナップ  木漏れ日のひと時 "
   },
@@ -1544,9 +1669,11 @@
     "skills": [
       {
         "name": "すいちゃんはーー今日もかわいいーー！！",
+        "cost": "2 any color",
         "dmg": "50"
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "hoshimachi suisei hbp01-079 #jp #gen0 #singing あっと驚かせるから見逃さないでね！ : deal 20 special damage to 1 of your opponent's back holomem. however, your opponent's life does not reduce even if downed. すいちゃんはーー今日もかわいいーー！！ "
   },
@@ -1562,9 +1689,11 @@
     "skills": [
       {
         "name": "戦うメイドさん",
+        "cost": "2 Blue",
         "dmg": "70"
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "hoshimachi suisei hbp01-080 #jp #gen0 #singing 雪山の記憶 : you may roll a die once:if it is odd, down 1 of your opponent's back holomem whose hp is reduced by 40 or more. however, your opponent's life does not reduce even if downed. 戦うメイドさん "
   },
@@ -1580,11 +1709,13 @@
     "skills": [
       {
         "name": "輝く彗星",
+        "cost": "3 Blue, 1 any color",
         "dmg": "60+",
         "description": "You may archive 2 blue cheers from this holomem:This Arts gets +60 for each holomem that is stacked to this holomem (This Arts can target your opponent's back holomem too)."
       }
     ],
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP01",
     "searchString": "hoshimachi suisei hbp01-081 #jp #gen0 #singing 空を駆ける光 : send the top card of your cheer deck to your blue holomem. 輝く彗星 you may archive 2 blue cheers from this holomem:this arts gets +60 for each holomem that is stacked to this holomem (this arts can target your opponent's back holomem too)."
   },
@@ -1619,9 +1750,11 @@
     "skills": [
       {
         "name": "波だ~! 泳げ~!",
+        "cost": "1 any color",
         "dmg": "10"
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "kobo kanaeru hbp01-083 #id #idgen3 ほを海に連れて!: if your center holomem has #id, you may roll a die once:if it is 3 or greater, send the top card of your cheer deck to your holomem. 波だ~! 泳げ~! "
   },
@@ -1636,9 +1769,11 @@
     "skills": [
       {
         "name": "になる～　",
+        "cost": "1 Blue, 1 any color",
         "dmg": "50"
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "kobo kanaeru hbp01-084 #id #idgen3 になる～　 "
   },
@@ -1653,14 +1788,17 @@
     "skills": [
       {
         "name": "perayaan",
+        "cost": "1 Blue",
         "dmg": "40"
       },
       {
         "name": "レインドロップス",
+        "cost": "1 Blue, 1 any color",
         "dmg": "50",
         "description": "Deal 10 Special Damage to 3 of your opponent's back holomem. However, your opponent's Life does not reduce even if downed."
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "kobo kanaeru hbp01-085 #id #idgen3 perayaan  レインドロップス deal 10 special damage to 3 of your opponent's back holomem. however, your opponent's life does not reduce even if downed."
   },
@@ -1676,9 +1814,11 @@
     "skills": [
       {
         "name": "OnAeru",
+        "cost": "1 any color",
         "dmg": "40"
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "kobo kanaeru hbp01-086 #id #idgen3 バーチャルマーケティング: you may archive 1 cheer from your holomem with #id:deal 10 special damage to all of your opponent's back holomem. however, your opponent's life does not reduce even if downed. onaeru "
   },
@@ -1693,15 +1833,18 @@
     "skills": [
       {
         "name": "雨のマントラ",
+        "cost": "1 Blue, 1 any color",
         "dmg": "40",
         "description": "You may archive 1 cheer from this holomem:Deal 20 Special Damage to all of your opponent's back holomem. However, your opponent's Life does not reduce even if downed."
       },
       {
         "name": "波のマントラ",
+        "cost": "2 Blue, 1 any color",
         "dmg": 40,
         "description": "You may archive 2 cheers from this holomem:Deal the same amount of Special Damage to the opponent's center holomem as the total number of Damage taken by all of your opponent's back holomem."
       }
     ],
+    "batonTouch": 2,
     "setName": "hBP01",
     "searchString": "kobo kanaeru hbp01-087 #id #idgen3 雨のマントラ you may archive 1 cheer from this holomem:deal 20 special damage to all of your opponent's back holomem. however, your opponent's life does not reduce even if downed. 波のマントラ you may archive 2 cheers from this holomem:deal the same amount of special damage to the opponent's center holomem as the total number of damage taken by all of your opponent's back holomem."
   },
@@ -1737,9 +1880,11 @@
     "skills": [
       {
         "name": "おつムーナ",
+        "cost": "1 Blue, 1 any color",
         "dmg": "60"
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "moona hoshinova hbp01-089 #id #idgen1 #singing おつムーナ "
   },
@@ -1755,9 +1900,11 @@
     "skills": [
       {
         "name": "楽しみにしてて!!",
+        "cost": "1 any color",
         "dmg": "20"
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "moona hoshinova hbp01-090 #id #idgen1 #singing ラピスラズリ: reveal 1 [green cheer or blue cheer] from your cheer deck, and send it to your holomem. then, shuffle the cheer deck. 楽しみにしてて!! "
   },
@@ -1773,16 +1920,19 @@
     "skills": [
       {
         "name": "月は夜に。",
+        "cost": "2 any color",
         "dmg": "50"
       },
       {
         "name": "ムーンナイトディーパ",
+        "cost": "1 Blue, 2 any color",
         "dmg": 80,
         "description": "You may archive 1 [green cheer or blue cheer] from this holomem:Deal 30 Special Damage to 1 of your opponent's back holomem."
       }
     ],
     "extraEffect": "When this holomem is downed, your life is reduced by 2.",
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP01",
     "searchString": "moona hoshinova hbp01-091 #id #idgen1 #singing when this holomem is downed, your life is reduced by 2. 月は夜に。  ムーンナイトディーパ you may archive 1 [green cheer or blue cheer] from this holomem:deal 30 special damage to 1 of your opponent's back holomem."
   },
@@ -1820,13 +1970,16 @@
     "skills": [
       {
         "name": "クロやすみ～",
+        "cost": "1 any color",
         "dmg": "40"
       },
       {
         "name": "お休みクロタイム",
+        "cost": "1 Blue, 1 any color",
         "dmg": "60"
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "ouro kronii hbp01-093 #en #promise クロやすみ～  お休みクロタイム "
   },
@@ -1842,9 +1995,11 @@
     "skills": [
       {
         "name": "忘れられないfesにしよう!!",
+        "cost": "1 any color",
         "dmg": "40"
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "ouro kronii hbp01-094 #en #promise クロにちは!: reveal 1 cheer from your cheer deck with the same color as 1 of your holomem with #promise, and send it to your holomem with #promise. then, shuffle the cheer deck. 忘れられないfesにしよう!! "
   },
@@ -1860,10 +2015,12 @@
     "skills": [
       {
         "name": "早送り",
+        "cost": "1 Blue, 2 any color",
         "dmg": "60",
         "description": "You may Bloom a 1st holomem from your hand on 1 of your Debut back holomem placed this turn"
       }
     ],
+    "batonTouch": 2,
     "setName": "hBP01",
     "searchString": "ouro kronii hbp01-095 #en #promise 巻き戻し: return 1 of your opponent's back holomem to debut holomem (after removing damage, 1 debut holomem and all of the cheers remain, and return all other cards to hand). 早送り you may bloom a 1st holomem from your hand on 1 of your debut back holomem placed this turn"
   },
@@ -1879,10 +2036,12 @@
     "skills": [
       {
         "name": "ぺこら~扉の向こう側へ~",
+        "cost": "1 any color",
         "dmg": 10
       }
     ],
     "extraEffect": "This holomem cannot Bloom.",
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "usada pekora hbp01-096 #jp #gen3 #kemomimi それは「冒険」: you may roll a die once:if it is even, reveal a buzz holomem from your deck, and add it to hand. then, shuffle the deck. this holomem cannot bloom. ぺこら~扉の向こう側へ~ "
   },
@@ -1898,10 +2057,12 @@
     "skills": [
       {
         "name": "フレア~扉の向こう側へ~",
+        "cost": "1 any color",
         "dmg": "20"
       }
     ],
     "extraEffect": "This holomem cannot Bloom.",
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "shiranui flare hbp01-097 #jp #gen3 #half-elf それは「愛と絆の物語」: exchange your center holomem with 1 non-resting back holomem. this holomem cannot bloom. フレア~扉の向こう側へ~ "
   },
@@ -1917,10 +2078,12 @@
     "skills": [
       {
         "name": "ノエル~扉の向こう側へ~",
+        "cost": "2 any color",
         "dmg": 20
       }
     ],
     "extraEffect": "This holomem cannot Bloom.",
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "shirogane noel hbp01-098 #jp #gen3 #alcohol それは「俺」: you may send 1 cheer from your archive to your holomem. this holomem cannot bloom. ノエル~扉の向こう側へ~ "
   },
@@ -1936,10 +2099,12 @@
     "skills": [
       {
         "name": "マリン~扉の向こう側へ~",
+        "cost": "1 any color",
         "dmg": 10
       }
     ],
     "extraEffect": "This holomem cannot Bloom.",
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "houshou marine hbp01-099 #jp #gen3 #painting #sea それは「エジンバラ城」: you may roll a die once:if it is odd, exchange your opponent's center holomem with 1 back holomem. this holomem cannot bloom. マリン~扉の向こう側へ~ "
   },
@@ -1955,10 +2120,12 @@
     "skills": [
       {
         "name": "ソウルご案内",
+        "cost": "1 any color",
         "dmg": 30
       }
     ],
     "extraEffect": "This holomem cannot Bloom.",
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "mori calliope hbp01-100 #en #myth #singing ソウル収穫　: you may return 1~3 cheers from your archive to the cheer deck. then, shuffle the cheer deck. this holomem cannot bloom. ソウルご案内 "
   },
@@ -1974,10 +2141,12 @@
     "skills": [
       {
         "name": "初歩的なことなんでしょう？",
+        "cost": "2 any color",
         "dmg": 20
       }
     ],
     "extraEffect": "This holomem cannot Bloom.",
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "watson amelia hbp01-101 #en #myth ソウル収穫　: you may return 1 item from your archive to hand. this holomem cannot bloom. 初歩的なことなんでしょう？ "
   },
@@ -2389,9 +2558,11 @@
     "skills": [
       {
         "name": "Otsu-kon-deshita",
+        "cost": "1 White",
         "dmg": "20"
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP02",
     "searchString": "shirakami fubuki hbp02-009 #jp #gen1 #gamers #kemomimi #painting おはこんきーつね！:[collab position only]all of your holomem with mascot attached get arts+10. otsu-kon-deshita "
   },
@@ -2406,14 +2577,17 @@
     "skills": [
       {
         "name": "キンモクセイの花フブキ",
+        "cost": "1 White",
         "dmg": "40"
       },
       {
         "name": "Thank You Friends♥",
+        "cost": "1 White, 1 any color",
         "dmg": "60"
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP02",
     "searchString": "shirakami fubuki hbp02-010 #jp #gen1 #gamers #kemomimi #painting キンモクセイの花フブキ  thank you friends♥ "
   },
@@ -2429,10 +2603,12 @@
     "skills": [
       {
         "name": "ダメですよっ！",
+        "cost": "1 any color",
         "dmg": "40"
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP02",
     "searchString": "shirakami fubuki hbp02-011 #jp #gen1 #gamers #kemomimi #painting 白上から目をそらしちゃ: reveal 1 card with #shirakamicharacter from your deck, and add it to hand. then, shuffle the deck. ダメですよっ！ "
   },
@@ -2448,11 +2624,13 @@
     "skills": [
       {
         "name": "力をかしてくださいね",
+        "cost": "1 White, 1 any color",
         "dmg": "50+",
         "description": "During this turn, your [center holomem and collab holomem] with mascot attached get Arts+20."
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP02",
     "searchString": "shirakami fubuki hbp02-012 #jp #gen1 #gamers #kemomimi #painting ちょっと動かしますね : you may reattach 1 mascot from your stage to your holomem. 力をかしてくださいね during this turn, your [center holomem and collab holomem] with mascot attached get arts+20."
   },
@@ -2468,12 +2646,14 @@
     "skills": [
       {
         "name": "マスコットたちの舞宴",
+        "cost": "2 White, 1 any color",
         "dmg": "80+",
         "description": "This Arts gets +20 for each mascot on your stage."
       }
     ],
     "hasAlternativeArt": true,
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP02",
     "searchString": "shirakami fubuki hbp02-013 #jp #gen1 #gamers #kemomimi #painting みんなと一緒! you may attach up to 2 mascots with different card names to this holomem. マスコットたちの舞宴 this arts gets +20 for each mascot on your stage."
   },
@@ -2510,14 +2690,17 @@
     "skills": [
       {
         "name": "おはまっする〜!",
+        "cost": "1 any color",
         "dmg": "30"
       },
       {
         "name": "おつまっする~",
+        "cost": "1 White, 1 any color",
         "dmg": "60"
       }
     ],
     "hasFoils": true,
+    "batonTouch": 2,
     "setName": "hBP02",
     "searchString": "shirogane noel hbp02-015 #jp #gen3 #alcohol おはまっする〜!  おつまっする~ "
   },
@@ -2555,10 +2738,12 @@
     "skills": [
       {
         "name": "ゆるふわ脳筋女騎士",
+        "cost": "2 any color",
         "dmg": "50"
       },
       {
         "name": "3期生ぱわー",
+        "cost": "1 White, 2 any color",
         "dmg": "60+",
         "description": "(Collab position only) For each other Holomen on your stage with the #Gen3 tag, this Arts gets +20. However, the number of Holomen counted is limited to 4.."
       }
@@ -2566,6 +2751,7 @@
     "extraEffect": "If this holomem is downed, you get Life-2",
     "hasAlternativeArt": true,
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP02",
     "searchString": "shirogane noel hbp02-017 #jp #gen3 #alcohol if this holomem is downed, you get life-2 ゆるふわ脳筋女騎士  3期生ぱわー (collab position only) for each other holomen on your stage with the #gen3 tag, this arts gets +20. however, the number of holomen counted is limited to 4.."
   },
@@ -2601,10 +2787,12 @@
     "skills": [
       {
         "name": "Very Easy",
+        "cost": "1 any color",
         "dmg": "20"
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP02",
     "searchString": "pavolia reine hbp02-019 #id #idgen2 #bird #painting 友達をhaluにさせる方法 : you may send 1 cheer from your archive to your holomem. very easy "
   },
@@ -2619,10 +2807,12 @@
     "skills": [
       {
         "name": "Royal Halu Sleepover",
+        "cost": "1 Green, 1 any color",
         "dmg": "50"
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP02",
     "searchString": "pavolia reine hbp02-020 #id #idgen2 #bird #painting royal halu sleepover "
   },
@@ -2638,11 +2828,13 @@
     "skills": [
       {
         "name": "だから見ててね！大好き！",
+        "cost": "1 any color",
         "dmg": "20",
         "description": "You may send 1 Cheer from your Archive to any of your holomems."
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP02",
     "searchString": "pavolia reine hbp02-021 #id #idgen2 #bird #painting 心を込めて歌って、踊ります。 restore 10 hp to 1 of your holomem for each cheer color on your stage. だから見ててね！大好き！ you may send 1 cheer from your archive to any of your holomems."
   },
@@ -2658,11 +2850,13 @@
     "skills": [
       {
         "name": "Spicy Night",
+        "cost": "1 Green, 1 any color",
         "dmg": "40+",
         "description": "If your stage has 2 or more cheer colors, this Arts gets +20."
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP02",
     "searchString": "pavolia reine hbp02-022 #id #idgen2 #bird #painting what are you waiting for?: reveal 1 〈tatang〉 from your deck, and add it to hand. then, shuffle the deck. spicy night if your stage has 2 or more cheer colors, this arts gets +20."
   },
@@ -2678,12 +2872,14 @@
     "skills": [
       {
         "name": "孔雀の舞",
+        "cost": "1 Green, 3 any color",
         "dmg": "100+",
         "description": "This Arts gets +20 for every cheer color on your stage."
       }
     ],
     "hasAlternativeArt": true,
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP02",
     "searchString": "pavolia reine hbp02-023 #id #idgen2 #bird #painting kanjeng : reveal 1 cheer from your cheer deck, and send it to your holomem. then, shuffle the cheer deck. 孔雀の舞 this arts gets +20 for every cheer color on your stage."
   },
@@ -2719,14 +2915,17 @@
     "skills": [
       {
         "name": "おはみぉーん",
+        "cost": "1 any color",
         "dmg": "30"
       },
       {
         "name": "おつみぉーん",
+        "cost": "1 Green, 1 any color",
         "dmg": "50"
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP02",
     "searchString": "ookami mio hbp02-025 #jp #gamers #kemomimi #cooking おはみぉーん  おつみぉーん "
   },
@@ -2742,10 +2941,12 @@
     "skills": [
       {
         "name": "今年も見守っててね！",
+        "cost": "1 any color",
         "dmg": "20"
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP02",
     "searchString": "ookami mio hbp02-026 #jp #gamers #kemomimi #cooking アイドルとして成長した姿 : reveal 1 cheer from your cheer deck with the same color as 1 of your holomem with #gamers on stage, and send it to your holomem. then, shuffle the cheer deck. 今年も見守っててね！ "
   },
@@ -2760,6 +2961,7 @@
     "skills": [
       {
         "name": "タロットの導き",
+        "cost": "1 Green, 1 any color",
         "dmg": "60+",
         "description": "You may archive the top card of your deck:If the archived card is a holomem, this Arts gets +20. If it is a support card, this Arts gets +50."
       }
@@ -2767,6 +2969,7 @@
     "extraEffect": "If this holomem is downed, you get Life-2",
     "hasAlternativeArt": true,
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP02",
     "searchString": "ookami mio hbp02-027 #jp #gamers #kemomimi #cooking if this holomem is downed, you get life-2 タロットの導き you may archive the top card of your deck:if the archived card is a holomem, this arts gets +20. if it is a support card, this arts gets +50."
   },
@@ -2781,10 +2984,12 @@
     "skills": [
       {
         "name": "宝鐘海賊団船長の宝鐘マリンですぅー!",
+        "cost": "1 any color",
         "dmg": "30"
       }
     ],
     "extraEffect": "You may include any number of this holomem in the deck.",
+    "batonTouch": 1,
     "setName": "hBP02",
     "searchString": "houshou marine hbp02-028 #jp #gen3 #painting #sea you may include any number of this holomem in the deck. 宝鐘海賊団船長の宝鐘マリンですぅー! "
   },
@@ -2800,9 +3005,11 @@
     "skills": [
       {
         "name": "マリン“船長”だろぉぉん！？",
+        "cost": "1 Red, 1 any color",
         "dmg": "30"
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP02",
     "searchString": "houshou marine hbp02-029 #jp #gen3 #painting #sea #alcohol マリンと宅飲み: deal 20 special damage to your opponent's collab holomem. マリン“船長”だろぉぉん！？ "
   },
@@ -2817,14 +3024,17 @@
     "skills": [
       {
         "name": "船長、何されちゃうのかな？",
+        "cost": "1 Red",
         "dmg": "40"
       },
       {
         "name": "もう、どスケベ♥",
+        "cost": "1 Red, 1 any color",
         "dmg": "60"
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP02",
     "searchString": "houshou marine hbp02-030 #jp #gen3 #painting #sea 船長、何されちゃうのかな？  もう、どスケベ♥ "
   },
@@ -2862,10 +3072,12 @@
     "skills": [
       {
         "name": "ヨーソロー",
+        "cost": "2 any color",
         "dmg": "50"
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP02",
     "searchString": "houshou marine hbp02-032 #jp #gen3 #painting #sea 宝鐘の海賊団: reveal a card named houshou marine from your deck and put it into your hand. then shuffle your deck. you may only use the bloom effect 「宝鐘の海賊団」 once per turn. ヨーソロー "
   },
@@ -2881,12 +3093,14 @@
     "skills": [
       {
         "name": "キミたち～？: 船長、かわいい？",
+        "cost": "1 Red, 2 any color",
         "dmg": "80+",
         "description": "This Arts gets +20 for each holomem stacked to this holomem."
       }
     ],
     "hasAlternativeArt": true,
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP02",
     "searchString": "houshou marine hbp02-033 #jp #gen3 #painting #sea ゴシッククィーン: you may return 1 holomem from your archive to hand. if 3 or more holomem are stacked to this holomem, deal 50 special damage to your opponent's center holomem or collab holomem. キミたち～？: 船長、かわいい？ this arts gets +20 for each holomem stacked to this holomem."
   },
@@ -2902,10 +3116,12 @@
     "skills": [
       {
         "name": "余は草",
+        "cost": "1 Red, 1 any color",
         "dmg": "50"
       },
       {
         "name": "オーガニックショット",
+        "cost": "1 Red, 2 any color",
         "dmg": "80",
         "description": "If a tool or mascot is attached to this holomem, deal 30 special damage to your opponent's center holomem or collab holomem."
       }
@@ -2913,6 +3129,7 @@
     "extraEffect": "If this holomem is downed, you get Life-2",
     "hasAlternativeArt": true,
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP02",
     "searchString": "nakiri ayame hbp02-034 #jp #gen2 #shooter if this holomem is downed, you get life-2 余は草  オーガニックショット if a tool or mascot is attached to this holomem, deal 30 special damage to your opponent's center holomem or collab holomem."
   },
@@ -2927,10 +3144,12 @@
     "skills": [
       {
         "name": "ばっくばっくばく～ん",
+        "cost": "1 any color",
         "dmg": "30"
       }
     ],
     "extraEffect": "You may include any number of this holomem in the deck.",
+    "batonTouch": 1,
     "setName": "hBP02",
     "searchString": "sakamata chloe hbp02-035 #jp #holox #sea you may include any number of this holomem in the deck. ばっくばっくばく～ん "
   },
@@ -2946,10 +3165,12 @@
     "skills": [
       {
         "name": "吐いて捨てるような現実を！",
+        "cost": "1 any color",
         "dmg": "20"
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP02",
     "searchString": "sakamata chloe hbp02-036 #jp #holox #sea 掃除屋でインターン: look at the top 3 cards of your deck. reveal 1 2nd holomem with #holox from among them, and add it to hand. then, return the remaining cards to the bottom of the deck in any order. 吐いて捨てるような現実を！ "
   },
@@ -2964,10 +3185,12 @@
     "skills": [
       {
         "name": "ふたりじめビーチ",
+        "cost": "1 Blue, 1 any color",
         "dmg": "60"
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP02",
     "searchString": "sakamata chloe hbp02-037 #jp #holox #sea ふたりじめビーチ "
   },
@@ -2983,10 +3206,12 @@
     "skills": [
       {
         "name": "(ここ喜ぶ所です）",
+        "cost": "1 any color",
         "dmg": "30"
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP02",
     "searchString": "sakamata chloe hbp02-038 #jp #holox #sea 君の心をばっくばっくばく～んしちゃうぞ♡: look at the top 3 cards of your cheer deck. reveal 1 cheer from among them, and send it to your holomem. then, return the remaining cheers to the bottom of the cheer deck in any order. (ここ喜ぶ所です） "
   },
@@ -3002,11 +3227,13 @@
     "skills": [
       {
         "name": "ホロックスロット",
+        "cost": "1 Blue, 1 any color",
         "dmg": "20+",
         "description": "You may reveal the top 3 cards of your deck:This Arts gets +20 for each holomem revealed. Then, archive the revealed cards."
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP02",
     "searchString": "sakamata chloe hbp02-039 #jp #holox #sea ぷいぷいぷい～: (once per turn) when you reveal cards with this holomem's art 「ホロックスロット」, you may put 1 of them that is a support card into your hand instead of archiving it. ホロックスロット you may reveal the top 3 cards of your deck:this arts gets +20 for each holomem revealed. then, archive the revealed cards."
   },
@@ -3022,12 +3249,14 @@
     "skills": [
       {
         "name": "ホロックスロット",
+        "cost": "2 Blue, 1 any color",
         "dmg": "100+",
         "description": "You may reveal the top 3 cards of your deck:This Arts gets +20 for each holomem revealed. Then, archive the revealed cards."
       }
     ],
     "hasAlternativeArt": true,
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP02",
     "searchString": "sakamata chloe hbp02-040 #jp #holox #sea 最高に激アツ～(once per turn) when you reveal cards with this holomem's art 「ホロックスロット」, if the three revealed cards are all holomems with the same bloom level, your opponent loses 1 life. ホロックスロット you may reveal the top 3 cards of your deck:this arts gets +20 for each holomem revealed. then, archive the revealed cards."
   },
@@ -3044,6 +3273,7 @@
     "skills": [
       {
         "name": "ぽいずん猫",
+        "cost": "1 Blue, 2 any color",
         "dmg": "50",
         "description": "You may archive 1 ▲blue▲ cheer from this holomem:Deal 20 special damage to your opponent's center holomem and 1 of their back holomem."
       }
@@ -3051,6 +3281,7 @@
     "extraEffect": "If this holomem is downed, you get Life-2",
     "hasAlternativeArt": true,
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP02",
     "searchString": "nekomata okayu hbp02-041 #jp #gamers #kemomimi #singing 毒の愛:(center position only) all 〈nekomata okayu〉on your stage deal +20 special damage to your opponent's center holomem. if this holomem is downed, you get life-2 ぽいずん猫 you may archive 1 ▲blue▲ cheer from this holomem:deal 20 special damage to your opponent's center holomem and 1 of their back holomem."
   },
@@ -3065,10 +3296,12 @@
     "skills": [
       {
         "name": "どうも～",
+        "cost": "1 any color",
         "dmg": "20"
       }
     ],
     "extraEffect": "You may include any number of this holomem in the deck.",
+    "batonTouch": 1,
     "setName": "hBP02",
     "searchString": "murasaki shion hbp02-042 #jp #gen2 you may include any number of this holomem in the deck. どうも～ "
   },
@@ -3084,9 +3317,11 @@
     "skills": [
       {
         "name": "一緒に行こう",
+        "cost": "1 Purple",
         "dmg": "30"
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP02",
     "searchString": "murasaki shion hbp02-043 #jp #gen2 魔法見せてあげる: you may roll a die once:if it is 4 or greater, reveal a card with #magic from your deck, and add it to hand. then, shuffle the deck. 一緒に行こう "
   },
@@ -3101,14 +3336,17 @@
     "skills": [
       {
         "name": "照れくさ",
+        "cost": "1 any color",
         "dmg": "30"
       },
       {
         "name": "やだ、もー",
+        "cost": "1 Purple, 1 any color",
         "dmg": "60"
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP02",
     "searchString": "murasaki shion hbp02-044 #jp #gen2 照れくさ  やだ、もー "
   },
@@ -3124,10 +3362,12 @@
     "skills": [
       {
         "name": "最高にハッピーです！！",
+        "cost": "1 any color",
         "dmg": "40"
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP02",
     "searchString": "murasaki shion hbp02-045 #jp #gen2 久しぶりの全体ライブーっ！！: look at the top 3 cards of your deck. reveal 1 [blue holomem or purple holomem] from among them, and add it to hand. then, return the remaining cards to the bottom of the deck in any order. 最高にハッピーです！！ "
   },
@@ -3143,11 +3383,13 @@
     "skills": [
       {
         "name": "チェンジ・ザ・エール",
+        "cost": "2 Purple",
         "dmg": "30",
         "description": "You may roll a die once:If it is 5 or greater, reattach 1 of your opponent's cheers from stage to your opponent's holomem."
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP02",
     "searchString": "murasaki shion hbp02-046 #jp #gen2 れ替えの魔法: you may archive 1 card from your hand:return 1 card with #magic from your archive to hand. チェンジ・ザ・エール you may roll a die once:if it is 5 or greater, reattach 1 of your opponent's cheers from stage to your opponent's holomem."
   },
@@ -3163,6 +3405,7 @@
     "skills": [
       {
         "name": "ヴァイオレットマジック",
+        "cost": "2 Purple, 1 any color",
         "dmg": "80",
         "description": "Deal 20 special damage for each of your opponent's center holomem's cheers to your opponent's center holomem and collab holomem."
       }
@@ -3171,6 +3414,7 @@
     "hasFullArt": true,
     "hasGrandPrix": true,
     "source": "Top 8 WGP2025",
+    "batonTouch": 2,
     "setName": "hBP02",
     "searchString": "murasaki shion hbp02-047 #jp #gen2 いたずらの魔法:you may roll a die once:if it is 4 or greater, reattach 1 cheer from your opponent's stage to your opponent's holomem. ヴァイオレットマジック deal 20 special damage for each of your opponent's center holomem's cheers to your opponent's center holomem and collab holomem."
   },
@@ -3185,10 +3429,12 @@
     "skills": [
       {
         "name": "ゾンばんは！",
+        "cost": "1 any color",
         "dmg": "20"
       }
     ],
     "extraEffect": "You may include any number of this holomem in the deck.",
+    "batonTouch": 1,
     "setName": "hBP02",
     "searchString": "kureiji ollie hbp02-048 #id #idgen2 #language you may include any number of this holomem in the deck. ゾンばんは！ "
   },
@@ -3204,10 +3450,12 @@
     "skills": [
       {
         "name": "おつクレイジー！",
+        "cost": "1 any color",
         "dmg": "20"
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP02",
     "searchString": "kureiji ollie hbp02-049 #id #idgen2 #language オリーがいつも見てるよ: draw 1 card, and archive 1 card from hand. おつクレイジー！ "
   },
@@ -3222,14 +3470,17 @@
     "skills": [
       {
         "name": "君を大好きな後輩",
+        "cost": "1 any color",
         "dmg": "20"
       },
       {
         "name": "きゃ～！先輩ごめ～ん！",
-        "dmg": "20"
+        "cost": "1 Purple, 1 any color",
+        "dmg": "60"
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP02",
     "searchString": "kureiji ollie hbp02-050 #id #idgen2 #language 君を大好きな後輩  きゃ～！先輩ごめ～ん！ "
   },
@@ -3245,10 +3496,12 @@
     "skills": [
       {
         "name": "推しを見て叫びまくるぞ！！",
+        "cost": "1 any color",
         "dmg": "20"
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP02",
     "searchString": "kureiji ollie hbp02-051 #id #idgen2 #language 限界化！！: you may bloom one of your debut holomems with #idgen2 using a holomem from your archive. you may only use the bloom effect 「限界化！！」 once per turn. 推しを見て叫びまくるぞ！！ "
   },
@@ -3264,11 +3517,13 @@
     "skills": [
       {
         "name": "推しを見て叫びまくるぞ！！",
-        "dmg": "20",
+        "cost": "2 any color",
+        "dmg": "40+",
         "description": "If a non-purple cheer is attached to this holomem, this Arts gets +20."
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP02",
     "searchString": "kureiji ollie hbp02-052 #id #idgen2 #language 真実一路: draw a card from your deck. 推しを見て叫びまくるぞ！！ if a non-purple cheer is attached to this holomem, this arts gets +20."
   },
@@ -3284,12 +3539,14 @@
     "skills": [
       {
         "name": "計算された戦術",
+        "cost": "1 Purple, 2 any color",
         "dmg": "100+",
         "description": "If you have 2 or more 2nd holomem with #IDGen2 on your stage, this Arts gets +40."
       }
     ],
     "hasAlternativeArt": true,
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP02",
     "searchString": "kureiji ollie hbp02-053 #id #idgen2 #language 蘇りしゾンビ: you may archive 2 cards from your hand:during this turn, this holomem gets arts+40. 計算された戦術 if you have 2 or more 2nd holomem with #idgen2 on your stage, this arts gets +40."
   },
@@ -3328,10 +3585,12 @@
     "skills": [
       {
         "name": "マイステージ",
+        "cost": "2 Purple",
         "dmg": "20"
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP02",
     "searchString": "mori calliope hbp02-055 #en #myth #singing ショータイム: you may archive 1 holomem from your hand:during this turn, 1 of your holomem with #myth on stage gets arts+20. マイステージ "
   },
@@ -3346,10 +3605,12 @@
     "skills": [
       {
         "name": "Cash-Money",
+        "cost": "1 Purple",
         "dmg": "50"
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP02",
     "searchString": "mori calliope hbp02-056 #en #myth #singing cash-money "
   },
@@ -3365,10 +3626,12 @@
     "skills": [
       {
         "name": "一緒にブチアガろうぜ！",
+        "cost": "1 Purple, 1 any color",
         "dmg": "50"
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP02",
     "searchString": "mori calliope hbp02-057 #en #myth #singing みんなで作る最高のfes :you may archive 2 holomem with the same tag from your hand:draw 2 cards. 一緒にブチアガろうぜ！ "
   },
@@ -3384,11 +3647,13 @@
     "skills": [
       {
         "name": "Dead Beat",
+        "cost": "1 Purple, 1 any color",
         "dmg": "30+",
         "description": "If this holomem has a Tool or a Mascot attached, this Art gains +30 power."
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP02",
     "searchString": "mori calliope hbp02-058 #en #myth #singing what's up?: you may return 1 [〈mori calliope's scythe〉 or 〈death-sensei〉] from your archive to hand. dead beat if this holomem has a tool or a mascot attached, this art gains +30 power."
   },
@@ -3404,12 +3669,14 @@
     "skills": [
       {
         "name": "Featuring Myth",
+        "cost": "2 Purple, 1 any color",
         "dmg": "80+",
         "description": "If you have 4 or more holomem with #Myth in your archive, this Arts gets +40. Then, if you have 8 or more, this Arts gets +40."
       }
     ],
     "hasAlternativeArt": true,
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP02",
     "searchString": "mori calliope hbp02-059 #en #myth #singing soul voice: reveal 1 card from your deck, and archive it. then, shuffle the deck. featuring myth if you have 4 or more holomem with #myth in your archive, this arts gets +40. then, if you have 8 or more, this arts gets +40."
   },
@@ -3425,11 +3692,13 @@
     "skills": [
       {
         "name": "隠しきれない魅力",
+        "cost": "1 Purple, 2 any color",
         "dmg": "80+"
       }
     ],
     "extraEffect": "If this holomem is downed, you get Life-2",
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP02",
     "searchString": "yuzuki choco hbp02-060 #jp #gen2 #cooking 誘惑の視線: you may restore 50 hp to 1 of your back holomem:deal 10 special damage to your opponent's center holomem for every 10 hp restored. if this holomem is downed, you get life-2 隠しきれない魅力 "
   },
@@ -3464,10 +3733,12 @@
     "skills": [
       {
         "name": "君とタコグラム",
+        "cost": "2 Purple",
         "dmg": "60"
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP02",
     "searchString": "ninomae ina'nis hbp02-062 #en #myth #painting #sea 君とタコグラム "
   },
@@ -3483,10 +3754,12 @@
     "skills": [
       {
         "name": "楽しんでいこう！！！",
+        "cost": "1 any color",
         "dmg": "30"
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP02",
     "searchString": "ninomae ina'nis hbp02-063 #en #myth #painting #sea みんな「wah」の準備はいいかー！restore 20 hp to 1 of your holomem with #myth. 楽しんでいこう！！！ "
   },
@@ -3502,6 +3775,7 @@
     "skills": [
       {
         "name": "アルカイックスマイル",
+        "cost": "1 Purple, 1 any color",
         "dmg": "60+",
         "description": "If you have 5 or more holomem with #Myth in your archive, you may reattach 1 cheer from this holomem to your other holomem. Then, if you have 10 or more, this Arts gets +50."
       }
@@ -3509,6 +3783,7 @@
     "extraEffect": "If this holomem is downed, you get Life-2",
     "hasAlternativeArt": true,
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP02",
     "searchString": "ninomae ina'nis hbp02-064 #en #myth #painting #sea if this holomem is downed, you get life-2 アルカイックスマイル if you have 5 or more holomem with #myth in your archive, you may reattach 1 cheer from this holomem to your other holomem. then, if you have 10 or more, this arts gets +50."
   },
@@ -3546,14 +3821,17 @@
     "skills": [
       {
         "name": "良い響きですね",
+        "cost": "1 any color",
         "dmg": "30"
       },
       {
         "name": "アイドルソングというものは",
+        "cost": "1 Purple, 1 any color",
         "dmg": "60"
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP02",
     "searchString": "nerissa ravencroft hbp02-066 #en #advent #singing #bird 良い響きですね  アイドルソングというものは "
   },
@@ -3569,10 +3847,12 @@
     "skills": [
       {
         "name": "コーヒーよりも紅茶です",
+        "cost": "1 any color",
         "dmg": "20"
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP02",
     "searchString": "nerissa ravencroft hbp02-067 #en #advent #singing #bird ネリッサとお茶会: look at the top 3 cards of your deck. reveal 1 holomem with #singing from among them, and add it to hand. then, return the remaining cards to the bottom of the deck in any order. コーヒーよりも紅茶です "
   },
@@ -3588,10 +3868,12 @@
     "skills": [
       {
         "name": "歌に宿りし愛情",
+        "cost": "1 Purple, 2 any color",
         "dmg": "80"
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP02",
     "searchString": "nerissa ravencroft hbp02-068 #en #advent #singing #bird 音の魔人: during this turn, your [center holomem and collab holomem] with #singing get arts+30. 歌に宿りし愛情 "
   },
@@ -3607,11 +3889,13 @@
     "skills": [
       {
         "name": "『巫女』の『ホロ』！",
+        "cost": "1 any color",
         "dmg": 20
       }
     ],
     "extraEffect": "This holomem cannot Bloom.",
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP02",
     "searchString": "magical girl miko hbp02-069 #holowitch #gen0 #magic みんなの願いを咲かせる祈り！: you may roll a die once:if it is odd, reveal 1 [red cheer or blue cheer] from your cheer deck, and send it to your back holomem. then, shuffle the cheer deck. this holomem cannot bloom. 『巫女』の『ホロ』！ "
   },
@@ -3627,11 +3911,13 @@
     "skills": [
       {
         "name": "『天使』の『ホロ』！",
+        "cost": "1 any color",
         "dmg": 20
       }
     ],
     "extraEffect": "This holomem cannot Bloom.",
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP02",
     "searchString": "magical girl kanata hbp02-070 #holowitch #gen4 #magic この手を差し伸べ、つかんで握る！: you may roll a die once:if it is odd, reveal 1 [white cheer or green cheer] from your cheer deck, and send it to your back holomem. then, shuffle the cheer deck. this holomem cannot bloom. 『天使』の『ホロ』！ "
   },
@@ -3647,11 +3933,13 @@
     "skills": [
       {
         "name": "『姫』の『ホロ』！",
+        "cost": "1 any color",
         "dmg": 20
       }
     ],
     "extraEffect": "This holomem cannot Bloom.",
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP02",
     "searchString": "magical girl luna hbp02-071 #holowitch #gen4 #magic 甘～い幸せ、おすそわけ！: you may roll a die once:if it is odd, reveal 1 [purple cheer or yellow cheer] from your cheer deck, and send it to your back holomem. then, shuffle the cheer deck. this holomem cannot bloom. 『姫』の『ホロ』！ "
   },
@@ -3667,11 +3955,13 @@
     "skills": [
       {
         "name": "『魔女』の『ホロ』！",
+        "cost": "1 any color",
         "dmg": 20
       }
     ],
     "extraEffect": "This holomem cannot Bloom.",
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP02",
     "searchString": "magical girl shion hbp02-072 #holowitch #gen2 #magic 眠れる神秘を我が物に！: you may roll a die once:if it is even, reveal 1 event from your deck, and add it to hand. then, shuffle the deck. this holomem cannot bloom. 『魔女』の『ホロ』！ "
   },
@@ -3687,11 +3977,13 @@
     "skills": [
       {
         "name": "『海賊』の『ホロ』！",
+        "cost": "1 any color",
         "dmg": 20
       }
     ],
     "extraEffect": "This holomem cannot Bloom.",
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP02",
     "searchString": "magical girl marine hbp02-073 #holowitch #gen3 #magic きらめくお宝、ロックオン！: you may roll a die once:if it is even, reveal 1 fan from your deck, and add it to hand. then, shuffle the deck. this holomem cannot bloom. 『海賊』の『ホロ』！ "
   },
@@ -3707,11 +3999,13 @@
     "skills": [
       {
         "name": "『シャチ』の『ホロ』！",
+        "cost": "1 any color",
         "dmg": 20
       }
     ],
     "extraEffect": "This holomem cannot Bloom.",
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP02",
     "searchString": "magical girl chloe hbp02-074 #holowitch #holox #magic 荒波をゆく奔放の牙！！:you may roll a die once:if it is even, reveal 1 tool from your deck, and add it to hand. then, shuffle the deck. this holomem cannot bloom. 『シャチ』の『ホロ』！ "
   },
@@ -14774,14 +15068,11 @@
     "hp": 120,
     "color": "White",
     "tag": "#EN #Justice #Kemomimi #Painting",
-    "giftEffect": "ボナペティート -楽しい食事- : ■While this holomem does not have <Chattino> attached, this holomem requires -1 white cheer for its Arts.\n■While this holomem has <Chattino> attached, this holomem gets +30 HP.",
+    "giftEffect": "Buon Appetito -Enjoy Your Meal- ■While this holomem does not have <Chattino> attached, this holomem requires -1 white cheer for its Arts. ■While this holomem has <Chattino> attached, this holomem gets +30 HP.",
     "skills": [
       {
         "name": "この幸せをシェアしよう",
-        "description": "■While this holomem has <Chattino> attached, this holomem gets +30 HP."
-      },
-      {
-        "name": "Let's Share This Happiness",
+        "cost": "1 White",
         "dmg": 10,
         "description": "If this holomem does not have <Chattino> attached, attach 1 <Chattino> from your deck to this holomem. Then, shuffle the deck."
       }
@@ -14789,7 +15080,7 @@
     "hasFoils": true,
     "batonTouch": 1,
     "setName": "hBP08",
-    "searchString": "raora panthera hbp08-019 #en #justice #kemomimi #painting ボナペティート -楽しい食事- : ■while this holomem does not have <chattino> attached, this holomem requires -1 white cheer for its arts.\n■while this holomem has <chattino> attached, this holomem gets +30 hp. この幸せをシェアしよう ■while this holomem has <chattino> attached, this holomem gets +30 hp. let's share this happiness if this holomem does not have <chattino> attached, attach 1 <chattino> from your deck to this holomem. then, shuffle the deck."
+    "searchString": "raora panthera hbp08-019 #en #justice #kemomimi #painting buon appetito -enjoy your meal- ■while this holomem does not have <chattino> attached, this holomem requires -1 white cheer for its arts. ■while this holomem has <chattino> attached, this holomem gets +30 hp. この幸せをシェアしよう if this holomem does not have <chattino> attached, attach 1 <chattino> from your deck to this holomem. then, shuffle the deck."
   },
   {
     "cardNumber": "hBP08-020",
@@ -17642,9 +17933,11 @@
     "skills": [
       {
         "name": "ぬんぬん",
+        "cost": "1 any color",
         "dmg": 30
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD01",
     "searchString": "tokino sora hsd01-003 #jp #gen0 #singing ぬんぬん "
   },
@@ -17660,9 +17953,11 @@
     "skills": [
       {
         "name": "オンステージ!",
+        "cost": "1 any color",
         "dmg": 20
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD01",
     "searchString": "tokino sora hsd01-004 #jp #gen0 #singing レッツダンス!: for the duration of this turn, your center holomen's art gains +20. オンステージ! "
   },
@@ -17677,13 +17972,16 @@
     "skills": [
       {
         "name": "ぬんぬんしよう",
+        "cost": "1 White",
         "dmg": 30
       },
       {
         "name": "あなたの心は･･･くもりのち晴れ!",
+        "cost": "1 White, 1 any color",
         "dmg": 50
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD01",
     "searchString": "tokino sora hsd01-005 #jp #gen0 #singing ぬんぬんしよう  あなたの心は･･･くもりのち晴れ! "
   },
@@ -17699,15 +17997,18 @@
     "skills": [
       {
         "name": "ドリームライブ",
+        "cost": "1 White, 1 any color",
         "dmg": 50
       },
       {
         "name": "SorAZ シンパシー",
+        "cost": "1 White, 1 Green, 1 any color",
         "dmg": "60+",
         "description": "When you have the Holomen 'AZKi' on your stage, this art gains +50."
       }
     ],
     "extraEffect": "If this holomem is downed, you get Life-2.",
+    "batonTouch": 2,
     "setName": "hSD01",
     "searchString": "tokino sora hsd01-006 #jp #gen0 #singing if this holomem is downed, you get life-2. ドリームライブ  soraz シンパシー when you have the holomen 'azki' on your stage, this art gains +50."
   },
@@ -17723,9 +18024,11 @@
     "skills": [
       {
         "name": "希望の化身",
+        "cost": "1 White",
         "dmg": 20
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD01",
     "searchString": "irys hsd01-007 #en #promise #singing hope!: look at your holopower. reveal one card from among them and add it to your hand. then, choose one card from your hand and turn it into holopower. 希望の化身 "
   },
@@ -17740,9 +18043,11 @@
     "skills": [
       {
         "name": "がんばれてえらい!",
+        "cost": "1 any color",
         "dmg": 20
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD01",
     "searchString": "azki hsd01-008 #jp #gen0 #singing がんばれてえらい! "
   },
@@ -17758,9 +18063,11 @@
     "skills": [
       {
         "name": "ほいでほいで",
+        "cost": "1 any color",
         "dmg": 10
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD01",
     "searchString": "azki hsd01-009 #jp #gen0 #singing 広がる地図: you can roll a die once: if the result is 4 or lower, send the top card of your cheer deck to your back holomen. if the result is 1, you may also move this holomen to the back position. ほいでほいで "
   },
@@ -17775,9 +18082,11 @@
     "skills": [
       {
         "name": "きみとあてのない旅",
+        "cost": "1 Green, 1 any color",
         "dmg": 50
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD01",
     "searchString": "azki hsd01-010 #jp #gen0 #singing きみとあてのない旅 "
   },
@@ -17792,15 +18101,18 @@
     "skills": [
       {
         "name": "SorAZ グラビティ",
+        "cost": "1 Green",
         "dmg": 60,
         "description": "When the Holomen 'Tokino Sora' is on your stage, send the top card of your cheer deck to one of your Holomen."
       },
       {
         "name": "デスティニーソング",
+        "cost": "2 Green, 1 any color",
         "dmg": "100+",
         "description": "You can roll a die once: If the result is odd, this art gains +50. If the result is 1, this art gains an additional +50."
       }
     ],
+    "batonTouch": 2,
     "setName": "hSD01",
     "searchString": "azki hsd01-011 #jp #gen0 #singing soraz グラビティ when the holomen 'tokino sora' is on your stage, send the top card of your cheer deck to one of your holomen. デスティニーソング you can roll a die once: if the result is odd, this art gains +50. if the result is 1, this art gains an additional +50."
   },
@@ -17816,9 +18128,11 @@
     "skills": [
       {
         "name": "お絵かきたのしー!",
+        "cost": "1 Green",
         "dmg": 20
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD01",
     "searchString": "airani iofifteen hsd01-012 #id #idgen1 #painting 一緒にお絵かき!: you may send one white or green cheer card from your archive to your center holomen. お絵かきたのしー! "
   },
@@ -17833,11 +18147,13 @@
     "skills": [
       {
         "name": "越えたい未来",
+        "cost": "2 any color",
         "dmg": 50,
         "description": "You may roll a die once: If the result is odd, send the top card of your cheer deck to this Holomen. If the result is even, draw one card from your deck."
       }
     ],
     "extraEffect": "This Holomen is also treated as 'Tokino Sora' and 'AZKi'",
+    "batonTouch": 1,
     "setName": "hSD01",
     "searchString": "soraz hsd01-013 #jp #gen0 #singing this holomen is also treated as 'tokino sora' and 'azki' 越えたい未来 you may roll a die once: if the result is odd, send the top card of your cheer deck to this holomen. if the result is even, draw one card from your deck."
   },
@@ -17852,10 +18168,12 @@
     "skills": [
       {
         "name": "へい",
+        "cost": "1 White, 1 Green",
         "dmg": 30
       }
     ],
     "extraEffect": "This holomem cannot Bloom.",
+    "batonTouch": 1,
     "setName": "hSD01",
     "searchString": "amane kanata hsd01-014 #jp #gen4 #singing this holomem cannot bloom. へい "
   },
@@ -17871,10 +18189,12 @@
     "skills": [
       {
         "name": "ピュアピュアピュア~",
+        "cost": "1 any color",
         "dmg": 10
       }
     ],
     "extraEffect": "This holomem cannot Bloom.",
+    "batonTouch": 1,
     "setName": "hSD01",
     "searchString": "hakui koyori hsd01-015 #jp #holox #kemomimi soazko: when collaborating with 'tokino sora,' draw one card from your deck. when collaborating with 'azki,' send the top card of your cheer deck to your center holomen this holomem cannot bloom. ピュアピュアピュア~ "
   },
@@ -17990,9 +18310,11 @@
     "skills": [
       {
         "name": "Shiranui",
+        "cost": "1 any color",
         "dmg": 30
       }
     ],
+    "batonTouch": 0,
     "setName": "hSD02",
     "searchString": "nakiri ayame hsd02-003 #jp #gen2 #shooter karma : deal 10 special damage to your opponent's collab holomem. shiranui "
   },
@@ -18008,9 +18330,11 @@
     "skills": [
       {
         "name": "Delicious dangos",
+        "cost": "1 Red",
         "dmg": 30
       }
     ],
+    "batonTouch": 0,
     "setName": "hSD02",
     "searchString": "nakiri ayame hsd02-004 #jp #gen2 #shooter ayame's first anniversary : if this holomem has a poyoyo attached, your center holomem's arts gain +20 power this turn. delicious dangos "
   },
@@ -18025,13 +18349,16 @@
     "skills": [
       {
         "name": "Sleepy yo~",
+        "cost": "1 any color",
         "dmg": 20
       },
       {
         "name": "Otsunakiri",
+        "cost": "1 Red, 1 any color",
         "dmg": 60
       }
     ],
+    "batonTouch": 0,
     "setName": "hSD02",
     "searchString": "nakiri ayame hsd02-005 #jp #gen2 #shooter sleepy yo~  otsunakiri "
   },
@@ -18047,9 +18374,11 @@
     "skills": [
       {
         "name": "一緒にお祝い",
+        "cost": "1 Red",
         "dmg": 30
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD02",
     "searchString": "nakiri ayame hsd02-006 #jp #gen2 #shooter you may archive 1 card from your hand for the following effect: deal 20 special damage to your opponent's center or collab holomem. 一緒にお祝い "
   },
@@ -18065,9 +18394,11 @@
     "skills": [
       {
         "name": "輝いた余を見逃さないでね～～！！",
+        "cost": "1 any color",
         "dmg": 30
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD02",
     "searchString": "nakiri ayame hsd02-007 #jp #gen2 #shooter when this blooms from a debut holomem, look at the top 2 cards of your deck, reveal 1 and put it into your hand and archive the other.. 輝いた余を見逃さないでね～～！！ "
   },
@@ -18083,15 +18414,18 @@
     "skills": [
       {
         "name": "ファンシーバースデー",
+        "cost": "1 Red, 1 any color",
         "dmg": 40
       },
       {
         "name": "プレゼント何かな？",
+        "cost": "2 Red, 1 any color",
         "dmg": 50,
         "description": "You may Archive one card from your hand for the following effect: deal 50 special damage to your opponent's Center or Collab holomem."
       }
     ],
     "extraEffect": "If this holomem is downed, you get Life-2.",
+    "batonTouch": 1,
     "setName": "hSD02",
     "searchString": "nakiri ayame hsd02-008 #jp #gen2 #shooter if this holomem is downed, you get life-2. ファンシーバースデー  プレゼント何かな？ you may archive one card from your hand for the following effect: deal 50 special damage to your opponent's center or collab holomem."
   },
@@ -18106,16 +18440,19 @@
     "skills": [
       {
         "name": "あやふぶみの「あや」担当",
+        "cost": "1 Red",
         "dmg": 60
       },
       {
         "name": "余ーだ余",
+        "cost": "2 Red, 1 any color",
         "dmg": 40,
         "description": "You may Archive 1-3 cards from your hand for the following effect: deal 40 special damage for each card Archived to your opponent's Center holomem."
       }
     ],
     "imageSet": "hBP02",
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hSD02",
     "searchString": "nakiri ayame hsd02-009 #jp #gen2 #shooter あやふぶみの「あや」担当  余ーだ余 you may archive 1-3 cards from your hand for the following effect: deal 40 special damage for each card archived to your opponent's center holomem."
   },
@@ -18131,10 +18468,12 @@
     "skills": [
       {
         "name": "あやふぶみの「ふぶ」担当",
+        "cost": "1 any color",
         "dmg": 20
       }
     ],
     "extraEffect": "This holomem cannot Bloom.",
+    "batonTouch": 1,
     "setName": "hSD02",
     "searchString": "shirakami fubuki hsd02-010 #jp #gen1 #gamers #kemomimi #painting you may return 1 mascot from your archive to your hand. this holomem cannot bloom. あやふぶみの「ふぶ」担当 "
   },
@@ -18150,10 +18489,12 @@
     "skills": [
       {
         "name": "あやふぶみの「み」担当",
+        "cost": "1 any color",
         "dmg": 10
       }
     ],
     "extraEffect": "This holomem cannot Bloom.",
+    "batonTouch": 1,
     "setName": "hSD02",
     "searchString": "ookami mio hsd02-011 #jp #gamers #kemomimi #cooking you may archive 1 holomem from your hand for the following effect: send the top card of your cheer deck to one of your debut holomems. this holomem cannot bloom. あやふぶみの「み」担当 "
   },
@@ -18236,9 +18577,11 @@
     "skills": [
       {
         "name": "僕をお家に入れてください",
+        "cost": "1 Blue",
         "dmg": 10
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD03",
     "searchString": "nekomata okayu hsd03-003 #jp #gamers #kemomimi if your center holomem has #gamers, deal 10 special damage to your opponent's center holomem and one of their back holomems. holomems downed with this effect do not reduce life. 僕をお家に入れてください "
   },
@@ -18254,9 +18597,11 @@
     "skills": [
       {
         "name": "学生猫",
+        "cost": "1 any color",
         "dmg": 20
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD03",
     "searchString": "nekomata okayu hsd03-004 #jp #gamers #kemomimi you may reveal one card from the top of your deck. if that card is a debut or spot holomem, send the top card of your cheer deck to this holomem. then put that card on the bottom of your deck. 学生猫 "
   },
@@ -18271,13 +18616,16 @@
     "skills": [
       {
         "name": "ぎゅ～ってしてよね♡",
+        "cost": "1 any color",
         "dmg": 30
       },
       {
         "name": "えへへないたずら",
+        "cost": "1 Blue, 1 any color",
         "dmg": 50
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD03",
     "searchString": "nekomata okayu hsd03-005 #jp #gamers #kemomimi ぎゅ～ってしてよね♡  えへへないたずら "
   },
@@ -18292,14 +18640,17 @@
     "skills": [
       {
         "name": "猫かぶり",
+        "cost": "1 Blue",
         "dmg": 30
       },
       {
         "name": "しゃー",
+        "cost": "1 Blue, 1 any color",
         "dmg": 40,
         "description": "You may Archive 1 Blue Cheer from this holomem for the following effect: deal 10 special damage to your opponent's Center holomem and one of their Back holomems."
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD03",
     "searchString": "nekomata okayu hsd03-006 #jp #gamers #kemomimi 猫かぶり  しゃー you may archive 1 blue cheer from this holomem for the following effect: deal 10 special damage to your opponent's center holomem and one of their back holomems."
   },
@@ -18315,9 +18666,11 @@
     "skills": [
       {
         "name": "全力で僕なりの歌、お届けします！",
+        "cost": "1 any color",
         "dmg": 20
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD03",
     "searchString": "nekomata okayu hsd03-007 #jp #gamers #kemomimi send a cheer from your archive to one of your holomems with #gamers. 全力で僕なりの歌、お届けします！ "
   },
@@ -18334,10 +18687,12 @@
     "skills": [
       {
         "name": "いちばんえらい猫又おかゆ～",
+        "cost": "1 Blue, 1 any color",
         "dmg": 60
       }
     ],
     "extraEffect": "If this holomem is downed, you get Life-2.",
+    "batonTouch": 2,
     "setName": "hSD03",
     "searchString": "nekomata okayu hsd03-008 #jp #gamers #kemomimi (center position only) your takane lui, ookami mio, shirakami fubuki, la+ darknesss, and inugami korone's arts gain +20 power. if this holomem is downed, you get life-2. いちばんえらい猫又おかゆ～ "
   },
@@ -18352,16 +18707,19 @@
     "skills": [
       {
         "name": "MOGMOG",
+        "cost": "1 Blue, 1 any color",
         "dmg": 60
       },
       {
         "name": "おかゆ～",
+        "cost": "2 Blue, 2 any color",
         "dmg": 100,
         "description": "You may Archive 2 Blue Cheers from this holomem for the following effect: deal 30 special damage to your opponent's Center holomem and one of their Back holomems."
       }
     ],
     "imageSet": "hBP02",
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hSD03",
     "searchString": "nekomata okayu hsd03-009 #jp #gamers #kemomimi mogmog  おかゆ～ you may archive 2 blue cheers from this holomem for the following effect: deal 30 special damage to your opponent's center holomem and one of their back holomems."
   },
@@ -18377,10 +18735,12 @@
     "skills": [
       {
         "name": "おらよ～",
+        "cost": "1 any color",
         "dmg": 30
       }
     ],
     "extraEffect": "This holomem cannot Bloom.",
+    "batonTouch": 1,
     "setName": "hSD03",
     "searchString": "inugami korone hsd03-010 #jp #gamers #kemomimi if your center holomem is nekomata okayu, reveal 1 fan or mascot from your deck and put it into your hand. then shuffle your deck. this holomem cannot bloom. おらよ～ "
   },
@@ -18395,15 +18755,18 @@
     "skills": [
       {
         "name": "泥棒建設農業大臣",
+        "cost": "1 any color",
         "dmg": 10
       },
       {
         "name": "絶対、食わせてみせるわ",
+        "cost": "2 any color",
         "dmg": 20,
         "description": "If you have 2 or less cards in your hand, draw from your Deck until you have 3 cards in your hand."
       }
     ],
     "extraEffect": "This holomem cannot Bloom.",
+    "batonTouch": 1,
     "setName": "hSD03",
     "searchString": "la+ darknesss hsd03-011 #jp #holox #shooter this holomem cannot bloom. 泥棒建設農業大臣  絶対、食わせてみせるわ if you have 2 or less cards in your hand, draw from your deck until you have 3 cards in your hand."
   },
@@ -18486,9 +18849,11 @@
     "skills": [
       {
         "name": "マイキュ～トスチュ～デ～ンツ",
+        "cost": "1 Purple, 1 any color",
         "dmg": 30
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD04",
     "searchString": "yuzuki choco hsd04-003 #jp #gen2 #cooking if your oshi holomem is purple, draw 1 card from your deck. マイキュ～トスチュ～デ～ンツ "
   },
@@ -18504,9 +18869,11 @@
     "skills": [
       {
         "name": "いっぱい食べてね♡",
+        "cost": "1 Purple",
         "dmg": 20
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD04",
     "searchString": "yuzuki choco hsd04-004 #jp #gen2 #cooking you may archive 1 card from your hand for the following effect: reveal an event with #food from your deck and put it into your hand. then shuffle your deck. いっぱい食べてね♡ "
   },
@@ -18521,13 +18888,16 @@
     "skills": [
       {
         "name": "おつかれいと……",
+        "cost": "1 Purple",
         "dmg": 20
       },
       {
         "name": "あ～む（ﾁｭｯ）",
+        "cost": "1 Purple, 1 any color",
         "dmg": 40
       }
     ],
+    "batonTouch": 0,
     "setName": "hSD04",
     "searchString": "yuzuki choco hsd04-005 #jp #gen2 #cooking おつかれいと……  あ～む（ﾁｭｯ） "
   },
@@ -18542,9 +18912,11 @@
     "skills": [
       {
         "name": "禁断のキッス",
+        "cost": "1 Purple, 1 any color",
         "dmg": 30
       }
     ],
+    "batonTouch": 0,
     "setName": "hSD04",
     "searchString": "yuzuki choco hsd04-006 #jp #gen2 #cooking 禁断のキッス "
   },
@@ -18560,10 +18932,12 @@
     "skills": [
       {
         "name": "大好き！ちゅっ♡",
+        "cost": "2 any color",
         "dmg": 30,
         "description": "Restore 20HP to one of your Back holomems."
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD04",
     "searchString": "yuzuki choco hsd04-007 #jp #gen2 #cooking you may return a non-limited event card from your archive to your hand. 大好き！ちゅっ♡ restore 20hp to one of your back holomems."
   },
@@ -18579,15 +18953,18 @@
     "skills": [
       {
         "name": "がんばってつくったよ",
+        "cost": "1 Purple, 1 any color",
         "dmg": 40
       },
       {
         "name": "召し上がれ",
+        "cost": "2 Purple, 1 any color",
         "dmg": "60+",
         "description": "You may return one Event with #Food from your Archive to your hand: if you do, this Art gains +20 power."
       }
     ],
     "extraEffect": "If this holomem is downed, you get Life-2.",
+    "batonTouch": 1,
     "setName": "hSD04",
     "searchString": "yuzuki choco hsd04-008 #jp #gen2 #cooking if this holomem is downed, you get life-2. がんばってつくったよ  召し上がれ you may return one event with #food from your archive to your hand: if you do, this art gains +20 power."
   },
@@ -18602,16 +18979,19 @@
     "skills": [
       {
         "name": "33… 22… 11…",
+        "cost": "1 Purple, 1 any color",
         "dmg": 50
       },
       {
         "name": "あくとっ",
+        "cost": "2 Purple, 1 any color",
         "dmg": 60,
         "description": "For each Event card you've played during this turn, this Art gains +40 power."
       }
     ],
     "imageSet": "hBP02",
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hSD04",
     "searchString": "yuzuki choco hsd04-009 #jp #gen2 #cooking 33… 22… 11…  あくとっ for each event card you've played during this turn, this art gains +40 power."
   },
@@ -18627,10 +19007,12 @@
     "skills": [
       {
         "name": "地獄くじ引き、引かせるぞっ",
+        "cost": "2 any color",
         "dmg": 20
       }
     ],
     "extraEffect": "This holomem cannot Bloom.",
+    "batonTouch": 1,
     "setName": "hSD04",
     "searchString": "oozora subaru hsd04-010 #jp #gen2 if your center holomem is yuzuki choco, you may send one cheer from your archive to any of your holomems. this holomem cannot bloom. 地獄くじ引き、引かせるぞっ "
   },
@@ -18646,10 +19028,12 @@
     "skills": [
       {
         "name": "んな～～～～～～～～",
+        "cost": "1 any color",
         "dmg": 10
       }
     ],
     "extraEffect": "This holomem cannot Bloom.",
+    "batonTouch": 1,
     "setName": "hSD04",
     "searchString": "himemori luna hsd04-011 #jp #gen4  look at your holo power cards, reveal one, and put it into your hand. then put a card from your hand into your holo power. this holomem cannot bloom. んな～～～～～～～～ "
   },
@@ -18711,10 +19095,12 @@
     "skills": [
       {
         "name": "ぶんぶんぶーん！",
+        "cost": "1 any color",
         "dmg": 30
       }
     ],
     "extraEffect": "You may include any number of this holomem in the deck.",
+    "batonTouch": 1,
     "setName": "hSD05",
     "searchString": "todoroki hajime hsd05-002 #dev_is #regloss #baby you may include any number of this holomem in the deck. ぶんぶんぶーん！ "
   },
@@ -18730,9 +19116,11 @@
     "skills": [
       {
         "name": "お洒落番長",
+        "cost": "1 any color",
         "dmg": 30
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD05",
     "searchString": "todoroki hajime hsd05-003 #dev_is #regloss #baby こんちくわ: during this turn, your center holomem with #regloss gains +10 arts. お洒落番長 "
   },
@@ -18747,9 +19135,11 @@
     "skills": [
       {
         "name": "ReGLOSSの番長",
+        "cost": "1 White, 1 any color",
         "dmg": 40
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD05",
     "searchString": "todoroki hajime hsd05-004 #dev_is #regloss #baby reglossの番長 "
   },
@@ -18764,13 +19154,16 @@
     "skills": [
       {
         "name": "夜路紫駆！",
+        "cost": "1 White",
         "dmg": 40
       },
       {
         "name": "うぃー！",
+        "cost": "2 any color",
         "dmg": 60
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD05",
     "searchString": "todoroki hajime hsd05-005 #dev_is #regloss #baby 夜路紫駆！  うぃー！ "
   },
@@ -18785,14 +19178,17 @@
     "skills": [
       {
         "name": "足取り軽め、轟はじめ",
+        "cost": "1 any color",
         "dmg": 30
       },
       {
         "name": "ありあとりゃあすっ",
+        "cost": "1 White, 1 any color",
         "dmg": "50+",
         "description": "If you have 3 or more Holomems with different card names with #ReGLOSS on your stage, this arts gains +20."
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD05",
     "searchString": "todoroki hajime hsd05-006 #dev_is #regloss #baby 足取り軽め、轟はじめ  ありあとりゃあすっ if you have 3 or more holomems with different card names with #regloss on your stage, this arts gains +20."
   },
@@ -18808,9 +19204,11 @@
     "skills": [
       {
         "name": "度胸、愛嬌、最強",
+        "cost": "1 any color",
         "dmg": 20
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD05",
     "searchString": "todoroki hajime hsd05-007 #dev_is #regloss #baby 宇宙一の番長を目指すなんでも屋 : draw 1 card from your deck. 度胸、愛嬌、最強 "
   },
@@ -18826,11 +19224,13 @@
     "skills": [
       {
         "name": "……なんか、番長っぽくなってきたかも！",
+        "cost": "2 White",
         "dmg": 50,
         "description": "During this turn, the arts of one Debut Holomem with #ReGLOSS on your stage gains +40."
       }
     ],
     "extraEffect": "If this holomem is downed, you get Life-2.",
+    "batonTouch": 2,
     "setName": "hSD05",
     "searchString": "todoroki hajime hsd05-008 #dev_is #regloss #baby if this holomem is downed, you get life-2. ……なんか、番長っぽくなってきたかも！ during this turn, the arts of one debut holomem with #regloss on your stage gains +40."
   },
@@ -18868,10 +19268,12 @@
     "skills": [
       {
         "name": "ちょいと一席",
+        "cost": "1 any color",
         "dmg": 20,
         "description": "You may send 1 Cheer from your Archive to your Holomem with #ReGLOSS."
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD05",
     "searchString": "juufuutei raden hsd05-010 #dev_is #regloss #alcohol ちょいと一席 you may send 1 cheer from your archive to your holomem with #regloss."
   },
@@ -18886,9 +19288,11 @@
     "skills": [
       {
         "name": "任せておきなさい！",
+        "cost": "1 any color",
         "dmg": 20
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD05",
     "searchString": "ichijou ririka hsd05-011 #dev_is #regloss #cooking 任せておきなさい！ "
   },
@@ -18904,9 +19308,11 @@
     "skills": [
       {
         "name": "世界一かわいいよ",
+        "cost": "1 any color",
         "dmg": 20
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD05",
     "searchString": "hiodoshi ao hsd05-012 #dev_is #regloss #painting ドーンッ！: deal 10 special damage to your opponent's center holomem or one of their back holomems. 世界一かわいいよ "
   },
@@ -18922,9 +19328,11 @@
     "skills": [
       {
         "name": "任せておきなさい！",
+        "cost": "1 any color",
         "dmg": 20
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD05",
     "searchString": "otonose kanade hsd05-013 #dev_is #regloss #singing クレッシェンドな日々　:you may move 1 cheer on your stage to one of your holomems other than this holomem. 任せておきなさい！ "
   },
@@ -18968,9 +19376,11 @@
     "skills": [
       {
         "name": "いえす！ｼﾞｬｷﾝｼﾞｬｷﾝ！！",
+        "cost": "1 any color",
         "dmg": 20
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD06",
     "searchString": "kazama iroha hsd06-002 #jp #holox のっと！ﾆﾝﾆﾝ！！ restore 10hp to one of your holomems. いえす！ｼﾞｬｷﾝｼﾞｬｷﾝ！！ "
   },
@@ -18985,10 +19395,12 @@
     "skills": [
       {
         "name": "一刀両断叩き斬る",
+        "cost": "1 Green",
         "dmg": "30+",
         "description": "If your Center holomem is damaged, this Art gains +10 power."
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD06",
     "searchString": "kazama iroha hsd06-003 #jp #holox 一刀両断叩き斬る if your center holomem is damaged, this art gains +10 power."
   },
@@ -19003,9 +19415,11 @@
     "skills": [
       {
         "name": "照れ屋な用心棒",
+        "cost": "1 Green, 1 any color",
         "dmg": 60
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD06",
     "searchString": "kazama iroha hsd06-004 #jp #holox 照れ屋な用心棒 "
   },
@@ -19021,9 +19435,11 @@
     "skills": [
       {
         "name": "かざまといっしょ！",
+        "cost": "1 Green",
         "dmg": 30
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD06",
     "searchString": "kazama iroha hsd06-005 #jp #holox かざまとおでかけ : send the top card of your cheer deck to your holomem with $holox かざまといっしょ！ "
   },
@@ -19040,10 +19456,12 @@
     "skills": [
       {
         "name": "刀の錆になるでござる！",
+        "cost": "1 Green, 1 any color",
         "dmg": 50
       }
     ],
     "extraEffect": "If this holomem is downed, you get Life-2.",
+    "batonTouch": 2,
     "setName": "hSD06",
     "searchString": "kazama iroha hsd06-006 #jp #holox サムライ少女　: reveal 1 <chakimaru> or <pokobe> from your deck and put it into your hand. then shuffle your deck. if this holomem is downed, you get life-2. 刀の錆になるでござる！ "
   },
@@ -19082,9 +19500,11 @@
     "skills": [
       {
         "name": "どやぁ",
+        "cost": "1 any color",
         "dmg": 10
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD06",
     "searchString": "hakui koyori hsd06-008 #jp #holox #kemomimi ずのー！　: if your center holomem has $holox and you have 5 or fewer cards in your hand, draw 1 card from your deck. どやぁ "
   },
@@ -19099,10 +19519,12 @@
     "skills": [
       {
         "name": "頼れる女幹部",
+        "cost": "1 any color",
         "dmg": 20,
         "description": "You may return 1 Debut holomem with $HoloX from your Archive to your hand."
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD06",
     "searchString": "takane lui hsd06-009 #jp #holox #bird #alcohol 頼れる女幹部 you may return 1 debut holomem with $holox from your archive to your hand."
   },
@@ -19118,10 +19540,12 @@
     "skills": [
       {
         "name": "世界一かわいいよ",
-        "dmg": 20,
+        "cost": "1 any color",
+        "dmg": "30+",
         "description": "[Collab position only] If you have used your SP Oshi Skill during this turn's Main Step, this Art gains +50 power."
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD06",
     "searchString": "la+ darknesss hsd06-010 #jp #holox #shooter ドーンッ！: deal 10 special damage to your opponent's center holomem or one of their back holomems. 世界一かわいいよ [collab position only] if you have used your sp oshi skill during this turn's main step, this art gains +50 power."
   },
@@ -19201,9 +19625,11 @@
     "skills": [
       {
         "name": "キミといっしょにお出かけ",
+        "cost": "1 Yellow",
         "dmg": 20
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD07",
     "searchString": "shiranui flare hsd07-003 #jp #gen3 #half-elf 大切な仲間たちと: if there are 5 or fewer holomems on your stage, you may reveal a debut <omaru polka>, <sakura miko>, <hoshimachi suisei>, or <shirogane noel> from your deck and put it onto your stage. then shuffle your deck. キミといっしょにお出かけ "
   },
@@ -19218,10 +19644,12 @@
     "skills": [
       {
         "name": "ワンダフルライフ",
+        "cost": "1 Yellow",
         "dmg": "30+",
         "description": "If you have fewer cards in hand than your opponent, this Art gains +10 power."
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD07",
     "searchString": "shiranui flare hsd07-004 #jp #gen3 #half-elf ワンダフルライフ if you have fewer cards in hand than your opponent, this art gains +10 power."
   },
@@ -19236,13 +19664,16 @@
     "skills": [
       {
         "name": "私からキミへ",
+        "cost": "1 Yellow",
         "dmg": 30
       },
       {
         "name": "キミとティータイム",
+        "cost": "1 Yellow, 1 any color",
         "dmg": 50
       }
     ],
+    "batonTouch": 2,
     "setName": "hSD07",
     "searchString": "shiranui flare hsd07-005 #jp #gen3 #half-elf 私からキミへ  キミとティータイム "
   },
@@ -19258,17 +19689,14 @@
     "skills": [
       {
         "name": "キミを1番好きなのはわたしぃ～♡",
+        "cost": "1 any color",
         "dmg": "30+",
         "description": "If you have 3 or less LIFE, this Art gains +30 power."
-      },
-      {
-        "name": "ありあとりゃあすっ",
-        "dmg": "50+",
-        "description": "If you have 3 or more Holomems with different card names with #ReGLOSS on your stage, this arts gains +20."
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD07",
-    "searchString": "shiranui flare hsd07-006 #jp #gen3 #half-elf エルフレンドのさえずり: reveal 1 <elfriend> from your deck and put it into your hand. then shuffle your deck. キミを1番好きなのはわたしぃ～♡ if you have 3 or less life, this art gains +30 power. ありあとりゃあすっ if you have 3 or more holomems with different card names with #regloss on your stage, this arts gains +20."
+    "searchString": "shiranui flare hsd07-006 #jp #gen3 #half-elf エルフレンドのさえずり: reveal 1 <elfriend> from your deck and put it into your hand. then shuffle your deck. キミを1番好きなのはわたしぃ～♡ if you have 3 or less life, this art gains +30 power."
   },
   {
     "cardNumber": "hSD07-007",
@@ -19304,11 +19732,13 @@
     "skills": [
       {
         "name": "エルフレパーティー",
+        "cost": "1 Yellow, 1 any color",
         "dmg": 50,
         "description": "You may attach 1 Elfriend from your Archive to this holomem."
       }
     ],
     "extraEffect": "If this holomem is downed, you get Life-2.",
+    "batonTouch": 2,
     "setName": "hSD07",
     "searchString": "shiranui flare hsd07-008 #jp #gen3 #half-elf if this holomem is downed, you get life-2. エルフレパーティー you may attach 1 elfriend from your archive to this holomem."
   },
@@ -19347,9 +19777,11 @@
     "skills": [
       {
         "name": "いっぱい建築したいです",
+        "cost": "1 any color",
         "dmg": 20
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD07",
     "searchString": "shirogane noel hsd07-010 #jp #gen3 #alcohol 大物の確証: your center holomem's arts gain +10 power until the end of this turn. いっぱい建築したいです "
   },
@@ -19365,9 +19797,11 @@
     "skills": [
       {
         "name": "魔王軍は無くなりました",
+        "cost": "1 any color",
         "dmg": 20
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD07",
     "searchString": "sakura miko hsd07-011 #jp #gen0 #baby バーニン♪ バーニン♪: deal 10 special damage to your opponent's center holomem. 魔王軍は無くなりました "
   },
@@ -19383,9 +19817,11 @@
     "skills": [
       {
         "name": "骨を埋める覚悟　",
+        "cost": "1 any color",
         "dmg": 20
       }
     ],
+    "batonTouch": 0,
     "setName": "hSD07",
     "searchString": "omaru polka hsd07-012 #jp #gen5 #kemomimi 僕らに水を: if your center holomem is shiranui flare and you have fewer cards in hand than your opponent, draw 1 card from your deck. 骨を埋める覚悟　 "
   },
@@ -19401,9 +19837,11 @@
     "skills": [
       {
         "name": "任せて雇ってください‼",
+        "cost": "1 any color",
         "dmg": 20
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD07",
     "searchString": "hoshimachi suisei hsd07-013 #dev_is #regloss #singing 飯が底をつきそう……:if your center holomem is shiranui flare, you may send 1 cheer from your archive to any of your holomems other than this one. 任せて雇ってください‼ "
   },
@@ -19457,9 +19895,11 @@
     "skills": [
       {
         "name": "浴衣似合うでしょ",
+        "cost": "1 any color",
         "dmg": "20"
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD08",
     "searchString": "amane kanata hsd08-002 #jp #gen4 #singing #summer ホロサマー: look at the top 5 cards of your deck. reveal 1 debut holomem with #summer from among them, and add the revealed card to hand. then, return the remaining cards to the bottom of the deck in any order. 浴衣似合うでしょ "
   },
@@ -19475,10 +19915,12 @@
     "skills": [
       {
         "name": "みんなのスパダリ",
+        "cost": "1 White, 2 any color",
         "dmg": "100+, +50 vs green",
         "description": "This Arts gets +10 for each of your holomem with #Summer."
       }
     ],
+    "batonTouch": 2,
     "setName": "hSD08",
     "searchString": "amane kanata hsd08-003 #jp #gen4 #singing 相談のるよ: reveal 1 debut holomem with #gen4 from your deck, and add it to hand. then, shuffle the deck. みんなのスパダリ this arts gets +10 for each of your holomem with #summer."
   },
@@ -19494,10 +19936,12 @@
     "skills": [
       {
         "name": "きみの背中に追いつけるように",
+        "cost": "2 White, 1 any color",
         "dmg": "120, +50 vs red",
         "description": "[Once per turn] If your opponent's center holomem is downed by this Arts, deal 40 Special Damage to 1 of your opponent's 2nd holomem."
       }
     ],
+    "batonTouch": 2,
     "setName": "hSD08",
     "searchString": "amane kanata hsd08-004 #jp #gen4 #singing エンジェルウィンド : [center position only] your collab debut holomem with #gen4 gets arts+40. きみの背中に追いつけるように [once per turn] if your opponent's center holomem is downed by this arts, deal 40 special damage to 1 of your opponent's 2nd holomem."
   },
@@ -19513,9 +19957,11 @@
     "skills": [
       {
         "name": "お祭りなのら",
+        "cost": "1 any color",
         "dmg": "30"
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD08",
     "searchString": "himemori luna hsd08-005 #jp #gen4 #baby #summer なんでも入る巾着: [collab position only]if your holomem is downed during your opponent's turn, if you have equal or less life than your opponent, your may return 1 item with \"pc\" in its name from your archive to hand. お祭りなのら "
   },
@@ -19531,9 +19977,11 @@
     "skills": [
       {
         "name": "トワに見惚れちゃった？",
+        "cost": "1 any color",
         "dmg": "20"
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD08",
     "searchString": "tokoyami towa hsd08-006 #jp #gen4 #singing #shooter #summer 花火見ていく？: deal 10 special damage to your opponent's center holomem. if you are going second and this is your first turn, deal 20 special damage instead. トワに見惚れちゃった？ "
   },
@@ -19549,9 +19997,11 @@
     "skills": [
       {
         "name": "わたあめおいしいねぇ",
+        "cost": "1 any color",
         "dmg": "10"
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD08",
     "searchString": "tsunomaki watame hsd08-007 #jp #gen4 #animalears #singing #summer みんなと夏祭り: you may send 1 cheer from your archive to your 2nd holomem with #gen4. わたあめおいしいねぇ "
   },
@@ -19586,9 +20036,11 @@
     "skills": [
       {
         "name": "船長も一緒にい・か・が？",
+        "cost": "1 any color",
         "dmg": "20"
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD09",
     "searchString": "houshou marine hsd09-002 #jp #gen3 #painting #sea #summer ホロサマー: look at the top 5 cards of your deck. reveal 1 debut holomem with #summer from among them, and add the revealed card to hand. then, return the remaining cards to the bottom of the deck in any order. 船長も一緒にい・か・が？ "
   },
@@ -19605,9 +20057,11 @@
     "skills": [
       {
         "name": "マリンに任せろってマジで",
+        "cost": "1 Red, 1 any color",
         "dmg": "50"
       }
     ],
+    "batonTouch": 2,
     "setName": "hSD09",
     "searchString": "houshou marine hsd09-003 #jp #gen3 #painting #sea みんな優勝するぞ: deal 10 special damage for each differently-named holomem with #gen3 on your stage to your opponent's center holomem. マリンに任せろってマジで "
   },
@@ -19622,15 +20076,18 @@
     "skills": [
       {
         "name": "3期生の絆",
+        "cost": "1 Red",
         "dmg": "60, +50 vs Yellow",
         "description": "If your stage has a holomem with #Gen3 other than <Houshou Marine>, draw 1 card from your deck."
       },
       {
         "name": "キミたちと水平線の向こう側へ",
+        "cost": "2 Red, 1 any color",
         "dmg": "120, +50 vs yellow",
         "description": "Deal 10 Special Damage for each differently-named holomem with #Gen3 on your stage to your opponent's center holomem and collab holomem."
       }
     ],
+    "batonTouch": 2,
     "setName": "hSD09",
     "searchString": "houshou marine hsd09-004 #jp #gen3 #painting #sea 3期生の絆 if your stage has a holomem with #gen3 other than <houshou marine>, draw 1 card from your deck. キミたちと水平線の向こう側へ deal 10 special damage for each differently-named holomem with #gen3 on your stage to your opponent's center holomem and collab holomem."
   },
@@ -19646,9 +20103,11 @@
     "skills": [
       {
         "name": "夏が来たぞー！",
+        "cost": "1 any color",
         "dmg": "20"
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD09",
     "searchString": "shirogane noel hsd09-005 #jp #gen3 #alcohol #summer 3期生の海の家: your center 2nd holomem gets arts+10 for each of your differently-named holomem with #gen3. 夏が来たぞー！ "
   },
@@ -19664,9 +20123,11 @@
     "skills": [
       {
         "name": "◇ご注文のかき氷ぺこ！",
+        "cost": "1 any color",
         "dmg": "10"
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD09",
     "searchString": "usada pekora hsd09-006 #jp #gen3 #kemomimi #summer あんたたち働くぺこー！: if you are going second and this is your first turn, send the top card of your cheer deck to your holomem with #gen3. ◇ご注文のかき氷ぺこ！ "
   },
@@ -19682,9 +20143,11 @@
     "skills": [
       {
         "name": "冷たいものお待ちどうさま♪",
+        "cost": "3 any color",
         "dmg": "80"
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD09",
     "searchString": "shiranui flare hsd09-007 #jp #gen3 #half-elf #summer クールダウンしよ: [collab position only]if this holomem is downed during your opponent's turn, if you have less life than your opponent, you take -1 life damage. 冷たいものお待ちどうさま♪ "
   },

--- a/sets/all_cards.json
+++ b/sets/all_cards.json
@@ -452,12 +452,14 @@
     "skills": [
       {
         "name": "ミッションスタート",
+        "cost": "1 any color",
         "dmg": "30"
       }
     ],
     "extraEffect": "You may include any number of this holomem in the deck",
     "hasHolomenRare": true,
     "imageSet": "hBP07",
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "vestia zeta hbp01-024 #id #idgen3 you may include any number of this holomem in the deck ミッションスタート "
   },
@@ -533,10 +535,12 @@
     "skills": [
       {
         "name": "ハイRyS！",
+        "cost": "1 any color",
         "dmg": "30"
       }
     ],
     "extraEffect": "You may include any number of this holomem in the deck.",
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "irys hbp01-028 #en #promise #singing you may include any number of this holomem in the deck. ハイrys！ "
   },
@@ -605,12 +609,14 @@
     "skills": [
       {
         "name": "アロ～ナ！",
+        "cost": "1 any color",
         "dmg": "30"
       }
     ],
     "extraEffect": "You may include any number of this holomem in the deck.",
     "hasHolomenRare": true,
     "imageSet": "hBP05",
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "aki rosenthal hbp01-032 #jp #gen1 #half-elf #alcohol you may include any number of this holomem in the deck. アロ～ナ！ "
   },
@@ -720,11 +726,13 @@
     "skills": [
       {
         "name": "こんぺこー!",
+        "cost": "1 Green",
         "dmg": "20+",
         "description": "Roll a die once: If the result is even, this art gains +20"
       }
     ],
     "extraEffect": "You may include any number of this holomem in the deck.",
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "usada pekora hbp01-038 #jp #gen3 #kemomimi you may include any number of this holomem in the deck. こんぺこー! roll a die once: if the result is even, this art gains +20"
   },
@@ -776,11 +784,13 @@
     "skills": [
       {
         "name": "見逃しちゃだめべこだよ!",
+        "cost": "1 any color",
         "dmg": 30
       }
     ],
     "hasFullArt": true,
     "imageSet": "hBP06",
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "usada pekora hbp01-041 #jp #gen3 #kemomimi 成長した兎田べこらを: send the top card of your cheer deck to your center holomen or collab holomen. 見逃しちゃだめべこだよ! "
   },
@@ -837,12 +847,14 @@
     "skills": [
       {
         "name": "こんあずき～!",
+        "cost": "1 any color",
         "dmg": "20"
       }
     ],
     "hasHolomenRare": true,
     "imageSet": "hBP07",
     "extraEffect": "You may include any number of this holomem in the deck.",
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "azki hbp01-044 #jp #gen0 #singing you may include any number of this holomem in the deck. こんあずき～! "
   },
@@ -913,10 +925,12 @@
     "skills": [
       {
         "name": "皆殿、風真いろはでござる-",
+        "cost": "1 any color",
         "dmg": "20"
       }
     ],
     "extraEffect": "You may include any number of this holomem in the deck.",
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "kazama iroha hbp01-048 #jp #holox you may include any number of this holomem in the deck. 皆殿、風真いろはでござる- "
   },
@@ -996,11 +1010,13 @@
     "skills": [
       {
         "name": "スラマッパギ!",
+        "cost": "1 any color",
         "dmg": "10",
         "description": "You may reattach 1 cheer from your stage to your holomem with #ID."
       }
     ],
     "extraEffect": "You may include any number of this holomem in the deck.",
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "airani iofifteen hbp01-052 #id #idgen1 #painting you may include any number of this holomem in the deck. スラマッパギ! you may reattach 1 cheer from your stage to your holomem with #id."
   },
@@ -1069,10 +1085,12 @@
     "skills": [
       {
         "name": "皆さん、待っ鷹ね?",
+        "cost": "1 any color",
         "dmg": "30"
       }
     ],
     "extraEffect": "You may include any number of this holomem in the deck.",
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "takane lui hbp01-056 #jp #holox #bird #alcohol you may include any number of this holomem in the deck. 皆さん、待っ鷹ね? "
   },
@@ -1186,11 +1204,13 @@
     "skills": [
       {
         "name": "キッケリキー!",
+        "cost": "1 any color",
         "dmg": "20+",
         "description": "You may archive 1 card from your hand:This Arts gets +20."
       }
     ],
     "extraEffect": "You may include any number of this holomem in the deck.",
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "takanashi kiara hbp01-062 #en #myth #bird you may include any number of this holomem in the deck. キッケリキー! you may archive 1 card from your hand:this arts gets +20."
   },
@@ -1303,12 +1323,14 @@
     "skills": [
       {
         "name": "ポルカおるよ！",
+        "cost": "1 any color",
         "dmg": "20+"
       }
     ],
     "extraEffect": "You may include any number of this holomem in the deck.",
     "hasHolomenRare": true,
     "imageSet": "hBP05",
+    "batonTouch": 0,
     "setName": "hBP01",
     "searchString": "omaru polka hbp01-068 #jp #gen5 #kemomimi you may include any number of this holomem in the deck. ポルカおるよ！ "
   },
@@ -1385,11 +1407,13 @@
     "skills": [
       {
         "name": "WAZZUP!!",
+        "cost": "1 any color",
         "dmg": "20",
         "description": "If a red cheer is attached to this holomem, you may roll a die once:If it is odd, deal 20 Special Damage to your opponent's collab holomem.m"
       }
     ],
     "extraEffect": "You may include any number of this holomem in the deck",
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "hakos baelz hbp01-072 #en #promise #kemomimi you may include any number of this holomem in the deck wazzup!! if a red cheer is attached to this holomem, you may roll a die once:if it is odd, deal 20 special damage to your opponent's collab holomem.m"
   },
@@ -1457,6 +1481,7 @@
     "skills": [
       {
         "name": "スターの原石",
+        "cost": "1 any color",
         "dmg": "20",
         "description": "Deal 10 Special Damage to 1 of your opponent's back holomem. However, your opponent's Life does not reduce even if downed."
       }
@@ -1464,6 +1489,7 @@
     "extraEffect": "You may include any number of this holomem in the deck.",
     "hasHolomenRare": true,
     "imageSet": "hBP05",
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "hoshimachi suisei hbp01-076 #jp #gen0 #singing you may include any number of this holomem in the deck. スターの原石 deal 10 special damage to 1 of your opponent's back holomem. however, your opponent's life does not reduce even if downed."
   },
@@ -1572,10 +1598,12 @@
     "skills": [
       {
         "name": "ぼこぼこぼこぼ",
+        "cost": "1 Blue",
         "dmg": "30"
       }
     ],
     "extraEffect": "You may include any number of this holomem in the deck.",
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "kobo kanaeru hbp01-082 you may include any number of this holomem in the deck. ぼこぼこぼこぼ "
   },
@@ -1688,11 +1716,13 @@
     "skills": [
       {
         "name": "ムーン　ムーン　ムーナだよ！",
+        "cost": "1 Blue",
         "dmg": "10",
         "description": "You may roll a die once:If it is even, deal 20 Special Damage to 1 of your opponent's back holomem. However, your opponent's Life does not reduce even if downed."
       }
     ],
     "extraEffect": "You may include any number of this holomem in the deck.",
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "moona hoshinova hbp01-088 #id #idgen1 #singing you may include any number of this holomem in the deck. ムーン　ムーン　ムーナだよ！ you may roll a die once:if it is even, deal 20 special damage to 1 of your opponent's back holomem. however, your opponent's life does not reduce even if downed."
   },
@@ -1767,6 +1797,7 @@
     "skills": [
       {
         "name": "クロにちは~",
+        "cost": "1 Blue",
         "dmg": "10",
         "description": "You may reattach 1 cheer from this holomem to your other holomem with #Promise."
       }
@@ -1774,6 +1805,7 @@
     "hasHolomenRare": true,
     "imageSet": "hBP07",
     "extraEffect": "You may include any number of this holomem in the deck.",
+    "batonTouch": 1,
     "setName": "hBP01",
     "searchString": "ouro kronii hbp01-092 #en #promise you may include any number of this holomem in the deck. クロにちは~ you may reattach 1 cheer from this holomem to your other holomem with #promise."
   },
@@ -2336,10 +2368,12 @@
     "skills": [
       {
         "name": "こんこんきーつね！",
+        "cost": "1 any color",
         "dmg": "30"
       }
     ],
     "extraEffect": "You may include any number of this holomem in the deck.",
+    "batonTouch": 1,
     "setName": "hBP02",
     "searchString": "shirakami fubuki hbp02-008 #jp #gen1 #gamers #kemomimi #painting you may include any number of this holomem in the deck. こんこんきーつね！ "
   },
@@ -2454,12 +2488,14 @@
     "skills": [
       {
         "name": "こんまっする〜!",
+        "cost": "1 any color",
         "dmg": "20"
       }
     ],
     "extraEffect": "You may include any number of this holomem in the deck.",
     "hasHolomenRare": true,
     "imageSet": "hBP05",
+    "batonTouch": 1,
     "setName": "hBP02",
     "searchString": "shirogane noel hbp02-014 #jp #gen3 #alcohol you may include any number of this holomem in the deck. こんまっする〜! "
   },
@@ -2497,11 +2533,13 @@
     "skills": [
       {
         "name": "目に焼き付けるんだゾ♡",
+        "cost": "2 any color",
         "dmg": "30"
       }
     ],
     "hasFullArt": true,
     "imageSet": "hBP06",
+    "batonTouch": 1,
     "setName": "hBP02",
     "searchString": "shirogane noel hbp02-016 #jp #gen3 #alcohol ノエちゃんの勇姿……: if bloomed from debut, reveal 1 [debut holomem, 1st holomem or spot holomem] with #gen 3 from your deck, and add it to hand. then, shuffle the deck. 目に焼き付けるんだゾ♡ "
   },
@@ -2542,10 +2580,12 @@
     "skills": [
       {
         "name": "ペルハティアン！",
+        "cost": "1 any color",
         "dmg": "30"
       }
     ],
     "extraEffect": "You may include any number of this holomem in the deck.",
+    "batonTouch": 1,
     "setName": "hBP02",
     "searchString": "pavolia reine hbp02-018 #id #idgen2 #bird #painting you may include any number of this holomem in the deck. ペルハティアン！ "
   },
@@ -2658,11 +2698,13 @@
     "skills": [
       {
         "name": "うちうち、うちだよ～大神ミオだよ～",
+        "cost": "1 any color",
         "dmg": "10",
         "description": "You may reattach 1 cheer from your stage to your holomem with #JP."
       }
     ],
     "extraEffect": "You may include any number of this holomem in the deck.",
+    "batonTouch": 2,
     "setName": "hBP02",
     "searchString": "ookami mio hbp02-024 #jp #gamers #kemomimi #cooking you may include any number of this holomem in the deck. うちうち、うちだよ～大神ミオだよ～ you may reattach 1 cheer from your stage to your holomem with #jp."
   },
@@ -2798,11 +2840,13 @@
     "skills": [
       {
         "name": "いっしょに出航しましょう！（健全)",
+        "cost": "1 any color",
         "dmg": "30"
       }
     ],
     "hasFullArt": true,
     "imageSet": "hBP06",
+    "batonTouch": 1,
     "setName": "hBP02",
     "searchString": "houshou marine hbp02-031 #jp #gen3 #painting #sea キミたちの声が船長の支えです！ deal 20 special damage to your opponent's collab holomem. いっしょに出航しましょう！（健全) "
   },
@@ -3260,6 +3304,7 @@
     "skills": [
       {
         "name": "グリム・リーパーの第一弟子",
+        "cost": "1 any color",
         "dmg": "30+",
         "description": "If your archive has holomem, this Arts gets +10."
       }
@@ -3267,6 +3312,7 @@
     "extraEffect": "You may include any number of this holomem in the deck.",
     "hasHolomenRare": true,
     "imageSet": "hBP06",
+    "batonTouch": 1,
     "setName": "hBP02",
     "searchString": "mori calliope hbp02-054 #en #myth #singing you may include any number of this holomem in the deck. グリム・リーパーの第一弟子 if your archive has holomem, this arts gets +10."
   },
@@ -3398,10 +3444,12 @@
     "skills": [
       {
         "name": "WAH!",
+        "cost": "1 any color",
         "dmg": "10"
       }
     ],
     "extraEffect": "You may include any number of this holomem in the deck.",
+    "batonTouch": 1,
     "setName": "hBP02",
     "searchString": "ninomae ina'nis hbp02-061 #en #myth #painting #sea you may include any number of this holomem in the deck. wah! "
   },
@@ -3475,6 +3523,7 @@
     "skills": [
       {
         "name": "Hiya darlings!",
+        "cost": "1 any color",
         "dmg": "30",
         "description": "If a red cheer is attached to this holomem, this Arts gets +10."
       }
@@ -3482,6 +3531,7 @@
     "extraEffect": "You may include any number of this holomem in the deck.",
     "hasHolomenRare": true,
     "imageSet": "hBP05",
+    "batonTouch": 1,
     "setName": "hBP02",
     "searchString": "nerissa ravencroft hbp02-065 #en #advent #singing #bird you may include any number of this holomem in the deck. hiya darlings! if a red cheer is attached to this holomem, this arts gets +10."
   },
@@ -4136,11 +4186,13 @@
     "skills": [
       {
         "name": "みんな～、おりゅ～？",
+        "cost": "1 any color",
         "dmg": "10",
         "description": "If you do not have a holomem with 〈Lu-knights〉 attached, reveal 1 〈Lu-knights〉 from your deck, and attach it to your holomem. Then, shuffle the deck."
       }
     ],
     "extraEffect": "You may include any number of this holomem in the deck.",
+    "batonTouch": 1,
     "setName": "hBP03",
     "searchString": "himemori luna hbp03-009 #jp #gen4 #baby you may include any number of this holomem in the deck. みんな～、おりゅ～？ if you do not have a holomem with 〈lu-knights〉 attached, reveal 1 〈lu-knights〉 from your deck, and attach it to your holomem. then, shuffle the deck."
   },
@@ -4156,10 +4208,12 @@
     "skills": [
       {
         "name": "お菓子たべるのら？",
+        "cost": "1 White",
         "dmg": "20"
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP03",
     "searchString": "himemori luna hbp03-010 #jp #gen4 #baby お菓子の国のお姫様: if your center holomem is <himemori luna>, draw 1 card from your deck. お菓子たべるのら？ "
   },
@@ -4174,14 +4228,17 @@
     "skills": [
       {
         "name": "おつルーナ",
+        "cost": "1 White",
         "dmg": "40"
       },
       {
         "name": "ぐっどないと～",
+        "cost": "1 White, 1 any color",
         "dmg": "60"
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP03",
     "searchString": "himemori luna hbp03-011 #jp #gen4 #baby おつルーナ  ぐっどないと～ "
   },
@@ -4197,10 +4254,12 @@
     "skills": [
       {
         "name": "力をかしてくださいね",
+        "cost": "1 White, 1 any color",
         "dmg": "40"
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP03",
     "searchString": "himemori luna hbp03-012 #jp #gen4 #baby 一緒に最高のライブにしようね: during this turn, 1 of your holomem with a fan attached gets arts+20. 力をかしてくださいね "
   },
@@ -4216,11 +4275,13 @@
     "skills": [
       {
         "name": "ムーンギャラクシー",
+        "cost": "1 White",
         "dmg": "20",
         "description": "You may attach 1 〈Lu-knights〉 from your archive to your 〈Himemori Luna〉."
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP03",
     "searchString": "himemori luna hbp03-013 #jp #gen4 #baby んなたんと一緒に、宇宙に行くのら～！:[collab position only] your center holomem 〈himemori luna〉 with a fan attached gets arts+20. ムーンギャラクシー you may attach 1 〈lu-knights〉 from your archive to your 〈himemori luna〉."
   },
@@ -4236,12 +4297,14 @@
     "skills": [
       {
         "name": "お疲れ様なのらね",
+        "cost": "2 White, 1 any color",
         "dmg": "100+",
         "description": "If 〈Lu-knights〉 is attached to this holomen, this Arts gets +50.."
       }
     ],
     "hasAlternativeArt": true,
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP03",
     "searchString": "himemori luna hbp03-014 #jp #gen4 #baby ルーナについてくるのら～: if your oshi holomem is 〈himemori luna〉, you may attach 1 〈lu-knights〉 from your archive to your 〈himemori luna〉. お疲れ様なのらね if 〈lu-knights〉 is attached to this holomen, this arts gets +50.."
   },
@@ -4257,12 +4320,14 @@
     "skills": [
       {
         "name": "これが番長の実力ってやつよ",
+        "cost": "1 White, 2 any color",
         "dmg": "110",
         "description": "If you have 4 or more back holomem with #ReGLOSS, this holomem gets Arts+40."
       }
     ],
     "hasAlternativeArt": true,
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP03",
     "searchString": "todoroki hajime hbp03-015 #dev_is #regloss #baby メランコリャック: [center position only] your collab holomem with #regloss takes -20 damage. これが番長の実力ってやつよ if you have 4 or more back holomem with #regloss, this holomem gets arts+40."
   },
@@ -4277,10 +4342,12 @@
     "skills": [
       {
         "name": "ららーいおん♪",
+        "cost": "1 any color",
         "dmg": "30"
       }
     ],
     "extraEffect": "You may include any number of this holomem in the deck.",
+    "batonTouch": 1,
     "setName": "hBP03",
     "searchString": "shishiro botan hbp03-016 #jp #gen5 #kemomimi #shooter you may include any number of this holomem in the deck. ららーいおん♪ "
   },
@@ -4296,10 +4363,12 @@
     "skills": [
       {
         "name": "ぼ。",
+        "cost": "1 Green",
         "dmg": "20"
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP03",
     "searchString": "shishiro botan hbp03-017 #jp #gen5 #kemomimi #shooter プリペア: if your oshi holomem is 〈shishiro botan〉, you may archive the top card of your cheer deck:restore 10 hp to 1 of your holomem. ぼ。 "
   },
@@ -4314,13 +4383,16 @@
     "skills": [
       {
         "name": "ぼたんがアイドルになったら…",
+        "cost": "1 Green",
         "dmg": "40"
       },
       {
         "name": "絶対、ドキドキさせるから",
+        "cost": "1 Green, 1 any color",
         "dmg": "60"
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP03",
     "searchString": "shishiro botan hbp03-018 #jp #gen5 #kemomimi #shooter ぼたんがアイドルになったら…  絶対、ドキドキさせるから "
   },
@@ -4336,11 +4408,13 @@
     "skills": [
       {
         "name": "じゅるり",
+        "cost": "1 any color",
         "dmg": "30",
         "description": "Reveal 1 〈Tsunomaki Watame〉 from your hand, and you may return it to the bottom of the deck:Restore 20 HP to this holomem."
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP03",
     "searchString": "shishiro botan hbp03-019 #jp #gen5 #kemomimi #shooter 歌う事は楽しい事: you may archive 1 cheer from one of your back holomems for the following effect: deal 30 special damage to your opponent's center or collab holomem. you may only use the bloom effect [歌う事は楽しい事] once per turn. じゅるり reveal 1 〈tsunomaki watame〉 from your hand, and you may return it to the bottom of the deck:restore 20 hp to this holomem."
   },
@@ -4356,10 +4430,12 @@
     "skills": [
       {
         "name": "ショッピングカートで来た",
+        "cost": "1 Green, 1 any color",
         "dmg": "50"
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP03",
     "searchString": "shishiro botan hbp03-020 #jp #gen5 #kemomimi #shooter ssssr: send the top card of your cheer deck to one of your back holomems <shishiro botan>. ショッピングカートで来た "
   },
@@ -4375,12 +4451,14 @@
     "skills": [
       {
         "name": "神エイム",
+        "cost": "1 Green, 2 any color",
         "dmg": "110",
         "description": "If your Oshi holomem is 〈Shishiro Botan〉, you may archive 1 cheer from your back holomem:Deal 40 special damage to your opponent's center holomem or collab holomem."
       }
     ],
     "hasAlternativeArt": true,
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP03",
     "searchString": "shishiro botan hbp03-021 #jp #gen5 #kemomimi #shooter なんとかしてくれる獅白ぼたん: you may send 1 green cheer each from your archive to 1~2 of your back holomem with #shooter. 神エイム if your oshi holomem is 〈shishiro botan〉, you may archive 1 cheer from your back holomem:deal 40 special damage to your opponent's center holomem or collab holomem."
   },
@@ -4397,12 +4475,14 @@
     "skills": [
       {
         "name": "情熱のベリーダンサー",
+        "cost": "2 Green",
         "dmg": "50",
         "description": "If your Oshi holomem is 〈Aki Rosenthal〉, restore 10 HP to all of your holomem with a tool attached."
       }
     ],
     "hasFullArt": true,
     "extraEffect": "If this holomem is downed, you get Life-2.",
+    "batonTouch": 2,
     "setName": "hBP03",
     "searchString": "aki rosenthal hbp03-022 #jp #gen1 #half-elf #alcohol 異国の世界の姿 : [center position・collab position only]usable at the beginning of your opponent's performance phase:during this turn, your life cannot be reduced by your opponent's abilities. if this holomem is downed, you get life-2. 情熱のベリーダンサー if your oshi holomem is 〈aki rosenthal〉, restore 10 hp to all of your holomem with a tool attached."
   },
@@ -4419,12 +4499,14 @@
     "skills": [
       {
         "name": "カードするぺこ",
+        "cost": "1 Green, 2 any color",
         "dmg": "80+",
         "description": "If a die was rolled once or more by the ability of your 〈Usada Pekora〉 this turn, this Arts gets +40."
       }
     ],
     "hasFullArt": true,
     "extraEffect": "If this holomem is downed, you get Life-2.",
+    "batonTouch": 2,
     "setName": "hBP03",
     "searchString": "usada pekora hbp03-023 #jp #gen3 #kemomimi あんたたちぃ:　you may roll a die once:if it is even, reveal 1 fan from your deck, and add it to hand. then, shuffle the deck. if this holomem is downed, you get life-2. カードするぺこ if a die was rolled once or more by the ability of your 〈usada pekora〉 this turn, this arts gets +40."
   },
@@ -4440,12 +4522,14 @@
     "skills": [
       {
         "name": "風真が斬る",
+        "cost": "1 Green, 3 any color",
         "dmg": "100+",
         "description": "If 2 or more non-green cheers are attached to this holomem, this Arts gets +50."
       }
     ],
     "hasAlternativeArt": true,
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP03",
     "searchString": "kazama iroha hbp03-024 #jp #holox 風真が護る:　you may send 1 cheer each from your archive to 1 each of your [〈kazama iroha〉 and 〈hoshimachi suisei〉]. 風真が斬る if 2 or more non-green cheers are attached to this holomem, this arts gets +50."
   },
@@ -4460,6 +4544,7 @@
     "skills": [
       {
         "name": "にゃっはろ～",
+        "cost": "1 any color",
         "dmg": "30"
       }
     ],
@@ -4467,6 +4552,7 @@
     "imageSet": "hBP07",
     "manualUrlHR": "https://hololive-official-cardgame.com/wp-content/images/cardlist/hBP07/hBP03-025_02_HR.png",
     "extraEffect": "You may include any number of this holomem in the deck.",
+    "batonTouch": 1,
     "setName": "hBP03",
     "searchString": "sakura miko hbp03-025 #jp #gen0 #baby you may include any number of this holomem in the deck. にゃっはろ～ "
   },
@@ -4482,10 +4568,12 @@
     "skills": [
       {
         "name": "さくらの季節",
+        "cost": "1 Red, 1 any color",
         "dmg": "30"
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP03",
     "searchString": "sakura miko hbp03-026 #jp #gen0 #baby 君と待ち合わせ:　you may roll a dice. if the result is 2, 4, or 6, deal 10 special damage to your opponent's center holomem. if the result is 3 or 5, draw 1 card from your deck and deal 10 special damage to your opponent's center holomem. さくらの季節 "
   },
@@ -4500,14 +4588,17 @@
     "skills": [
       {
         "name": "エリートな水着",
+        "cost": "1 any color",
         "dmg": "40"
       },
       {
         "name": "ぷにち",
+        "cost": "1 Red, 1 any color",
         "dmg": "60"
       }
     ],
     "hasFoils": true,
+    "batonTouch": 0,
     "setName": "hBP03",
     "searchString": "sakura miko hbp03-027 #jp #gen0 #baby エリートな水着  ぷにち "
   },
@@ -4522,15 +4613,18 @@
     "skills": [
       {
         "name": "応援頼んだぞ",
+        "cost": "1 any color",
         "dmg": "30"
       },
       {
         "name": "みこぴー！(｀・ω・´)🌸",
+        "cost": "1 Red, 1 any color",
         "dmg": "50",
         "description": "You may roll a dice. If the result is 2, 4, or 6, deal 20 special damage to your opponent's Center holomem. If the result is 3 or 5, deal 20 special damage to your opponent's Center and Collab holomem"
       }
     ],
     "hasFoils": true,
+    "batonTouch": 0,
     "setName": "hBP03",
     "searchString": "sakura miko hbp03-028 #jp #gen0 #baby 応援頼んだぞ  みこぴー！(｀・ω・´)🌸 you may roll a dice. if the result is 2, 4, or 6, deal 20 special damage to your opponent's center holomem. if the result is 3 or 5, deal 20 special damage to your opponent's center and collab holomem"
   },
@@ -4546,11 +4640,13 @@
     "skills": [
       {
         "name": "35Pと記念写真",
+        "cost": "1 Red, 1 any color",
         "dmg": "30",
         "descirption": "If 〈35P〉 is attached to this holomem, this Arts gets +30."
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 0,
     "setName": "hBP03",
     "searchString": "sakura miko hbp03-029 #jp #gen0 #baby にぇ:　reveal 1 <35p> from your deck and put it into your hand. then shuffle your deck. 35pと記念写真 "
   },
@@ -4566,12 +4662,14 @@
     "skills": [
       {
         "name": "エリート巫女",
+        "cost": "1 Red, 2 any color",
         "dmg": "120+",
         "description": "This Arts gets +20 for each 〈35P〉 attached to this holomem."
       }
     ],
     "hasAlternativeArt": true,
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP03",
     "searchString": "sakura miko hbp03-030 #jp #gen0 #baby エリートギャンブル:　[center position only] (once per turn) [1/turn]during your main phase, if〈35p〉 is attached to this holomem, you may roll a die once:if it is 3 or 5, during this turn, this holomem gets arts+50. エリート巫女 this arts gets +20 for each 〈35p〉 attached to this holomem."
   },
@@ -4586,10 +4684,12 @@
     "skills": [
       {
         "name": "おはるーじゅ！",
+        "cost": "1 any color",
         "dmg": "30"
       }
     ],
     "extraEffect": "You may include any number of this holomem in the deck.",
+    "batonTouch": 1,
     "setName": "hBP03",
     "searchString": "akai haato hbp03-031 #jp #gen1 #cooking you may include any number of this holomem in the deck. おはるーじゅ！ "
   },
@@ -4604,10 +4704,12 @@
     "skills": [
       {
         "name": "おつるーじゅ！",
+        "cost": "1 Red, 1 any color",
         "dmg": "60"
       }
     ],
     "hasFoils": true,
+    "batonTouch": 0,
     "setName": "hBP03",
     "searchString": "akai haato hbp03-032 #jp #gen1 #cooking おつるーじゅ！ "
   },
@@ -4623,10 +4725,12 @@
     "skills": [
       {
         "name": "はあちゃまっちゃま～！",
+        "cost": "1 any color",
         "dmg": "40"
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP03",
     "searchString": "akai haato hbp03-033 #jp #gen1 #cooking 全力でいくぞおおお！:　deal 10 special damage to your opponent's center holomem. if that holomem has a tool attached, deal 30 special damage instead. はあちゃまっちゃま～！ "
   },
@@ -4643,6 +4747,7 @@
     "skills": [
       {
         "name": "レッド オア ルージュ",
+        "cost": "1 Red, 1 any color",
         "dmg": "40+",
         "description": "You may roll a die once:If it is odd, deal 20 special damage to your opponent's center holomem and collab holomem. If it is even, this Arts gets +40."
       }
@@ -4650,6 +4755,7 @@
     "extraEffect": "If this holomem is downed, you get Life-2.",
     "hasAlternativeArt": true,
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP03",
     "searchString": "akai haato hbp03-034 #jp #gen1 #cooking もう1人のはあと: you may return 1 [1st holomem or 2nd holomem] with #gen 1 other than buzz from archive to hand.. if this holomem is downed, you get life-2. レッド オア ルージュ you may roll a die once:if it is odd, deal 20 special damage to your opponent's center holomem and collab holomem. if it is even, this arts gets +40."
   },
@@ -4665,12 +4771,14 @@
     "skills": [
       {
         "name": "challenger",
+        "cost": "1 Red, 1 any color",
         "dmg": "50",
         "descirption": "If your Oshi holomem is 〈Takane Lui〉, you may archive 2 cards from your hand:Draw 3 cards."
       }
     ],
     "hasFullArt": true,
     "extraEffect": "If this holomem is downed, you get Life-2.",
+    "batonTouch": 2,
     "setName": "hBP03",
     "searchString": "takane lui hbp03-035 #jp #holox #bird #alcohol if this holomem is downed, you get life-2. challenger "
   },
@@ -4686,10 +4794,12 @@
     "skills": [
       {
         "name": "鋼の翼",
+        "cost": "1 Red, 1 any color",
         "dmg": "50"
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP03",
     "searchString": "takanashi kiara hbp03-036 #en #myth #bird ハッピータイム: reveal 1~4 〈takanashi kiara〉 from your deck, and you may archive them. then, shuffle the deck. 鋼の翼 "
   },
@@ -4704,11 +4814,13 @@
     "skills": [
       {
         "name": "フワワじゃないよ、モココだよ",
+        "cost": "1 any color",
         "dmg": "20",
         "description": "If your center holomem is 〈Fuwawa Abyssgard〉, this Arts requires -1 ▲◇▲"
       }
     ],
     "extraEffect": "You may include any number of this holomem in the deck.",
+    "batonTouch": 0,
     "setName": "hBP03",
     "searchString": "mococo abyssgard hbp03-037 #en #advent #kemomimi you may include any number of this holomem in the deck. フワワじゃないよ、モココだよ if your center holomem is 〈fuwawa abyssgard〉, this arts requires -1 ▲◇▲"
   },
@@ -4724,10 +4836,12 @@
     "skills": [
       {
         "name": "モココとドーナツクッキング",
+        "cost": "1 any color",
         "dmg": "30"
       }
     ],
     "hasFoils": true,
+    "batonTouch": 0,
     "setName": "hBP03",
     "searchString": "mococo abyssgard hbp03-038 #en #advent #kemomimi 遊びの時間だー！:　when bloomed from debut, reveal 1 1st holomem 〈fuwawa abyssgard〉 from your deck, and add it to hand. then, shuffle the deck. モココとドーナツクッキング "
   },
@@ -4744,12 +4858,14 @@
     "skills": [
       {
         "name": "もこもこしてる方",
+        "cost": "1 Red, 1 Blue",
         "dmg": "50+",
         "description": "[Collab Position only] If your center holomem is 〈Fuwawa Abyssgard〉, this Arts gets +30."
       }
     ],
     "extraEffect": "If this holomem is downed, you get Life-2.",
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP03",
     "searchString": "mococo abyssgard hbp03-039 #en #advent #kemomimi 魔界乃番犬の暴れん坊:　during your reset phase, if your center holomem is 〈fuwawa abyssgard〉, this holomem does not rest even if moved to the back position. if this holomem is downed, you get life-2. もこもこしてる方 [collab position only] if your center holomem is 〈fuwawa abyssgard〉, this arts gets +30."
   },
@@ -4764,10 +4880,12 @@
     "skills": [
       {
         "name": "チワワじゃないよ、フワワだよ",
+        "cost": "1 any color",
         "dmg": "30"
       }
     ],
     "extraEffect": "You may include any number of this holomem in the deck.",
+    "batonTouch": 1,
     "setName": "hBP03",
     "searchString": "fuwawa abyssgard hbp03-040 #en #advent #kemomimi you may include any number of this holomem in the deck. チワワじゃないよ、フワワだよ "
   },
@@ -4782,14 +4900,17 @@
     "skills": [
       {
         "name": "魔界乃番犬のまとめ役",
+        "cost": "1 any color",
         "dmg": "40"
       },
       {
         "name": "ふわふわしてる方",
+        "cost": "1 Blue, 1 any color",
         "dmg": "60"
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP03",
     "searchString": "fuwawa abyssgard hbp03-041 #en #advent #kemomimi 魔界乃番犬のまとめ役  ふわふわしてる方 "
   },
@@ -4805,10 +4926,12 @@
     "skills": [
       {
         "name": "フワワと森のお散歩",
+        "cost": "2 any color",
         "dmg": "50"
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP03",
     "searchString": "fuwawa abyssgard hbp03-042 #en #advent #kemomimi フワ花流水: if 〈mococo abyssgard〉 is on your stage, deal 20 special damage to 1 of your opponent's center holomem or back holomem. however, your opponent's life does not reduce even if downed. フワワと森のお散歩 "
   },
@@ -4823,16 +4946,19 @@
     "skills": [
       {
         "name": "ドーナツ大好き",
+        "cost": "1 Blue",
         "dmg": "60"
       },
       {
         "name": "一緒に食べる？",
+        "cost": "1 Blue, 1 Red, 1 any color",
         "dmg": "100",
         "description": "[Center Position only] If your Oshi holomem is 〈FUWAMOCO〉, you may reattach 1 cheer from this holomem to your 〈Mococo Abyssgard〉:Deal 50 special damage to your opponent's center holomem."
       }
     ],
     "hasAlternativeArt": true,
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP03",
     "searchString": "fuwawa abyssgard hbp03-043 #en #advent #kemomimi ドーナツ大好き  一緒に食べる？ [center position only] if your oshi holomem is 〈fuwamoco〉, you may reattach 1 cheer from this holomem to your 〈mococo abyssgard〉:deal 50 special damage to your opponent's center holomem."
   },
@@ -4848,11 +4974,13 @@
     "skills": [
       {
         "name": "バーチャルゴースト",
+        "cost": "1 Blue, 1 any color",
         "dmg": "40",
         "descirption": "If your Oshi holomem is 〈Hoshimachi Suisei〉, you may reattach 1 blue cheer from this holomem to your back holomem 〈Hoshimachi Suisei〉"
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP03",
     "searchString": "hoshimachi suisei hbp03-044 #jp #gen0 #singing プラネットステージ: look at the top 4 cards of your deck. reveal 1 〈hoshimachi suisei〉 from among them, and add it to hand. then, return the remaining cards to the bottom of the deck in any order. バーチャルゴースト "
   },
@@ -4869,12 +4997,14 @@
     "skills": [
       {
         "name": "元気いっぱい！",
+        "cost": "1 Blue, 1 any color",
         "dmg": "40+",
         "description": "This Arts gets +10 for each of your opponent's back holomem with reduced HP."
       }
     ],
     "hasFullArt": true,
     "extraEffect": "If this holomem is downed, you get Life-2.",
+    "batonTouch": 2,
     "setName": "hBP03",
     "searchString": "kobo kanaeru hbp03-045 #id #idgen3 ブルーレイン: you may archive 1 cheer from your holomem with #id:deal 30 special damage divided as you choose as sets of 10 to your opponent's back holomem. however, your opponent's life does not reduce even if downed. if this holomem is downed, you get life-2. 元気いっぱい！ this arts gets +10 for each of your opponent's back holomem with reduced hp."
   },
@@ -4889,14 +5019,17 @@
     "skills": [
       {
         "name": "可愛い女の子かと思った？",
+        "cost": "1 any color",
         "dmg": "10"
       },
       {
         "name": "じゃじゃーん！ 青くんでした。",
+        "cost": "2 any color",
         "dmg": "40"
       }
     ],
     "extraEffect": "You may include any number of this holomem in the deck.",
+    "batonTouch": 1,
     "setName": "hBP03",
     "searchString": "hiodoshi ao hbp03-046 #dev_is #regloss #painting you may include any number of this holomem in the deck. 可愛い女の子かと思った？  じゃじゃーん！ 青くんでした。 "
   },
@@ -4911,10 +5044,12 @@
     "skills": [
       {
         "name": "アフタヌーンティーデートのその後に…　",
+        "cost": "1 Blue, 1 any color",
         "dmg": "60"
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP03",
     "searchString": "hiodoshi ao hbp03-047 #dev_is #regloss #painting アフタヌーンティーデートのその後に…　 "
   },
@@ -4929,15 +5064,18 @@
     "skills": [
       {
         "name": "僕、カッコいいでしょ？",
+        "cost": "1 any color",
         "dmg": "30"
       },
       {
         "name": "ReGLOSSのボーイッシュ担当",
+        "cost": "2 any color",
         "dmg": "40",
         "description": "You may move 1 Cheer from this holomem to one of your back holomems with #ReGLOSS."
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP03",
     "searchString": "hiodoshi ao hbp03-048 #dev_is #regloss #painting 僕、カッコいいでしょ？  reglossのボーイッシュ担当 you may move 1 cheer from this holomem to one of your back holomems with #regloss."
   },
@@ -4954,12 +5092,14 @@
     "skills": [
       {
         "name": "イケメンにお任せを",
+        "cost": "1 Blue, 2 any color",
         "dmg": "50",
         "description": "Deal 10 special damage for each of your back holomem with #ReGLOSS and with different card names to your opponent's center holomem or 1 of their back holomem."
       }
     ],
     "extraEffect": "If this holomem is downed, you get Life-2.",
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP03",
     "searchString": "hiodoshi ao hbp03-049 #dev_is #regloss #painting 困ったお姫様たちだね: reveal 1 cheer from your cheer deck with the same color as your center holomem with #regloss, and send it to your holomem with #regloss. then, shuffle the cheer deck. if this holomem is downed, you get life-2. イケメンにお任せを deal 10 special damage for each of your back holomem with #regloss and with different card names to your opponent's center holomem or 1 of their back holomem."
   },
@@ -4974,16 +5114,19 @@
     "skills": [
       {
         "name": "魔界乃番犬シスターズ",
+        "cost": "2 any color",
         "dmg": "40",
         "description": "Reveal 1 [red cheer or blue cheer] from your cheer deck, and send it to your holomem with #Advent. Then, shuffle the cheer deck."
       },
       {
         "name": "2人揃ってFUWAMOCOです！",
+        "cost": "1 Blue, 1 Red",
         "dmg": "60"
       }
     ],
     "extraEffect": "This holomem is also regarded as 〈Fuwawa Abyssgard〉〈Mococo Abyssgard〉",
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP03",
     "searchString": "fuwamoco hbp03-050 #en #advent #kemomimi this holomem is also regarded as 〈fuwawa abyssgard〉〈mococo abyssgard〉 魔界乃番犬シスターズ reveal 1 [red cheer or blue cheer] from your cheer deck, and send it to your holomem with #advent. then, shuffle the cheer deck. 2人揃ってfuwamocoです！ "
   },
@@ -4998,10 +5141,12 @@
     "skills": [
       {
         "name": "こんやっぴー",
+        "cost": "1 any color",
         "dmg": "30"
       }
     ],
     "extraEffect": "You may include any number of this holomem in the deck.",
+    "batonTouch": 1,
     "setName": "hBP03",
     "searchString": "tokoyami towa hbp03-051 #jp #gen4 #singing #shooter you may include any number of this holomem in the deck. こんやっぴー "
   },
@@ -5016,11 +5161,13 @@
     "skills": [
       {
         "name": "そういう感じなんだ",
+        "cost": "1 Purple",
         "dmg": "20",
         "description": "Deal 10 special damage to your opponent's center holomem. If your Oshi holomem is 〈Tokoyami Towa〉, you may archive 1 tool attached to your opponent's [center holomem or collab holomem]."
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP03",
     "searchString": "tokoyami towa hbp03-052 #jp #gen4 #singing #shooter そういう感じなんだ deal 10 special damage to your opponent's center holomem. if your oshi holomem is 〈tokoyami towa〉, you may archive 1 tool attached to your opponent's [center holomem or collab holomem]."
   },
@@ -5035,14 +5182,17 @@
     "skills": [
       {
         "name": "おつやっぴー　",
+        "cost": "1 any color",
         "dmg": "30"
       },
       {
         "name": "きゅりん",
+        "cost": "1 Purple, 1 any color",
         "dmg": "60"
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP03",
     "searchString": "tokoyami towa hbp03-053 #jp #gen4 #singing #shooter おつやっぴー　  きゅりん "
   },
@@ -5058,11 +5208,13 @@
     "skills": [
       {
         "name": "大爆発させちゃうぜ！",
+        "cost": "1 any color",
         "dmg": "30",
         "description": "You may Archive 4 Purple Cheers from this holomem for the following effect: return 1 Cheer from your opponent's Stage to the bottom of their Cheer Deck."
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP03",
     "searchString": "tokoyami towa hbp03-054 #jp #gen4 #singing #shooter トワにしか出せない色: deal 20 special damage to your opponent's center or collab holomem. 大爆発させちゃうぜ！ you may archive 4 purple cheers from this holomem for the following effect: return 1 cheer from your opponent's stage to the bottom of their cheer deck."
   },
@@ -5077,15 +5229,18 @@
     "skills": [
       {
         "name": "トワとお家デートしたっていい",
+        "cost": "1 Purple",
         "dmg": "40"
       },
       {
         "name": "てんQ",
+        "cost": "1 Purple, 1 any color",
         "dmg": "50",
         "description": "If you have any Back holomems with #singing, deal 20 special damage to your opponent's Collab holomem."
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP03",
     "searchString": "tokoyami towa hbp03-055 #jp #gen4 #singing #shooter トワとお家デートしたっていい  てんq if you have any back holomems with #singing, deal 20 special damage to your opponent's collab holomem."
   },
@@ -5100,17 +5255,20 @@
     "skills": [
       {
         "name": "私を縛る固定概念を壊せ",
+        "cost": "1 Purple",
         "dmg": "30",
         "description": "Deal 30 special damage to your opponent's Center or Collab holomem."
       },
       {
         "name": "Break your ×××",
+        "cost": "2 Purple, 1 any color",
         "dmg": "80",
         "description": "Deal 20 special damage for each of your back holomem with #Singing to your opponent's center holomem or collab holomem. However, only up to 4 holomem are counted."
       }
     ],
     "hasAlternativeArt": true,
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP03",
     "searchString": "tokoyami towa hbp03-056 #jp #gen4 #singing #shooter 私を縛る固定概念を壊せ deal 30 special damage to your opponent's center or collab holomem. break your ××× deal 20 special damage for each of your back holomem with #singing to your opponent's center holomem or collab holomem. however, only up to 4 holomem are counted."
   },
@@ -5125,10 +5283,12 @@
     "skills": [
       {
         "name": "はろーぼー！",
+        "cost": "1 any color",
         "dmg": "30"
       }
     ],
     "extraEffect": "You may include any number of this holomem in the deck.",
+    "batonTouch": 1,
     "setName": "hBP03",
     "searchString": "robocosan hbp03-057 #jp #gen0 #shooter you may include any number of this holomem in the deck. はろーぼー！ "
   },
@@ -5143,14 +5303,17 @@
     "skills": [
       {
         "name": "おつろぼー",
+        "cost": "1 any color",
         "dmg": "30"
       },
       {
         "name": "いちゃあま彼女",
+        "cost": "1 Purple, 1 any color",
         "dmg": "60"
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP03",
     "searchString": "robocosan hbp03-058 #jp #gen0 #shooter おつろぼー  いちゃあま彼女 "
   },
@@ -5166,10 +5329,12 @@
     "skills": [
       {
         "name": "笑顔になーーれっ",
+        "cost": "1 any color",
         "dmg": "40"
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP03",
     "searchString": "robocosan hbp03-059 #jp #gen0 #shooter ponしたらその分: look at the top three cards of your deck. reveal one that is 1 holomem with #gen0 and put it into your hand. then put the remaining cards on the bottom of your deck in any order. 笑顔になーーれっ "
   },
@@ -5184,11 +5349,13 @@
     "skills": [
       {
         "name": "自称【高性能】",
+        "cost": "1 any color",
         "dmg": "70+",
         "description": "If your opponent's stage has 7 or more cheers, this Arts gets +70."
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP03",
     "searchString": "robocosan hbp03-060 #jp #gen0 #shooter 自称【高性能】 if your opponent's stage has 7 or more cheers, this arts gets +70."
   },
@@ -5203,14 +5370,17 @@
     "skills": [
       {
         "name": "ぉぁよ～",
+        "cost": "1 any color",
         "dmg": "20"
       },
       {
         "name": "ゆびゆび～",
+        "cost": "3 any color",
         "dmg": "60"
       }
     ],
     "extraEffect": "You may include any number of this holomem in the deck.",
+    "batonTouch": 1,
     "setName": "hBP03",
     "searchString": "inugami korone hbp03-061 #jp #gamers #kemomimi you may include any number of this holomem in the deck. ぉぁよ～  ゆびゆび～ "
   },
@@ -5226,10 +5396,12 @@
     "skills": [
       {
         "name": "ご注文はこれだでな",
+        "cost": "1 Yellow",
         "dmg": "30"
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP03",
     "searchString": "inugami korone hbp03-062 #jp #gamers #kemomimi ころねダイナー:　you may archive 1 cheer from this holomem for the following effect: reveal a debut holomem with #gamers from your deck and put it into your hand. then shuffle your deck. ご注文はこれだでな "
   },
@@ -5244,10 +5416,12 @@
     "skills": [
       {
         "name": "つころ～ん",
+        "cost": "1 Yellow",
         "dmg": "30"
       }
     ],
     "hasFoils": true,
+    "batonTouch": 2,
     "setName": "hBP03",
     "searchString": "inugami korone hbp03-063 #jp #gamers #kemomimi つころ～ん "
   },
@@ -5262,15 +5436,18 @@
     "skills": [
       {
         "name": "ぶるぁあああああ!!!!!!!!!!!!!!",
+        "cost": "1 Yellow, 1 any color",
         "dmg": "40+",
         "description": "This Arts gets +10 for each life reduced from your initial life."
       },
       {
         "name": "おーしぇーい",
+        "cost": "3 any color",
         "dmg": "70"
       }
     ],
     "hasFoils": true,
+    "batonTouch": 2,
     "setName": "hBP03",
     "searchString": "inugami korone hbp03-064 #jp #gamers #kemomimi ぶるぁあああああ!!!!!!!!!!!!!! this arts gets +10 for each life reduced from your initial life. おーしぇーい "
   },
@@ -5286,11 +5463,13 @@
     "skills": [
       {
         "name": "ほらよ～",
+        "cost": "2 any color",
         "dmg": "30",
         "description": "Send the top card of your Cheer Deck to one of your holomems with #Gamers."
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP03",
     "searchString": "inugami korone hbp03-065 #jp #gamers #kemomimi ボクシングスタイル:　[collab position only] during your opponent's main phase, the hp of your center holomem 〈inugami korone〉 cannot be reduced or changed by your opponent's abilities. ほらよ～ send the top card of your cheer deck to one of your holomems with #gamers."
   },
@@ -5306,12 +5485,14 @@
     "skills": [
       {
         "name": "最凶天災",
+        "cost": "2 Yellow, 1 any color",
         "dmg": "120+",
         "description": "If the target of this Arts is your opponent's 2nd holomem, you may archive 1 1st holomem stacked to this holomem:This Arts gets +50."
       }
     ],
     "hasAlternativeArt": true,
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP03",
     "searchString": "inugami korone hbp03-066 #jp #gamers #kemomimi わんだふぉ～♡: when this holomem is downed, send the top card of your cheer deck to your 〈inugami korone〉.. 最凶天災 if the target of this arts is your opponent's 2nd holomem, you may archive 1 1st holomem stacked to this holomem:this arts gets +50."
   },
@@ -5326,12 +5507,14 @@
     "skills": [
       {
         "name": "こんばんドドド～！",
+        "cost": "1 any color",
         "dmg": "30"
       }
     ],
     "hasHolomenRare": true,
     "imageSet": "hBP07",
     "extraEffect": "You may include any number of this holomem in the deck.",
+    "batonTouch": 1,
     "setName": "hBP03",
     "searchString": "tsunomaki watame hbp03-067 #jp #gen4 #kemomimi #singing you may include any number of this holomem in the deck. こんばんドドド～！ "
   },
@@ -5346,11 +5529,13 @@
     "skills": [
       {
         "name": "わためのうた",
+        "cost": "1 Yellow",
         "dmg": "20",
         "description": "If you have a holomem with 〈Watamates〉 attached, you may send 1 cheer from your archive to your yellow holomem.."
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP03",
     "searchString": "tsunomaki watame hbp03-068 #jp #gen4 #kemomimi #singing わためのうた if you have a holomem with 〈watamates〉 attached, you may send 1 cheer from your archive to your yellow holomem.."
   },
@@ -5365,14 +5550,17 @@
     "skills": [
       {
         "name": "癒しのひととき",
+        "cost": "1 Yellow",
         "dmg": "30"
       },
       {
         "name": "応援してくれるよねぇ？",
+        "cost": "3 any color",
         "dmg": "90"
       }
     ],
     "hasFoils": true,
+    "batonTouch": 2,
     "setName": "hBP03",
     "searchString": "tsunomaki watame hbp03-069 #jp #gen4 #kemomimi #singing 癒しのひととき  応援してくれるよねぇ？ "
   },
@@ -5388,11 +5576,13 @@
     "skills": [
       {
         "name": "最後まで見ててね、わためいと！",
+        "cost": "2 any color",
         "dmg": "30",
         "description": "Send the top card of your Cheer Deck to one of your Back holomems named <Tsunomaki Watame>."
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP03",
     "searchString": "tsunomaki watame hbp03-070 #jp #gen4 #kemomimi #singing めいっぱい歌って踊ります！:if there are 5 or fewer holomems on your stage, you may reveal a debut <tsunomaki watame> from your deck and put it onto your stage. then shuffle your deck. 最後まで見ててね、わためいと！ send the top card of your cheer deck to one of your back holomems named <tsunomaki watame>."
   },
@@ -5408,11 +5598,13 @@
     "skills": [
       {
         "name": "つのまきじゃんけん",
+        "cost": "1 Yellow, 1 any color",
         "dmg": "50",
         "description": "You may play rock-paper-scissors with your opponent until there's a winner:If you won, during this turn, this holomem gets Red Critical+30.."
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP03",
     "searchString": "tsunomaki watame hbp03-071 #jp #gen4 #kemomimi #singing member sheep おかえり～: you may return 1 〈watamates〉 from your archive to hand. つのまきじゃんけん you may play rock-paper-scissors with your opponent until there's a winner:if you won, during this turn, this holomem gets red critical+30.."
   },
@@ -5428,12 +5620,14 @@
     "skills": [
       {
         "name": "わためぇ Night Fever!!",
+        "cost": "1 Yellow, 2 any color",
         "dmg": "80+",
         "description": "[Center position only] If 6 or more cheers are attached to this holomem, during this turn, this holomem and your collab holomem get Arts+100."
       }
     ],
     "hasAlternativeArt": true,
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP03",
     "searchString": "tsunomaki watame hbp03-072 #jp #gen4 #kemomimi #singing まだまだいくよー！: when this holomem is downed, you may reattach 1 cheer from this holomem to your other 〈tsunomaki watame〉.. わためぇ night fever!! [center position only] if 6 or more cheers are attached to this holomem, during this turn, this holomem and your collab holomem get arts+100."
   },
@@ -5448,15 +5642,18 @@
     "skills": [
       {
         "name": "こんリス",
+        "cost": "1 any color",
         "dmg": "20"
       },
       {
         "name": "ぷるぷる～",
+        "cost": "3 any color",
         "dmg": "60",
         "description": "You may reattach 1 cheer from this holomem to your 〈Inugami Korone〉."
       }
     ],
     "extraEffect": "You may include any number of this holomem in the deck.",
+    "batonTouch": 1,
     "setName": "hBP03",
     "searchString": "ayunda risu hbp03-073 #id #idgen1 #kemomimi #singing you may include any number of this holomem in the deck. こんリス  ぷるぷる～ you may reattach 1 cheer from this holomem to your 〈inugami korone〉."
   },
@@ -5471,11 +5668,13 @@
     "skills": [
       {
         "name": "繋がる願い",
+        "cost": "1 any color",
         "dmg": "20+",
         "description": "■If your stage has 〈Airani Iofifteen〉, this Arts gets +10.■If your stage has 〈Moona Hoshinova〉, this Arts gets +10."
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP03",
     "searchString": "ayunda risu hbp03-074 #id #idgen1 #kemomimi #singing 繋がる願い ■if your stage has 〈airani iofifteen〉, this arts gets +10.■if your stage has 〈moona hoshinova〉, this arts gets +10."
   },
@@ -5490,14 +5689,17 @@
     "skills": [
       {
         "name": "おつリスー",
+        "cost": "1 any color",
         "dmg": "30"
       },
       {
         "name": "おやすみの思い出",
+        "cost": "1 Yellow, 2 any color",
         "dmg": "70"
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP03",
     "searchString": "ayunda risu hbp03-075 #id #idgen1 #kemomimi #singing おつリスー  おやすみの思い出 "
   },
@@ -5513,10 +5715,12 @@
     "skills": [
       {
         "name": "ぷるぷる、おつリス！！！",
+        "cost": "1 any color",
         "dmg": 20
       }
     ],
     "hasFoils": true,
+    "batonTouch": 2,
     "setName": "hBP03",
     "searchString": "ayunda risu hbp03-076 #id #idgen1 #kemomimi #singing いやっほー！ みんな元気？: reveal 1 [green cheer or yellow cheer] from your cheer deck, and send it to your holomem. then, shuffle the cheer deck. ぷるぷる、おつリス！！！ "
   },
@@ -5532,10 +5736,12 @@
     "skills": [
       {
         "name": "ナッツ",
+        "cost": "1 Yellow, 1 any color",
         "dmg": 40
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP03",
     "searchString": "ayunda risu hbp03-077 #id #idgen1 #kemomimi #singing 同期の絆:if there are 5 or fewer holomems on your stage, you may reveal a debut holomem with #idgen1 from your deck and put it onto your stage. then shuffle your deck. ナッツ "
   },
@@ -5551,12 +5757,14 @@
     "skills": [
       {
         "name": "魔法の森のリスの女の子",
+        "cost": "1 Yellow, 2 any color",
         "dmg": 50,
         "description": "■If a green cheer is attached to this holomem, this Arts gets +50.■If a blue cheer is attached to this holomem, this Arts gets +50."
       }
     ],
     "hasAlternativeArt": true,
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP03",
     "searchString": "ayunda risu hbp03-078 #id #idgen1 #kemomimi #singing マジカルサポート:　you may reattach 1 cheer from your holomem with #id gen 1 to your other holomem. 魔法の森のリスの女の子 ■if a green cheer is attached to this holomem, this arts gets +50.■if a blue cheer is attached to this holomem, this arts gets +50."
   },
@@ -5572,12 +5780,14 @@
     "skills": [
       {
         "name": "サンライズエール",
+        "cost": "1 Yellow, 1 any color",
         "dmg": "50+",
         "description": "If 3 or more cheers are attached to this holomem, this Arts gets +30."
       }
     ],
     "hasAlternativeArt": true,
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP03",
     "searchString": "shiranui flare hbp03-079 #jp #gen3 #half-elf 今日はステキな日: reveal 1 yellow cheer from your cheer deck and send it to this holomem. then shuffle your cheer deck. サンライズエール if 3 or more cheers are attached to this holomem, this arts gets +30."
   },
@@ -5592,14 +5802,17 @@
     "skills": [
       {
         "name": "ドレミファソラシド～！",
+        "cost": "1 any color",
         "dmg": 20
       },
       {
         "name": "音楽家の卵！ 音乃瀬～奏で～～～す！",
+        "cost": "3 any color",
         "dmg": 50
       }
     ],
     "extraEffect": "You may include any number of this holomem in the deck.",
+    "batonTouch": 1,
     "setName": "hBP03",
     "searchString": "otonose kanade hbp03-080 #dev_is #regloss #singing you may include any number of this holomem in the deck. ドレミファソラシド～！  音楽家の卵！ 音乃瀬～奏で～～～す！ "
   },
@@ -5614,10 +5827,12 @@
     "skills": [
       {
         "name": "明日は月曜日～っ♪",
+        "cost": "1 any color",
         "dmg": 30
       }
     ],
     "hasFoils": true,
+    "batonTouch": 2,
     "setName": "hBP03",
     "searchString": "otonose kanade hbp03-081 #dev_is #regloss #singing 明日は月曜日～っ♪ "
   },
@@ -5633,10 +5848,12 @@
     "skills": [
       {
         "name": "ぷにぷにじゃないっ",
+        "cost": "1 Yellow, 2 any color",
         "dmg": 60
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP03",
     "searchString": "otonose kanade hbp03-082 #dev_is #regloss #singing ここが私のステージだから！:　you may reattach 1~2 cheers from your stage to this holomem. ぷにぷにじゃないっ "
   },
@@ -5653,11 +5870,13 @@
     "skills": [
       {
         "name": "歌姫 音乃瀬奏さん",
+        "cost": "1 Yellow, 3 any color",
         "dmg": 120
       }
     ],
     "extraEffect": "If this holomem is downed, you get Life-2.",
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP03",
     "searchString": "otonose kanade hbp03-083 #dev_is #regloss #singing なんちゅーこった: at the end of your opponent's performance phase, if your life was reduced during that performance phase, you may send 1 cheer from your archive to this holomem. if this holomem is downed, you get life-2. 歌姫 音乃瀬奏さん "
   },
@@ -6128,6 +6347,7 @@
         "dmg": "30"
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP04",
     "searchString": "hakui koyori hbp04-008 #jp #holox #kemomimi you may include any number of this holomem in the deck. こんこよ～ "
   },
@@ -6148,6 +6368,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP04",
     "searchString": "hakui koyori hbp04-009 #jp #holox #kemomimi 終わりなき輪廻に迷いし子らよ look at the top 3 cards of your deck. from among them, reveal one [debut holomem with the #holox or a support card with the #koyolab] and add it to your hand. then, return the remaining cards to the bottom of your deck in any order."
   },
@@ -6172,6 +6393,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP04",
     "searchString": "hakui koyori hbp04-010 #jp #holox #kemomimi 助手く～ん、なんかお疲れっぽい？  こよに添い寝される？ "
   },
@@ -6192,6 +6414,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP04",
     "searchString": "hakui koyori hbp04-011 #jp #holox #kemomimi 助手くんっ見ててね！ you may attach a <koyori's assistant-kun> from your archive to one of your other holomem named <hakui koyori?."
   },
@@ -6213,6 +6436,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP04",
     "searchString": "hakui koyori hbp04-012 #jp #holox #kemomimi はい！ はい！ はい！ はい！ : reveal 1 support card with #koyolabo from your deck and put it into your hand. then shuffle your deck. 助手くんとこよはずっと一緒だよ！ if this holomem has <koyori's assistant-kun> attached, draw 1 card from top of deck."
   },
@@ -6235,6 +6459,7 @@
     ],
     "hasFullArt": true,
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP04",
     "searchString": "hakui koyori hbp04-013 #jp #holox #kemomimi 絶対諦めない！ : when this holomem downs an opponent's holomem, put the top card of your deck into your holo power. then look at your holo power cards, reveal 1, and put it into your hand. then shuffle your holo power. かくせいのこより if this holomem has a support card with #koyolabo attached, reveal 1 support card with #koyolabo from your deck and put it into your hand. then shuffle your deck."
   },
@@ -6256,6 +6481,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP04",
     "searchString": "shirakami fubuki hbp04-014 #jp #gen1 #gamers #kemomimi #painting 戻っておいで: you may return 1-2 cards with #shirakamicharacter from your archive to hand. 私の大切な人 if there are any holomem with #gamers that are not named shirakami fubuki on your stage, this art gains +50 power."
   },
@@ -6278,6 +6504,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP04",
     "searchString": "irys hbp04-015 #en #promise #singing if this holomem is downed, you get life-2. the race queen for each of your holomem with #promise, this art gains +10 power. the maximum number of holomem counted for this effect is 4."
   },
@@ -6298,6 +6525,7 @@
         "description": "If there are 5 or fewer holomem on your stage, you may reveal 1 Spot holomem with #Justice from your deck and put it onto your stage. Then shuffle your deck."
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP04",
     "searchString": "raora panthera hbp04-016 #en #justice #kemomimi #painting you may include any number of this holomem in the deck. チアオーラ if there are 5 or fewer holomem on your stage, you may reveal 1 spot holomem with #justice from your deck and put it onto your stage. then shuffle your deck."
   },
@@ -6317,6 +6545,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP04",
     "searchString": "raora panthera hbp04-017 #en #justice #kemomimi #painting 正義のピンクパンサー "
   },
@@ -6337,6 +6566,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP04",
     "searchString": "raora panthera hbp04-018 #en #justice #kemomimi #painting 神眼の描き手 : the arts of one of your holomem with #painting gain +20 power until the end of this turn. 情報収集はお手の物 "
   },
@@ -6358,6 +6588,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP04",
     "searchString": "raora panthera hbp04-019 #en #justice #kemomimi #painting 只今、情報収集中　. : look at the top three cards of your deck. reveal one that is a holomem with #painting and put it into your hand. then put the remaining cards on the bottom of your deck in any order. art streamer [collab position only] if your center holomem has #painting, this art gains +80 power."
   },
@@ -6382,6 +6613,7 @@
         "dmg": "40"
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP04",
     "searchString": "juufuutei raden hbp04-020 #dev_is #regloss #alcohol you may include any number of this holomem in the deck. 儒烏風亭一門は前座見習い！  儒烏風亭らでんでございます！ "
   },
@@ -6402,6 +6634,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP04",
     "searchString": "juufuutei raden hbp04-021 #dev_is #regloss #alcohol あなたに学びと面白いをお届け : if you have played an event with #mushroom this turn, restore 20 hp to one of your holomem with #regloss. らでんスタンバイ "
   },
@@ -6426,6 +6659,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP04",
     "searchString": "juufuutei raden hbp04-022 #dev_is #regloss #alcohol 博識ツッコミ  まぁそんなとこですな "
   },
@@ -6446,6 +6680,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP04",
     "searchString": "juufuutei raden hbp04-023 #dev_is #regloss #alcohol reglossの賑やかし : if this holomem is downed during your opponent's turn, you may move 1 cheer from this holomem to one of your other holomem with #regloss. ネタ枠担当 "
   },
@@ -6467,6 +6702,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP04",
     "searchString": "juufuutei raden hbp04-024 #dev_is #regloss #alcohol 冷静沈着 : [center position only] during your opponent's main step, this holomem's hp cannot be changed or reduced by your opponent's abilities or effects. 喝采反芻 you may send 1 cheer from your archive to this holomem."
   },
@@ -6489,6 +6725,7 @@
     ],
     "hasFullArt": true,
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP04",
     "searchString": "juufuutei raden hbp04-025 #dev_is #regloss #alcohol 伝統と革新 : reveal 1 event card with #mushroom from your deck and put it into your hand. then shuffle your deck. 御後がよろしいようで if your oshi holomem is <juufuutei raden>, you may choose 2 of your back holomem and move 1 cheer from this holomem to each of them. if you do, this art gains +30 power."
   },
@@ -6510,6 +6747,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP04",
     "searchString": "ookami mio hbp04-026 #jp #gamers #kemomimi #cooking フブキは特別な存在 : if your oshi holomem is <shirakami fubuki>, reveal 1 white cheer from your cheer deck and send it to one of your holomem named <shirakami fubuki>. then shuffle your cheer deck. うちってフブキのものだったの？ if there are any holomem with #gamers that are not named ookami mio on your stage, this art gains +50 power."
   },
@@ -6530,6 +6768,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP04",
     "searchString": "pavolia reine hbp04-027 #id #idgen2 #bird #painting holoro : send the top card of your cheer deck to one of your holomem named <kureiji ollie> or <anya melfissa>. terima kasih "
   },
@@ -6549,6 +6788,7 @@
         "dmg": "30"
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP04",
     "searchString": "cecilia immergreen hbp04-028 #en #justice #language you may include any number of this holomem in the deck. 正義の調べ "
   },
@@ -6568,6 +6808,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP04",
     "searchString": "cecilia immergreen hbp04-029 #en #justice #language 『古代自動人形』 "
   },
@@ -6588,6 +6829,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP04",
     "searchString": "cecilia immergreen hbp04-030 #en #justice #language こんな旋律思いついたの: you may choose any 1-2 cheers on your stage, and move them between your holomem in any way you like. 聞いてくれる？ "
   },
@@ -6609,6 +6851,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP04",
     "searchString": "cecilia immergreen hbp04-031 #en #justice #language 海を越えたお茶会 : if there are any holomem on your opponent's stage with #jp or #id, this holomem's arts gain +30 power. マルチリンガル choose one of your back holomem with the #language. you may reveal one cheer card of the same color as the chosen holomem from your cheer deck and attach it to that holomem. then, shuffle your cheer deck."
   },
@@ -6628,6 +6871,7 @@
         "dmg": "30"
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP04",
     "searchString": "ichijou ririka hbp04-032 #dev_is #regloss #cooking #language you may include any number of this holomem in the deck. こんりり "
   },
@@ -6653,6 +6897,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP04",
     "searchString": "ichijou ririka hbp04-033 #dev_is #regloss #cooking #language 莉々華スタンバイ  リミットオーバー if you have used <genkai-meshi> this turn, deal 20 special damage to the opponent's collab holomem."
   },
@@ -6677,6 +6922,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP04",
     "searchString": "ichijou ririka hbp04-034 #dev_is #regloss #cooking #language let's dance  subscribe or die! "
   },
@@ -6698,6 +6944,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP04",
     "searchString": "ichijou ririka hbp04-035 #dev_is #regloss #cooking #language 限界飯料理人 : you may return 1 struggle meal from your archive to hand. 社長パンチ deal 20 special damage to your opponent's collab holomem."
   },
@@ -6719,6 +6966,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP04",
     "searchString": "ichijou ririka hbp04-036 #dev_is #regloss #cooking #language おいしいもの独り占め : deal 20 special damage to your opponent's collab holomem. いひひっ if this art is targeting your opponent's collab holomem, draw 1 card."
   },
@@ -6741,6 +6989,7 @@
     ],
     "hasFullArt": true,
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP04",
     "searchString": "ichijou ririka hbp04-037 #dev_is #regloss #cooking #language kpg : you may roll a dice: if the result is 4 or more, and your opponent has no collab holomem, they choose one of their back holomem and move it to the collab position (this is not treated as collabing). お？ 喧嘩する？ deal 50 special damage to the opponent's center holomem. afterwards, if you have used <genkai-meshi> this turn, deal 30 special damage to the opponent's center holomem or collab holomem."
   },
@@ -6762,6 +7011,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP04",
     "searchString": "houshou marine hbp04-038 #jp #gen3 #painting #sea どこ見ちゃってるのかな～！！♥♡ : deal 10 damage to your opponent's center and collab holomem. えっち♥♥ for each holomem stacked under this one, this art gains +20 power."
   },
@@ -6781,6 +7031,7 @@
         "dmg": "20"
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP04",
     "searchString": "kaela kovalskia hbp04-039 #id #idgen3 you may include any number of this holomem in the deck. おはエラ "
   },
@@ -6805,6 +7056,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP04",
     "searchString": "kaela kovalskia hbp04-040 #id #idgen3 when life is hard  dahlah "
   },
@@ -6825,6 +7077,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP04",
     "searchString": "kaela kovalskia hbp04-041 #id #idgen3 jdon my soul : you may return 1 tool from your archive to hand. サイレント笑い "
   },
@@ -6854,6 +7107,7 @@
     ],
     "hasAlternativeArt": true,
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP04",
     "searchString": "kaela kovalskia hbp04-042 #id #idgen3 if this holomem is downed, you get life-2. holoh3ro if there are any holomem with #idgen3 on your stage other than this holomem, draw 1 card. お墨付きの一品 if any of your holomem have a tool with #kaela'sarms attached, deal 30 special damage to your opponent's collab holomem."
   },
@@ -6876,6 +7130,7 @@
     ],
     "hasHolomenRare": true,
     "imageSet": "hBP06",
+    "batonTouch": 1,
     "setName": "hBP04",
     "searchString": "yukihana lamy hbp04-043 #jp #gen5 #half-elf #alcohol you may include any number of this holomem in the deck. こんらみ～ deal 10 damage any of your opponent's holomem. however, even if this downs that holomem, your opponent's life is not reduced."
   },
@@ -6896,6 +7151,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP04",
     "searchString": "yukihana lamy hbp04-044 #jp #gen5 #half-elf #alcohol snow flower : if you do not have a <yukihana lamy> that is attached with <yukimin>, you may reveal one <yukimin> from your deck and attach it to your <yukihana lamy>. then, shuffle your deck. うぅ…. "
   },
@@ -6920,6 +7176,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP04",
     "searchString": "yukihana lamy hbp04-045 #jp #gen5 #half-elf #alcohol おつらみ  ボスが攻略できな～い "
   },
@@ -6940,6 +7197,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP04",
     "searchString": "yukihana lamy hbp04-046 #jp #gen5 #half-elf #alcohol いっぱい頑張るよ！ if there are any holomem on your stage with a fan attached, deal 10 special damage to any of your opponent's holomem."
   },
@@ -6960,6 +7218,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP04",
     "searchString": "yukihana lamy hbp04-047 #jp #gen5 #half-elf #alcohol fleur : f you have a <yukihana lamy> equipped with <yukimin>, deal 20 special damage to one of your opponent's holomem. however, even if this downs that holomem, your opponent's life is not reduced. 雪が煌く花束 "
   },
@@ -6982,6 +7241,7 @@
     ],
     "hasFullArt": true,
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP04",
     "searchString": "yukihana lamy hbp04-048 #jp #gen5 #half-elf #alcohol ユニーリアの令嬢 : send the top card of your cheer deck to one of your <yukihana lamy> with a <yukimin> attached. 今日も祝福がありますように you may archive 1 of this holomem's cheer cards: deal 30 special damage to one of your opponent's center holomem or back holomem."
   },
@@ -7007,6 +7267,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP04",
     "searchString": "moona hoshinova hbp04-049 #id #idgen1 #singing 月と星のステージ  shining moon deal 20 special damage to one of your opponent's back holomem. if you have a holomem with a different color than this one on your stage, this arts gets an additional +50."
   },
@@ -7026,6 +7287,7 @@
         "dmg": "30"
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP04",
     "searchString": "shiori novella hbp04-050 #en #advent you may include any number of this holomem in the deck. しおり～ん！ "
   },
@@ -7050,6 +7312,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP04",
     "searchString": "shiori novella hbp04-051 #en #advent それって素敵な物語だと思わない？  尽きない知識欲 "
   },
@@ -7070,6 +7333,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP04",
     "searchString": "shiori novella hbp04-052 #en #advent 脱獄計画 : deal 20 special damage to one of your opponent's back holomem. holomem downed with this effect do not reduce life. 魅力的な物語 "
   },
@@ -7094,6 +7358,7 @@
     ],
     "hasFullArt": true,
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP04",
     "searchString": "shiori novella hbp04-053 #en #advent 禁断の知識 : send the top card of your cheer deck to one of your holomem with #en. if this holomem is downed, you get life-2. 思い出の栞 you may reveal the top card of your holo power. if the revealed card is a holomem with #en, deal 20 special damage to any of your opponent's holomem. then put the revealed card face down at the bottom of your holo power."
   },
@@ -7116,6 +7381,7 @@
     "hasHolomenRare": true,
     "imageSet": "hBP07",
     "hasFoils": true,
+    "batonTouch": 0,
     "setName": "hBP04",
     "searchString": "la+ darknesss hbp04-054 #jp #holox #shooter you may include any number of this holomem in the deck. 貴様ら、刮目せよ！！ "
   },
@@ -7137,6 +7403,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 0,
     "setName": "hBP04",
     "searchString": "la+ darknesss hbp04-055 #jp #holox #shooter そこに跪け！ : you may roll a dice. if the result is 3 or more, rest one of your opponent's back holomem. 我ら、エデンの星を統べる者！ this art gains +10 power for each of your opponent's holomem who are resting."
   },
@@ -7161,6 +7428,7 @@
       }
     ],
     "manualUrl": "https://hololive-official-cardgame.com/wp-content/images/cardlist/hBP04/hBP04-056_C_02.png",
+    "batonTouch": 1,
     "setName": "hBP04",
     "searchString": "la+ darknesss hbp04-056 #jp #holox #shooter いちごだいすき！  ぷらすめいと諸君いつもありがとう "
   },
@@ -7181,6 +7449,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 0,
     "setName": "hBP04",
     "searchString": "la+ darknesss hbp04-057 #jp #holox #shooter holox集合 : you may roll a die; return a #secret society holox holomem from your archive to your hand if you roll an odd number, or to the top of your deck if you roll an even number. 最高のステージ魅せてやるからな！！ "
   },
@@ -7201,6 +7470,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 0,
     "setName": "hBP04",
     "searchString": "la+ darknesss hbp04-058 #jp #holox #shooter 貴様の運命試してみるか？ : you may roll a dice 3 times. your opponent's center holomem takes 10 special damage for each odd result. 吾輩に勝つつもりか？ "
   },
@@ -7223,6 +7493,7 @@
     ],
     "hasFullArt": true,
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP04",
     "searchString": "la+ darknesss hbp04-059 #jp #holox #shooter yes my dark！ : you may archive 1 card from your hand to roll a die 3 times: for each time you roll an odd number, draw 1 card. your bloom effect 「yes my dark!」can only be used once per turn. 吾輩最強伝説 deal 10 special damage to your opponent's center holomem for each time you rolled a dice as part of your effects during this turn."
   },
@@ -7246,6 +7517,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP04",
     "searchString": "murasaki shion hbp04-060 #jp #gen2 エールリバース : you may send 1 cheer from your opponent's archive to their center holomem. if this holomem is downed, you get life-2. ゲーム配信中 deal 10 special damage to the opponent's center holomem and collab holomem for each cheer attached to the opponent's center holomem."
   },
@@ -7267,6 +7539,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP04",
     "searchString": "kureiji ollie hbp04-061 #id #idgen2 #language オリーを見てください！: when you bloom with your sp oshi skill <蘇るオリー>, fully recover the hp of one of your <kureiji ollie>. holoroの魂 this arts gets +20 for each other 2nd holomem with the #id2ndgen on your stage."
   },
@@ -7290,6 +7563,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP04",
     "searchString": "mori calliope hbp04-062 #en #myth #singing 永遠の休息 : [center or collab position only] while this holomem is attached with <mori calliope's scythe> or <death-sensei>, your center holomem with the #myth trait gets +30 to its arts. if this holomem is downed, you get life-2. 最期の一杯 look at the top 2 cards of your deck. archive 1 of them and place the remaining card on top of your deck."
   },
@@ -7310,6 +7584,7 @@
         "dmg": "20"
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP04",
     "searchString": "koseki bijou hbp04-063 #en #advent #baby キラキラ コセキ！ : during your opponent's turn, when this holomem is downed, draw 1 card. you may include any number of this holomem in the deck. ボンビジュー！ "
   },
@@ -7329,6 +7604,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 2,
     "setName": "hBP04",
     "searchString": "koseki bijou hbp04-064 #en #advent #baby 煌く宝石 "
   },
@@ -7350,6 +7626,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP04",
     "searchString": "koseki bijou hbp04-065 #en #advent #baby 絶世の輝き : you may archive a red cheer from any of your holomem for the following effect: draw 2 cards. 鉱石と採掘者 if there are any red cheers in your archive, this art gains +20."
   },
@@ -7372,6 +7649,7 @@
     ],
     "hasFullArt": true,
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP04",
     "searchString": "koseki bijou hbp04-066 #en #advent #baby 『感情結晶体』 : you may count the number of cards in your hand and archive your entire hand: for each card archived this way, draw 1 card from your deck. your bloom effect『感情結晶体』can only be used once per turn. この輝きが、伝わればいいな for each cheer in your opponent's archive, this art gains +10."
   },
@@ -7398,6 +7676,7 @@
     ],
     "hasHolomenRare": true,
     "imageSet": "hBP06",
+    "batonTouch": 1,
     "setName": "hBP04",
     "searchString": "oozora subaru hbp04-067 #jp #gen2 #bird you may include any number of this holomem in the deck. あじまる！ あじまる！  ちわーす！ ホロライブ2期生 大空スバルっス!! "
   },
@@ -7418,6 +7697,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP04",
     "searchString": "oozora subaru hbp04-068 #jp #gen2 #bird 大空スバル盛り合わせセット : [center or collab position only] this holomem takes -20 damage from your opponent's 1st bloom holomem. スバルからきみへ！ "
   },
@@ -7442,6 +7722,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 2,
     "setName": "hBP04",
     "searchString": "oozora subaru hbp04-069 #jp #gen2 #bird おはようスバル  眠いんデスケド "
   },
@@ -7462,6 +7743,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP04",
     "searchString": "oozora subaru hbp04-070 #jp #gen2 #bird 全力で頑張るから : choose one of your holomem. for the rest of this turn, the chosen holomem gets +10 arts for each cheer card attached to it (up to a maximum of 3 cards). いっぱい応援して、楽しんでね！ "
   },
@@ -7487,6 +7769,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP04",
     "searchString": "oozora subaru hbp04-071 #jp #gen2 #bird しゅばっ！ send the top card of your cheer deck to this holomem. 最強で楽しい毎日 "
   },
@@ -7509,6 +7792,7 @@
     ],
     "hasFullArt": true,
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP04",
     "searchString": "oozora subaru hbp04-072 #jp #gen2 #singing #bird サンライトステージ : you may send 1 yellow cheer from your archive to any of your holomem. 太陽少女 for each cheer in play between both players, this art gains +10 power. the maximum number of cheers counted for this effect is 8."
   },
@@ -7528,6 +7812,7 @@
         "dmg": "30"
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP04",
     "searchString": "anya melfissa hbp04-073 #id #idgen2 #language you may include any number of this holomem in the deck. おはよー！ "
   },
@@ -7548,6 +7833,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP04",
     "searchString": "anya melfissa hbp04-074 #id #idgen2 #language a day at the café : [center position only] damage taken by this holomem and your collab holomem is reduced by 10. 隣座りますか？ "
   },
@@ -7572,6 +7858,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 2,
     "setName": "hBP04",
     "searchString": "anya melfissa hbp04-075 #id #idgen2 #language 悪魔の招待  悪魔の囁き "
   },
@@ -7592,6 +7879,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP04",
     "searchString": "anya melfissa hbp04-076 #id #idgen2 #language 私から皆さんへの歌 : you may attach 1 ancient weapon from your archive to one of your <anya melfissa>. 応援、よろしくね！ "
   },
@@ -7612,6 +7900,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP04",
     "searchString": "anya melfissa hbp04-077 #id #idgen2 #language ガラス越しの庭園 : during your opponent's turn, when this holomem is downed, return one card from among the holomem stacked here (including this card) to your hand. 黄色い薔薇 "
   },
@@ -7633,6 +7922,7 @@
     ],
     "hasFullArt": true,
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP04",
     "searchString": "anya melfissa hbp04-078 #id #idgen2 #language 宝物みつけた: [center position / collab position only] the yellow (黄) cost required for the arts of your center holomem <anya melfissa> that has <ancient weapon> attached is reduced by 1. ダンジョンアドベンチャー "
   },
@@ -7653,6 +7943,7 @@
         "dmg": "10"
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP04",
     "searchString": "natsuiro matsuri hbp04-079 #jp #gen1 #shooter わっしょ～い! : if this holomem is downed during your opponent's turn, you may move 1 cheer from this holomem to one of your other holomem. you may include any number of this holomem in the deck. ホロライブの清楚担当 "
   },
@@ -7677,6 +7968,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 2,
     "setName": "hBP04",
     "searchString": "natsuiro matsuri hbp04-080 #jp #gen1 #shooter 夏色応援団  戦え！ 血を血で洗え！ "
   },
@@ -7697,6 +7989,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP04",
     "searchString": "natsuiro matsuri hbp04-081 #jp #gen1 #shooter 大好きな君に届くように : reveal 1 yellow cheer from your cheer deck and send it to this holomem. then shuffle your cheer deck. 全力で歌うよッ！！ "
   },
@@ -7719,6 +8012,7 @@
     ],
     "hasFullArt": true,
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP04",
     "searchString": "natsuiro matsuri hbp04-082 #jp #gen1 #shooter レッツ ショッピング! : you may roll a dice once for each of your differently-named holomem with #gen1. for each time the result is 4 or higher, send the top card of your cheer deck to this holomem. お気に入りみつけた for each cheer attached to this holomem, this art gains +20 power."
   },
@@ -7739,6 +8033,7 @@
         "description": "If there are 5 or fewer holomem on your stage, you may reveal 1 Debut holomem with #Gen5 from your deck and put it onto your stage. Then shuffle your deck."
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP04",
     "searchString": "momosuzu nene hbp04-083 #jp #gen5 #singing #painting you may include any number of this holomem in the deck. こんねね～ if there are 5 or fewer holomem on your stage, you may reveal 1 debut holomem with #gen5 from your deck and put it onto your stage. then shuffle your deck."
   },
@@ -7763,6 +8058,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 2,
     "setName": "hBP04",
     "searchString": "momosuzu nene hbp04-084 #jp #gen5 #singing #painting はぁ～ん  またねね "
   },
@@ -7783,6 +8079,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP04",
     "searchString": "momosuzu nene hbp04-085 #jp #gen5 #singing #painting 最高の気分!!!!!!!!!!!!!! : reveal 1 cheer from your cheer deck of the same color as one of your holomem with #gen5, and send that cheer to any of your holomem with #gen5. then shuffle your cheer deck. いっぱいがんばるぞい!!!!! "
   },
@@ -7809,6 +8106,7 @@
     ],
     "hasAlternativeArt": true,
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP04",
     "searchString": "momosuzu nene hbp04-086 #jp #gen5 #singing #painting ハズバンドいっぱい  ギラギラパワー this arts gets +20 for each cheer in your archive (up to a maximum of 5 cheers)."
   },
@@ -7829,6 +8127,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP04",
     "searchString": "elizabeth rose bloodflame hbp04-087 #en #justice #singing 『緋色の女王』: [collab position only] whenever your debut holomem takes damage while in the center position, it takes -20 damage. this holomem cannot bloom. erb "
   },
@@ -7849,6 +8148,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 0,
     "setName": "hBP04",
     "searchString": "gigi murin hbp04-088 #en #justice え？ でも面白かったじゃん！ : if this holomem is downed during your opponent's turn, send the top card of your cheer deck to any of your holomem. this holomem cannot bloom. 怒らないでよ! "
   },
@@ -8204,6 +8504,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP05",
     "searchString": "shirogane noel hbp05-008 #jp #gen3 #alcohol まっするまっする: [collab position only] your center debut holomem with #gen3 takes -20 damage. 楽しく！ "
   },
@@ -8224,6 +8525,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP05",
     "searchString": "shirogane noel hbp05-009 #jp #gen3 #alcohol 夏深し if you are going second and this is your first turn, reveal 1 1st <shirogane noel> from your deck, and add it to hand. then, shuffle the deck. 夏の思い出 "
   },
@@ -8245,6 +8547,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP05",
     "searchString": "shirogane noel hbp05-010 #jp #gen3 #alcohol 闘う団長 [collab position only]if your center holomem has #gen3, your opponent's holomem's arts can only target your collab holomem. however, this excludes special damage. 生きる力 if you have used a <gyudon> this turn, this arts gets +30."
   },
@@ -8266,6 +8569,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP05",
     "searchString": "shirogane noel hbp05-011 #jp #gen3 #alcohol みんなが居てくれて: during this turn, your [center holomem and collab holomem] with #gen3 get arts+10. 団長幸せだよ for each holomen on your stage with #gen3 and a different card name, this arts gets +10."
   },
@@ -8293,6 +8597,7 @@
     ],
     "hasFullArt": true,
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP05",
     "searchString": "shirogane noel hbp05-012 #jp #gen3 #alcohol 騎士団の道 if this holomem is damaged, this arts +40. 慈悲の一撃 [center position only] if your collab holomem has #gen3, this arts +30."
   },
@@ -8313,6 +8618,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP05",
     "searchString": "tokino sora hbp05-013 #jp #gen0 #singing ray of jewelry [center position/collab position only] all holomem with #gen0 on your stage get arts+30. 7周年いえーい✩°｡⋆⸜(*╹꒳ ╹* )⸝ "
   },
@@ -8333,6 +8639,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP05",
     "searchString": "usada pekora hbp05-014 #jp #gen3 #kemomimi かわいいぺこか？ you may roll a die once:if it is even, draw 1 card from your deck."
   },
@@ -8359,6 +8666,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP05",
     "searchString": "usada pekora hbp05-015 #jp #gen3 #kemomimi にんじん… if you have 3 or more holomem with #gen3 are on your stage, send the top card of your cheer deck to this holomem. いらないぺこ？ if your oshi holomem's color is white, draw 1 card from your deck."
   },
@@ -8382,6 +8690,7 @@
     "hasFullArt": true,
     "hasAlternativeArt": true,
     "hasSigned": true,
+    "batonTouch": 2,
     "setName": "hBP05",
     "searchString": "usada pekora hbp05-016 #jp #gen3 #kemomimi 最強女神: when this holomen uses an arts, if the total of the dice rolled for that arts is an odd number, draw 1 card from your deck. if it is an even number, draw 2 cards from your deck. ウーサペコラを崇めるぺこ you may roll a die once for each holomen card stacked under this holomen: for each 1 of the total result from the roll(s), this arts gets +10."
   },
@@ -8410,6 +8719,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP05",
     "searchString": "himemori luna hbp05-017 #jp #gen4 #baby if this holomem is downed, you get life-2. レトロロマン you may attach 1 <luknight> from your archive to this holomem. ぱくぱく [collab position only ]for each <luknight> attached to your center holomem, reduce the cheer cost of this arts by 1 colorless cheer."
   },
@@ -8437,6 +8747,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP05",
     "searchString": "vestia zeta hbp05-018 #id #idgen3 海に行こう！ if a buzz holomem with #idgen3 is on your stage, draw 1 card from your deck. summer vibes if your opponent's holomem is downed by this arts, reveal 1 1st holomem with #idgen3 from your deck,and add it to hand. then, shuffle the deck."
   },
@@ -8457,6 +8768,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP05",
     "searchString": "airani iofifteen hbp05-019 #id #idgen1 #painting イオフィとおでかけ: you may archive 1 cheer from this holomem:restore 30 hp to 1 of your holomem with #idgen1. 君といる時間 "
   },
@@ -8477,6 +8789,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP05",
     "searchString": "airani iofifteen hbp05-020 #id #idgen1 #painting 過去・今・未来の私と君へ: if you are going second and this is your first turn, send the top card of your cheer deck to your holomem with #idgen1. 君となら "
   },
@@ -8497,6 +8810,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP05",
     "searchString": "airani iofifteen hbp05-021 #id #idgen1 #painting hello beb!: you may send 1 cheer from your archive to this holomem. 抹茶めっちゃ好き ( ´ڡ`* ) "
   },
@@ -8517,6 +8831,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP05",
     "searchString": "airani iofifteen hbp05-022 #id #idgen1 #painting 落日に染まる: if there are 4 or more cheers on your stage, during this turn 1 of your holomem with #idgen1 gets arts+20. matahari terbenam "
   },
@@ -8539,6 +8854,7 @@
     ],
     "hasFullArt": true,
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP05",
     "searchString": "airani iofifteen hbp05-023 #id #idgen1 #painting 宇宙人のお姫様: when this holomem downs an opponent's holomem, you may send 1 cheer from your archive to your holomem with #idgen1. リレーションガーデン [center position only]if your oshi holomem is <airani iofifteen>, this arts gets +20 for every 3 cheers on your stage."
   },
@@ -8567,6 +8883,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP05",
     "searchString": "azki hbp05-024 #jp #gen0 #singing if this holomem is downed, you get life-2. あずきんちでゆっくりしよ if a <pioneers> is on your stage, send the top card of your cheer deck to your <azki>. 帰っちゃうの？ if your oshi holomem is <azki>, this arts gets +20 for each cheer attached to this holomem."
   },
@@ -8586,6 +8903,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP05",
     "searchString": "aki rosenthal hbp05-025 #jp #gen1 #half-elf #alcohol 新たな旅を始めよう "
   },
@@ -8606,6 +8924,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP05",
     "searchString": "aki rosenthal hbp05-026 #jp #gen1 #half-elf #alcohol トワイライトリゾート: you may attach 1 <stone axe> from your archive to your <aki rosenthal>. 暮れなずむひととき "
   },
@@ -8628,6 +8947,7 @@
     ],
     "hasFullArt": true,
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP05",
     "searchString": "aki rosenthal hbp05-027 #jp #gen1 #half-elf #alcohol ゲーム？ スポーティー？ キャンプ？！: you may archive 1 tool attached to this holomem:reveal 1 [holomem or tool] from your deck,and add it to hand. then, shuffle the deck. ワンフォーオール if your opponent's holomem is downed by this arts, draw 1 card from your deck. then, if your oshi holomem is <aki rosenthal>, restore 20 hp to all of your holomem."
   },
@@ -8651,6 +8971,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP05",
     "searchString": "shishiro botan hbp05-028 #jp #gen5 #kemomimi #shooter ちょっと頑張りました : [center position only][once per turn]when your oshi holomem <shishiro botan> or a <shishiro botan> on your stage deals 30 or more special damage to your opponent's holomem, draw 1 card from your deck. if this holomem is downed, you get life-2. ここからが俺たちのスタートだ you may archive 1 cheer from your <shishiro botan>:deal 30 special damage to your opponent's center holomem."
   },
@@ -8678,6 +8999,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP05",
     "searchString": "juufuutei raden hbp05-029 #dev_is #regloss #alcohol 誰かの為に生きてきたけど if your oshi holomem is <juufuutei raden>, reveal 1 event with #mushroom from your deck, and add it to hand. then, shuffle the deck. 漸く自分の人生を生きてる if a 2nd holomem with #regloss is on your stage, this arts gets +40."
   },
@@ -8698,6 +9020,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP05",
     "searchString": "omaru polka hbp05-030 #jp #gen5 #kemomimi まばゆい日常を君と ;during this turn, your center holomem with a fan attached gets arts+10. うたたねの記念日 "
   },
@@ -8718,6 +9041,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP05",
     "searchString": "omaru polka hbp05-031 #jp #gen5 #kemomimi あゝ素晴らしきアイドル人生かな if you are going second and this is your first turn, reveal 1 <troupe member> from your deck, and add it to hand. then, shuffle your deck."
   },
@@ -8739,6 +9063,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP05",
     "searchString": "omaru polka hbp05-032 #jp #gen5 #kemomimi ポルカとのなんでもない休日 :deal 20 special damage to your opponent's collab holomem. 朝のポルカ ※若干のフィクション you may archive 1 card from your hand:deal 10 damage to your opponent's center holomem or collab holomem."
   },
@@ -8765,6 +9090,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP05",
     "searchString": "omaru polka hbp05-033 #jp #gen5 #kemomimi すごいね、桜！ you may roll a die once:archive a number of cards from the top of your deck equal to the number rolled. then, if there are 10 or more cards in your archive, this arts gets +10. 来年も君と見に来たいな this arts gets +10 for each <troupe member> attached to this holomem."
   },
@@ -8787,6 +9113,7 @@
     ],
     "hasFullArt": true,
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP05",
     "searchString": "omaru polka hbp05-034 #jp #gen5 #kemomimi おまたせ～！: [center position only]you may archive any number of cards from your hand:for each card archived, return 1 <troupe member> from your archive to hand. are you ready？ if your oshi holomem is <omaru polka>, this arts gets +30 for every 10 cards in your archive."
   },
@@ -8808,6 +9135,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP05",
     "searchString": "sakura miko hbp05-035 #jp #gen0 #baby 今のはちょっとね、練習で… [center position/collab position only]usable during your opponent's turn if 1 of your <sakura miko> is downed:reveal 1 <miorehaji> from your deck, and add it to hand. then, shuffle the deck. あえんびえん you may archive 2 cards from your hand:deal 50 special damage to your opponent's center holomem or collab holomem. if there is a <35p> on your stage, draw 1 card from your deck."
   },
@@ -8828,6 +9156,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP05",
     "searchString": "hoshimachi suisei hbp05-036 #jp #gen0 #singing 声出し最高！ if any of your opponent's back holomem are damaged, this arts gets +20."
   },
@@ -8855,6 +9184,7 @@
     ],
     "hasFullArt": true,
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP05",
     "searchString": "hoshimachi suisei hbp05-037 #jp #gen0 #singing non-limit boost if a red cheer and a blue cheer are attached to this holomem, you may send 2 cheers from your archive to this holomem. if any cheers of only one of those colors are attached to this holomem, you may send 1 cheer from your archive to this holomem. shout in crisis archive all cheers attached to this holomem."
   },
@@ -8876,6 +9206,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP05",
     "searchString": "mococo abyssgard hbp05-038 #en #advent #kemomimi モココェ: [collab position only]when you use your sp oshi skill \"bau bau!\", during this turn this holomem gets arts+70. then, if a 2nd holomem is on your stage, during this turn this holomem gets arts+50. ノーーーーーーエ！ if your center holomem is <fuwawa abyssgard>, this arts can be used with no cheer requirement."
   },
@@ -8903,6 +9234,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP05",
     "searchString": "ichijou ririka hbp05-039 #dev_is #regloss #cooking #language 人生に手遅れとかないか if you have used a <struggle meal> this turn, deal 20 special damage to your opponent's center holomem and collab holomem. いつでも軌道修正できる if the target of this arts is a 1st or greater collab holomem, this arts gets +70."
   },
@@ -8925,6 +9257,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP05",
     "searchString": "micomet hbp05-040 #jp #gen0 #baby #singing ビジネスフレンド: if your life is 3 or less, you may bloom a holomem from your hand on your center <sakura miko> or <hoshimachi suisei> which has already bloomed this turn. this holomem is also regarded as <sakura miko> <hoshimachi suisei> ビジネスパートナー you may reattach 1 cheer from this holomem to your back holomem."
   },
@@ -8945,6 +9278,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP05",
     "searchString": "nekomata okayu hbp05-041 #jp #gamers #kemomimi ぐるぐる～ deal 10 special damage to your opponent's center holomem."
   },
@@ -8965,6 +9299,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP05",
     "searchString": "nekomata okayu hbp05-042 #jp #gamers #kemomimi 一緒に入ろ～！: if you are going second and this is your first turn, reveal 1 2nd holomem with #gamers from your deck, and add it to hand. then, shuffle the deck. ずうっと一緒だよ "
   },
@@ -8986,6 +9321,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP05",
     "searchString": "nekomata okayu hbp05-043 #jp #gamers #kemomimi 僕でよくな～い？: [collab position only]if your center holomem has #gamers, your opponent's holomem's arts can only target your collab holomem. however, this excludes special damage. まだまだ遊べるよね～？ you may archive 1 blue cheer from this holomem:deal 10 special damage to your opponent's center holomem and 1 of your opponent's back holomem."
   },
@@ -9007,6 +9343,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP05",
     "searchString": "nekomata okayu hbp05-044 #jp #gamers #kemomimi お弁当タイム…？: deal 10 special damage to your opponent's center holomem and 1 of their back holomem. you may only use the bloom effect \"lunchtime...?\" once per turn. ドンストップゲーミング！ deal 10 special damage to 1 of your opponent's holomem."
   },
@@ -9029,6 +9366,7 @@
     ],
     "hasFullArt": true,
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP05",
     "searchString": "nekomata okayu hbp05-045 #jp #gamers #kemomimi 自分らしく居られる場所: [center position only]your oshi holomem <nekomata okayu> and all <nekomata okayu> on your stage deal +20 damage when dealing special damage to your opponent's center holomem. 僕のコト、大好きになってみない？ deal 20 special damage to 1 of your opponent's holomem. then, you may send 1 cheer from your archive to your back holomem with #gamers."
   },
@@ -9050,6 +9388,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP05",
     "searchString": "yukihana lamy hbp05-046 #jp #gen5 #half-elf #alcohol ラミィちゃんしか～？: reveal 1 <yukimin> from your deck, and add it to hand. then, shuffle the deck. 愛せな～い！ if a 2nd holomem with #gen5 is on your stage, deal 20 special damage to 1 of your opponent's holomem."
   },
@@ -9070,6 +9409,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP05",
     "searchString": "kobo kanaeru hbp05-047 #id #idgen3 アットユアサービス！ deal 10 special damage to 1 of your opponent's back holomem."
   },
@@ -9091,6 +9431,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP05",
     "searchString": "kobo kanaeru hbp05-048 #id #idgen3 deal 10 special damage to 2 of your opponent's back holomem. キミが元気になれるように deal 10 special damage to 2 of your opponent's back holomem."
   },
@@ -9118,6 +9459,7 @@
     ],
     "hasFullArt": true,
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP05",
     "searchString": "kobo kanaeru hbp05-049 #id #idgen3 雨跡をなぞ if your opponent's back holomem have taken a total of 80 or more damage, you may send 1 blue cheer from your archive to your <kobo kanaeru>. 残響する雨音 you may archive 2 cheers from this holomem:deal 30 special damage to all of your opponent's back holomem. however, your opponent's life does not reduce even if downed."
   },
@@ -9141,6 +9483,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP05",
     "searchString": "fuwawa abyssgard hbp05-050 #en #advent #kemomimi モゴジャ～～ン！！！: [center position only]when you use your oshi skill \"moco-chan!\", send the top card of your cheer deck to your holomem with #advent. if this holomem is downed, you get life-2. キーボードクラッシャー if your <mococo abyssgard> has performed arts this turn, this arts gets +40. if you have also used your oshi skill \"moco-chan!\" this turn, this arts gets +30."
   },
@@ -9162,6 +9505,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP05",
     "searchString": "hiodoshi ao hbp05-051 #dev_is #regloss #painting #alcohol 僕の目だけ見て: look at the top 3 cards of your deck. reveal 1 holomem with #alcohol from among them, and add it to hand. then, put the remaining cards on the bottom of your deck in any order. シャンパンシャンパン！ if there are 3 or more holomem with #alcohol on your stage, you may send 1 cheer from your archive to your back holomem with #alcohol."
   },
@@ -9182,6 +9526,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP05",
     "searchString": "yuzuki choco hbp05-052 #jp #gen2 #cooking 秘密の保健室: if there are any events in your archive, deal 10 special damage to your opponent's center holomem. 膝枕とかどうですか？ "
   },
@@ -9202,6 +9547,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP05",
     "searchString": "yuzuki choco hbp05-053 #jp #gen2 #cooking すうすう…: if you are going second, this is your first turn, and your oshi holomem is <yuzuki choco>, draw 2 cards from your deck. ぎゅーってして？ "
   },
@@ -9222,6 +9568,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP05",
     "searchString": "yuzuki choco hbp05-054 #jp #gen2 #cooking ガァチィ？ if you have used 2 or more events with #food this turn, this arts can be used with no cheer requirement."
   },
@@ -9242,6 +9589,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 0,
     "setName": "hBP05",
     "searchString": "yuzuki choco hbp05-055 #jp #gen2 #cooking 寝坊助悪魔: [center position only]at the end of your opponent's performance phase, if this holomem is undamaged, you may send the top card of your cheer deck to your <yuzuki choco>. ｱﾞｱﾞｱﾞｱﾞｱﾞ "
   },
@@ -9269,6 +9617,7 @@
     ],
     "hasFullArt": true,
     "hasAlternativeArt": true,
+    "batonTouch": 1,
     "setName": "hBP05",
     "searchString": "yuzuki choco hbp05-056 #jp #gen2 #cooking 愛を込めて this arts gets +20 for each event with #food you have used this turn. however, only up to 2 cards are counted. 夜に寄り添う you may archive 2 cards from your hand:return 1 holomem with #cooking from your archive to hand."
   },
@@ -9289,6 +9638,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP05",
     "searchString": "nerissa ravencroft hbp05-057 #en #advent #singing #bird going out!: during this turn, 1 of your holomem with #singing gets arts+10. cool summer nights "
   },
@@ -9309,6 +9659,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 0,
     "setName": "hBP05",
     "searchString": "nerissa ravencroft hbp05-058 #en #advent #singing #bird sugoidekai: if you are going second, this is your first turn, and your oshi holomem is <nerissa ravencroft>, put the top card of your deck to holo dmg. byeya darlings! "
   },
@@ -9334,6 +9685,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP05",
     "searchString": "nerissa ravencroft hbp05-059 #en #advent #singing #bird ワンアンドオンリー if your oshi holomem is <nerissa ravencroft>, draw 1 card from your deck. ツノに触らないで！ "
   },
@@ -9355,6 +9707,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP05",
     "searchString": "nerissa ravencroft hbp05-060 #en #advent #singing #bird 月の光: reveal 1 [<nerissa ravencroft's staff> or <jailbird>] from your deck, and add it to hand. then, shuffle the deck. 艶なる宴 you may archive 1 card from your hand:deal 20 special damage to your opponent's center holomem or collab holomem."
   },
@@ -9377,6 +9730,7 @@
     ],
     "hasFullArt": true,
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP05",
     "searchString": "nerissa ravencroft hbp05-061 #en #advent #singing #bird deo: when this holomem downs your opponent's holomem, draw 2 cards from your deck. unleashed charm you may archive 1~3 cards from your hand:during this turn, 1 of your holomem with #singing gets arts+20 for each card archived."
   },
@@ -9399,6 +9753,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP05",
     "searchString": "tokoyami towa hbp05-062 #jp #gen4 #singing #shooter 友達がいっぱい増えたよ: reveal 2 1st holomem other than buzz from your deck with #singing, and add them to hand. then, shuffle your deck. ありがとうみんな deal 20 special damage for each of your 1st holomem with #singing to your opponent's center holomem or collab holomem."
   },
@@ -9419,6 +9774,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP05",
     "searchString": "shiranui flare hbp05-063 #jp #gen3 #half-elf おうちでまったり: you may archive 1 cheer from this holomem:reveal 1 debut holomem from your deck with a different name from all holomem on your stage, and add it to hand. then, shuffle the deck. キミも一緒にゲームしない？ "
   },
@@ -9439,6 +9795,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP05",
     "searchString": "shiranui flare hbp05-064 #jp #gen3 #half-elf canvas: if you are going second and this is your first turn, reveal 2 debut holomem with different names from your deck, and add them to hand. then, shuffle the deck. 幸せの場所 "
   },
@@ -9459,6 +9816,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP05",
     "searchString": "shiranui flare hbp05-065 #jp #gen3 #half-elf 幸運の石: [collab position only][once per turn]if your other holomem would take damage from your opponent, you may roll a die once:if it is odd, that holomem takes -40 damage. if it is even, that holomem takes -20 damage. それは嘘じゃん！ "
   },
@@ -9480,6 +9838,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP05",
     "searchString": "shiranui flare hbp05-066 #jp #gen3 #half-elf 冬の旅: [collab position only]when your center holomem with #gen3 uses arts, you may archive 1 card from your hand:draw 1 card from your deck. 氷姿雪魄 this arts gets +10 for each differently-named holomem with #gen3 on your stage."
   },
@@ -9502,6 +9861,7 @@
     ],
     "hasFullArt": true,
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP05",
     "searchString": "shiranui flare hbp05-067 #jp #gen3 #half-elf カラフルストリーム: when this holomem uses arts, you may reattach 2 cheers from this holomem to 1 of your back holomem. then, return 1 1st holomem from your archive with the same name as the holomem that received the cheers to your hand. みんなに笑っててほしいから you may roll a die once:if it is greater than or equal to your current life, the arts gets +60. if it is less than or equal to your current life, draw 1 card from your deck."
   },
@@ -9522,6 +9882,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP05",
     "searchString": "shirakami fubuki hbp05-068 #jp #gen1 #gamers #kemomimi #painting ゆるゆる休養日: if a mascot is attached to this holomem, look at the top card of your deck. return that card to the top or bottom of the deck. おやつ食べてゲーム最高！ "
   },
@@ -9543,6 +9904,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP05",
     "searchString": "shirakami fubuki hbp05-069 #jp #gen1 #gamers #kemomimi #painting とびきりの笑顔: [back position only]this holomem does not take any damage from your opponent. 満点じゃい！ you may send the top card of your cheer deck to this holomem."
   },
@@ -9570,6 +9932,7 @@
     ],
     "hasFullArt": true,
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP05",
     "searchString": "shirakami fubuki hbp05-070 #jp #gen1 #gamers #kemomimi #painting フブキカフェにようこそ you may choose any number of [mascots and fans] with #shirakamicharacter from your archive, and attach them to your holomem. 国王兼喫茶経営者 if [your oshi holomem is <shirakami fubuki> or your oshi holomem's color is yellow], and there are 4 or more [tools, mascots, and fans] on your stage, this arts gets +100."
   },
@@ -9592,6 +9955,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP05",
     "searchString": "inugami korone hbp05-071 #jp #gamers #kemomimi 戌神族: reveal 1 1st holomem other than buzz from your deck with #gamers, and add it to hand. then, shuffle the deck. yb-2 during this turn, 1 of your holomem with #gamers gets arts+30."
   },
@@ -9620,6 +9984,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP05",
     "searchString": "tsunomaki watame hbp05-072 #jp #gen4 #kemomimi #singing if this holomem is downed, you get life-2. 君と色違いのリュック [center position only]if 4 or more cheers are attached to this holomem, during this turn this holomem and your collab holomem get arts+50. わためと海辺デート if your oshi holomem is <tsunomaki watame>, you may send the top card of your cheer deck to your <tsunomaki watame>."
   },
@@ -9641,6 +10006,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP05",
     "searchString": "ayunda risu hbp05-073 #id #idgen1 #kemomimi #singing brrrr: look at the top 3 cards of your cheer deck. reveal 1 cheer from among them, and send it to your <ayunda risu>. then, return the remaining cards to the bottom of the cheer deck in any order. then, draw 1 card from your deck. it's time to re4ge !!!!! if your oshi holomem is <ayunda risu>, this arts gets +10 for each cheer attached to your holomem with #idgen1. however, only up to 10 cheers are counted."
   },
@@ -9972,6 +10338,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP06",
     "searchString": "raora panthera hbp06-009 #en #justice #kemomimi #painting big pink cat: [center position only]your collab holomem takes -10 damage. i see you! "
   },
@@ -9991,6 +10358,7 @@
         "dmg": "30"
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP06",
     "searchString": "raora panthera hbp06-010 #en #justice #kemomimi #painting 夢みたいな最高のチーム: if you are going second and this is your first turn, reveal 1 [debut holomem or spot holomem] from your deck, and place it on stage. then, shuffle the deck. we're all great friends! "
   },
@@ -10011,6 +10379,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP06",
     "searchString": "raora panthera hbp06-011 #en #justice #kemomimi #painting raorao: reveal 1 [debut holomem or 1st holomem] from your deck with #justice, and add it to hand. then, shuffle the deck. mamma mia "
   },
@@ -10036,6 +10405,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 2,
     "setName": "hBP06",
     "searchString": "raora panthera hbp06-012 #en #justice #kemomimi #painting the real queen is here!  la fine draw 2 cards."
   },
@@ -10058,6 +10428,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP06",
     "searchString": "raora panthera hbp06-013 #en #justice #kemomimi #painting catch all chattini around the world!!!: reveal 1 <chattino> from your deck, and add it to hand. then, shuffle the deck. 一緒に世界を征服しよう！ [center position only]during this turn, your collab holomem with #painting gets arts+20."
   },
@@ -10080,6 +10451,7 @@
     ],
     "hasFullArt": true,
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP06",
     "searchString": "raora panthera hbp06-014 #en #justice #kemomimi #painting 夢紡ぎのアトリエ: when this holomem uses arts, look at your holo power. reveal 1 card from among them, and add it to hand. if you added a card to hand, put 1 card from your hand to holo power, then shuffle your holo power. 色彩のリナシメント [center position only]during this turn, your collab holomem with #painting gets arts+50, and the cheer cost of that holomem's arts is reduced by 1 colorless cheer."
   },
@@ -10101,6 +10473,7 @@
     ],
     "hasHolomenRare": true,
     "imageSet": "hBP06",
+    "batonTouch": 1,
     "setName": "hBP06",
     "searchString": "isaki riona hbp06-015 #dev_is #flowglow you may include any number of this holomem in the deck okae-riona~ "
   },
@@ -10120,6 +10493,7 @@
         "dmg": "20"
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP06",
     "searchString": "isaki riona hbp06-016 #dev_is #flowglow 一緒に共闘しよ: if you are going second and this is your first turn, reveal 1 [holomem with a collab effect and #flow glow] from your deck, and add it to hand. then, shuffle the deck. おつりおなああああ！ "
   },
@@ -10144,6 +10518,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP06",
     "searchString": "isaki riona hbp06-017 #dev_is #flowglow 夢はアリーナでするライブ  タイフーン起こすこのホロライブ "
   },
@@ -10165,6 +10540,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP06",
     "searchString": "isaki riona hbp06-018 #dev_is #flowglow tflow glowのリーダー: during this turn, 1 of your holomem with #flow glow gets arts+20. brr! brr! archive the top card of your deck."
   },
@@ -10186,6 +10562,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP06",
     "searchString": "isaki riona hbp06-019 #dev_is #flowglow ストイック負けず嫌い王: nif your oshi holomem is <isaki riona>, you may archive the top card of your deck:draw 1 card. 意外と熱血タイプ？ archive the top card of your deck."
   },
@@ -10208,6 +10585,7 @@
     ],
     "hasFullArt": true,
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP06",
     "searchString": "isaki riona hbp06-020 #dev_is #flowglow 意志の指揮者　: if this holomem is downed during your opponent's turn, you may archive the top 2 cards of your deck. if you do, draw 1 card from your deck for each differently-named holomem with #flow glow on your stage. レゾナンスロア archive 1~3 cards from the top of your deck. this arts gets +20 for each card archived."
   },
@@ -10229,6 +10607,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP06",
     "searchString": "hakui koyori hbp06-021 #jp #holox #kemomimi 君に届けっ:during this turn, 1 of your holomem with #holox gets arts+30. if this holomem has a support card with #koyolabo attached, that holomem gets arts+50 instead. 青春の１ページ you may return a support card with #koyolabo from your archive to the bottom of your deck:this arts gets +40."
   },
@@ -10248,6 +10627,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP06",
     "searchString": "kazama iroha hbp06-022 #jp #holox 手作りのお守り "
   },
@@ -10268,6 +10648,7 @@
         "dmg": "30"
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP06",
     "searchString": "kazama iroha hbp06-023 #jp #holox ホップすてっぷジャンプ！: if you are going second and this is your first turn, reveal 1 buzz <kazama iroha> from your deck, and add it to hand. then, shuffle the deck. gozagoza536 "
   },
@@ -10287,6 +10668,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 2,
     "setName": "hBP06",
     "searchString": "kazama iroha hbp06-024 #jp #holox まじかる☆ござるの元気の出る魔法 "
   },
@@ -10307,6 +10689,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP06",
     "searchString": "kazama iroha hbp06-025 #jp #holox のんびり過ごす記念日: [center position or collab position only]your holomem with #holox other than this holomem get arts+20. ツンツンツン… "
   },
@@ -10329,6 +10712,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP06",
     "searchString": "kazama iroha hbp06-026 #jp #holox 元気をお届け！: [center position only]when your holomem collabs, if you have 5 or more cards in your hand, you may send the top card of your cheer deck to your collab holomem. if this holomem is downed, you get life-2 喜んでもらえたらいいな "
   },
@@ -10352,6 +10736,7 @@
     ],
     "hasFullArt": true,
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP06",
     "searchString": "kazama iroha hbp06-027 #jp #holox 伝えたい想い: when this holomem downs your opponent's center holomem, you may bloom 1 of your <kazama iroha> that bloomed this turn once more using a holomem from your hand. 一緒にすてっぷ if your oshi holomem is <kazama iroha>, and you have a collab holomem, this arts gets +40. also, if this holomem has bloomed from a buzz holomem, damage from this arts cannot be reduced."
   },
@@ -10371,6 +10756,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP06",
     "searchString": "himemori luna hbp06-028 #jp #gen4 #baby んなあああああい "
   },
@@ -10396,6 +10782,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP06",
     "searchString": "himemori luna hbp06-029 #jp #gen4 #baby 祝祭 if there is a fan attached to your holomem, you may send the top card of your cheer deck to this holomem. ロイヤル・フラワーブーケ "
   },
@@ -10417,6 +10804,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP06",
     "searchString": "himemori luna hbp06-030 #jp #gen4 #baby みんなへ感謝の気持ち: [collab position only]during your opponent's turn, when you would archive a <lu-knights> attached to your center holomem, you may reattach it to your back <himemori luna> instead. 届けたいのら！ you may attach 1 <lu-knights> from your archive to your <himemori luna>."
   },
@@ -10439,6 +10827,7 @@
     ],
     "hasFullArt": true,
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP06",
     "searchString": "himemori luna hbp06-031 #jp #gen4 #baby んなっしょい！: if your oshi holomem is <himemori luna>, you may archive 1~2 <lu-knights> on your stage:for each card archived, send the top card of your cheer deck to 1 of your <himemori luna>. ずっと一緒なのらね if 2 or more <lu-knights> are attached to this holomem, this arts gets +50."
   },
@@ -10459,6 +10848,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP06",
     "searchString": "cecilia immergreen hbp06-032 #en #justice #language for! justice!: send the top card of your cheer deck to your other holomem with #justice. 春の思い出 "
   },
@@ -10480,6 +10870,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP06",
     "searchString": "juufuutei raden hbp06-033 #dev_is #regloss #alcohol 濡羽色のほころび: if you have used an event with #mushroom this turn, draw 2 cards. you may only use bloom effect \"wet feather-colored cracks\" once per turn. 茸 （くさびら) you may send 1 cheer from your archive to your holomem with #regloss."
   },
@@ -10500,6 +10891,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 0,
     "setName": "hBP06",
     "searchString": "nakiri ayame hbp06-034 #jp #gen2 #shooter 夏の海でドキドキデート you may archive 1 card from your hand:your center <nakiri ayame> gets arts+30."
   },
@@ -10519,6 +10911,7 @@
         "dmg": "20"
       }
     ],
+    "batonTouch": 0,
     "setName": "hBP06",
     "searchString": "nakiri ayame hbp06-035 #jp #gen2 #shooter かわ余: if you are going second and this is your first turn, reveal 1 [tool, mascot, or fan] from your deck and attach it to your <nakiri ayame>. then, shuffle the deck. …二度寝する(:3_ヽ)_ "
   },
@@ -10540,6 +10933,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP06",
     "searchString": "nakiri ayame hbp06-036 #jp #gen2 #shooter まったり夜桜温泉デート: reveal 1 [<asura & rakshasa>, <demonic sword \"asura\">, or <poyoyo>] from your deck, and add it to hand. then, shuffle the deck. お風呂上がりの幸せな時間 you may archive the top card of your cheer deck:draw 1 card."
   },
@@ -10561,6 +10955,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP06",
     "searchString": "nakiri ayame hbp06-037 #jp #gen2 #shooter お参りデート:you may return 2 red cheers from your archive to the bottom of your cheer deck in any order. ずっと元気でいられますように…. you may archive the top card of your cheer deck:deal 30 damage to your opponent's center holomem or collab holomem."
   },
@@ -10582,6 +10977,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP06",
     "searchString": "nakiri ayame hbp06-038 #jp #gen2 #shooter たまに増える余: you may archive the top card of your cheer deck:return 1 <nakiri ayame> from your archive to hand. では参る！ you may archive the top card of your cheer deck:deal 20 special damage to your opponent's center holomem or collab holomem."
   },
@@ -10604,6 +11000,7 @@
     ],
     "hasFullArt": true,
     "hasAlternativeArt": true,
+    "batonTouch": 0,
     "setName": "hBP06",
     "searchString": "nakiri ayame hbp06-039 #jp #gen2 #shooter 余、なんも聞いとらんかった。: [center position only]if you have a collab holomem and your opponent does not have a collab holomem, all of your holomem take no arts damage from your opponent. 百鬼乱舞 -朧月- if your oshi holomem is <nakiri ayame>, you may archive 1~3 cards from the top of your cheer deck:this arts gets +40 for each card archived. this arts may not be used from the collab position unless your life is 2 or less."
   },
@@ -10624,6 +11021,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP06",
     "searchString": "hakos baelz hbp06-040 #en #promise #kemomimi you can do it! roll a die once. if it is odd, deal 10 special damage to your opponent's center holomem and collab holomem."
   },
@@ -10643,6 +11041,7 @@
         "dmg": "30"
       }
     ],
+    "batonTouch": 0,
     "setName": "hBP06",
     "searchString": "hakos baelz hbp06-041 #en #promise #kemomimi gym rat: if you are going second and this is your first turn, draw 3 cards, then archive 2 cards from your hand. brat wellness "
   },
@@ -10664,6 +11063,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP06",
     "searchString": "hakos baelz hbp06-042 #en #promise #kemomimi strawberry princess: archive 1 card from your hand. then, draw 1 card. イチゴで彩る誕生日 you may archive 2 cards from your hand:this arts gets +20."
   },
@@ -10684,6 +11084,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP06",
     "searchString": "hakos baelz hbp06-043 #en #promise #kemomimi once a peasant,: you may archive 1 holomem with #promise from your hand:deal 30 special damage to your opponent's center holomem or collab holomem. always a peasant. "
   },
@@ -10709,6 +11110,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP06",
     "searchString": "hakos baelz hbp06-044 #en #promise #kemomimi ホイールオブフォーチュン if you have used your sp oshi skill \"🎲ǝnoz n∩ⅎ ǝh⊥ o⊥ ǝwoͻ˥ǝm🎲\" this game, roll a die once. this arts gets +10x the number rolled. ありがチュー！ "
   },
@@ -10736,6 +11138,7 @@
     ],
     "hasFullArt": true,
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP06",
     "searchString": "hakos baelz hbp06-045 #en #promise #kemomimi カオスリローデッドd return 1~5 holomem from your archive to the bottom of your deck in any order. this arts gets +10 for each holomem returned. 💥¡¡ssꓵhɔsꓶǝԁԁoꓷ💥 if you have used your sp oshi skill \"🎲ǝnoz n∩ⅎ ǝh⊥ o⊥ ǝwoͻ˥ǝm🎲\" this game, deal 100 special damage to your opponent's center holomem or collab holomem."
   },
@@ -10757,6 +11160,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP06",
     "searchString": "takane lui hbp06-046 #jp #holox #bird #alcohol 間違っているぞ！: if you have used your sp oshi skill \"hawkeye\" this game, this holomem has arts+20. 永久不滅の絆 if your oshi holomem is <takane lui>, you may archive 2 cards from your hand:deal 50 special damage to your opponent's center holomem or collab holomem."
   },
@@ -10778,6 +11182,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP06",
     "searchString": "ichijou ririka hbp06-047 #dev_is #regloss #cooking #language 家にあるもの限界飯:if your oshi holomem is <ichijou ririka> and there are 2 or more <struggle meal> in your archive, draw 2 cards. ガチでなんもない。タスケテ。 [collab position only]deal 50 damage to your opponent's collab holomem. if your opponent has no collab holomem, deal 50 damage to your opponent's center holomem instead."
   },
@@ -10798,6 +11203,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP06",
     "searchString": "moona hoshinova hbp06-048 #id #idgen1 #singing ムーンペース if a non-blue cheer is attached to this holomem, deal 10 special damage to 1 of your opponent's back holomem. however, your opponent's life does not reduce even if downed."
   },
@@ -10817,6 +11223,7 @@
         "dmg": "20"
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP06",
     "searchString": "moona hoshinova hbp06-049 #id #idgen1 #singing 青い琥珀: if you are going second and this is your first turn, reveal 1 blue cheer from your cheer deck and send it to your <moona hoshinova>. then, shuffle the cheer deck. 星々の踊り "
   },
@@ -10842,6 +11249,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP06",
     "searchString": "moona hoshinova hbp06-050 #id #idgen1 #singing 2 sides of the moon deal 10 special damage to 1 of your opponent's back holomem. lunar duality "
   },
@@ -10867,6 +11275,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP06",
     "searchString": "moona hoshinova hbp06-051 #id #idgen1 #singing スプリングパーティー  親愛の情 if your oshi holomem is <moona hoshinova>, you may archive 1 cheer from this holomem:draw 1 card."
   },
@@ -10890,6 +11299,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP06",
     "searchString": "moona hoshinova hbp06-052 #id #idgen1 #singing 新月: usable when this holomem deals arts damage to your opponent's holomem:deal the same amount of special damage to the chosen holomem as the amount of damage taken by that holomem. if this holomem is downed, you get life-2 下弦の月 if your oshi holomem is <moona hoshinova> and 4 or more cheers are attached to this holomem, this arts gets +60."
   },
@@ -10912,6 +11322,7 @@
     ],
     "hasFullArt": true,
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP06",
     "searchString": "moona hoshinova hbp06-053 #id #idgen1 #singing 星の運命: choose your opponent's center holomem or collab holomem. deal the same amount of special damage to the chosen holomem as the amount of damage taken by that holomem. tidal eclipse if 4 or more cheers are attached to this holomem, deal 90 special damage to your opponent's center holomem or collab holomem."
   },
@@ -10933,6 +11344,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP06",
     "searchString": "yukihana lamy hbp06-054 #jp #gen5 #half-elf #alcohol 有言実行！！: if this holomem has a <yukimin> attached, deal 20 special damage to your opponent's center holomem and draw 1 card. if this holomem has 3 or more <yukimin> attached, draw 2 cards instead. 暖かい誕生日とその先へ this arts gets +10 for each <yukimin> attached to this holomem."
   },
@@ -10954,6 +11366,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP06",
     "searchString": "sakamata chloe hbp06-055 #jp #holox #sea ワンワーーン！！！: if your oshi holomem is <murasaki shion>, send 3 cheers from your opponent's archive to your opponent's center holomem. then, you may send 1 cheer from your archive to your <murasaki shion>. 二人で紡いだ魔法 reveal the top 4 cards of your deck. this arts gets +20 for each holomem revealed. then, archive the revealed cards. if there is an event among them, draw 2 cards."
   },
@@ -10975,6 +11388,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP06",
     "searchString": "sakamata chloe hbp06-056 #jp #holox #sea ギャル叉と登校: f you have used your sp oshi skill \"life reset button\" this game, this holomem's arts \"spend your youth with sakamata?\" has its cost reduced by 1 colorless cheer. 沙花叉と青春しよ？ reveal the top 6 cards of your deck. this arts gets +20 for each holomem revealed. then, archive the revealed cards."
   },
@@ -10995,6 +11409,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP06",
     "searchString": "mori calliope hbp06-057 #en #myth #singing mori's underground live draw 1 card, then archive 1 card from your hand."
   },
@@ -11016,6 +11431,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP06",
     "searchString": "mori calliope hbp06-058 #en #myth #singing yes, chef.: draw 3 cards, then archive 2 cards from your hand. a chef's journey's end. if a purple cheer is attached to this holomem, draw 1 card from your deck. then, archive the top 2 cards of your deck."
   },
@@ -11036,6 +11452,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP06",
     "searchString": "mori calliope hbp06-059 #en #myth #singing お泊りパーリナイ!: if you have 3 or more holomem with #en on your stage, reveal 1 [blue cheer or purple cheer] from your cheer deck, and send it to your holomem. then, shuffle the cheer deck. まどろみの中で "
   },
@@ -11063,6 +11480,7 @@
     ],
     "hasFullArt": true,
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP06",
     "searchString": "mori calliope hbp06-060 #en #myth #singing bull's-eye!!!! if your oshi holomem is <mori calliope>, you may archive the top 2 cards of your deck. if you do, send the top card of your cheer deck to your holomem. memento mori. during this turn, 1 of your holomem with #myth gets arts+20. then, if your oshi holomem is <mori calliope> and you have 8 or more holomem in your archive, you may draw 1 card."
   },
@@ -11083,6 +11501,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP06",
     "searchString": "robocosan hbp06-061 #jp #gen0 #shooter ボクと過ごす甘いひと if a <roboser> is attached to this holomem, deal 20 special damage to your opponent's center holomem."
   },
@@ -11102,6 +11521,7 @@
         "dmg": "30"
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP06",
     "searchString": "robocosan hbp06-062 #jp #gen0 #shooter ロボ子と一緒にあそぼ: if you are going second and this is your first turn, reveal 2 <roboser> from your deck, and add them to hand. then, shuffle the deck. ひとりじゃないよ "
   },
@@ -11122,6 +11542,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP06",
     "searchString": "robocosan hbp06-063 #jp #gen0 #shooter プリンとお子様オムライス: if there is a <roboser> attached to your holomem, deal 20 special damage to your opponent's center holomem. んーーーおいしい[๑´ڡ`๑]♡ "
   },
@@ -11142,6 +11563,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP06",
     "searchString": "robocosan hbp06-064 #jp #gen0 #shooter いたずらしちゃうぞ～！: if your oshi holomem is <robocosan>, you may archive 1~2 cards from your hand:for each card archived, return 1 <roboser> from your archive to hand. がおー！！......ビックリした？ "
   },
@@ -11165,6 +11587,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP06",
     "searchString": "robocosan hbp06-065 #jp #gen0 #shooter 一言芳恩:when this holomem uses arts, if this holomem has bloomed from a 1st holomem, deal 50 special damage to your opponent's center holomem or collab holomem. if this holomem is downed, you get life-2 かけがえのない日々 if your holomem was downed on your opponent's last turn, this arts cheer cost is reduced by 1 colorless cheer."
   },
@@ -11187,6 +11610,7 @@
     ],
     "hasFullArt": true,
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP06",
     "searchString": "robocosan hbp06-066 #jp #gen0 #shooter どり～む_コネクト.zero: [center position only]when your collab holomem with #gen 0 uses arts, reveal 1 card from your deck and archive it. then, shuffle the deck. ＜封印＞ ダークブライダル if this holomem has 3 or more <roboser> attached, deal 70 special damage to your opponent's center holomem or collab holomem."
   },
@@ -11207,6 +11631,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP06",
     "searchString": "inugami korone hbp06-067 #jp #gamers #kemomimi ホロライブの狂犬: you may archive 1 holomem with #gamers from your hand:draw 1 card. 指一本くれや！ "
   },
@@ -11228,6 +11653,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP06",
     "searchString": "inugami korone hbp06-068 #jp #gamers #kemomimi まかしなー:reveal 1 <fingers> from your deck, and add it to hand. then, shuffle the deck. you may only use bloom effect \"leave it to me\" once per turn. おめでとうをありがとう！ if there is a support card attached to your holomem, draw 1 card, then archive 1 card from your hand."
   },
@@ -11249,6 +11675,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP06",
     "searchString": "inugami korone hbp06-069 #jp #gamers #kemomimi こぉねのことだけ見ててね？♡　:if there is a <fingers> attached to your holomem, draw 1 card. しばきあげパンチング if this holomem was unrested this turn by your oshi skill \"infinite stamina\", this arts gets +50."
   },
@@ -11271,6 +11698,7 @@
     ],
     "hasFullArt": true,
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP06",
     "searchString": "inugami korone hbp06-070 #jp #gamers #kemomimi ワンダーヴァイキング: [center position only][1/turn]you may return 1 <fingers> from your stage to the bottom of your deck:during this turn, this holomem's arts cheer cost is reduced by 2 colorless cheer. 終焉のウォウウォウアックス if you have used your oshi skill \"infinite stamina\" this turn, this arts gets +40."
   },
@@ -11297,6 +11725,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP06",
     "searchString": "la+ darknesss hbp06-071 #jp #holox #shooter らぷらすといっしょ！ roll a die 3 times. this arts gets +20 for each odd number rolled. みんなかつもくせよ！ roll a die 5 times. for each odd number rolled, draw 1 card and deal 30 special damage to your opponent's center holomem and collab holomem."
   },
@@ -11317,6 +11746,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP06",
     "searchString": "natsuiro matsuri hbp06-072 #jp #gen1 #shooter 勝てると思った？ this holomem takes -30 arts damage from your opponent's 1st holomem. ざんね～ん "
   },
@@ -11336,6 +11766,7 @@
         "dmg": "10"
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP06",
     "searchString": "natsuiro matsuri hbp06-073 #jp #gen1 #shooter いっしょに居てくれる…？: if you are going second, this is your first turn, and your oshi holomem is <natsuiro matsuri>, reveal 1 limited support card from your deck and add it to hand. then, shuffle the deck. ありがとっ "
   },
@@ -11356,6 +11787,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP06",
     "searchString": "natsuiro matsuri hbp06-074 #jp #gen1 #shooter 天使界隈: during this turn, your center holomem gets arts+10 for each support card you used this turn. however, only up to 3 cards are counted. cure pale "
   },
@@ -11381,6 +11813,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 2,
     "setName": "hBP06",
     "searchString": "natsuiro matsuri hbp06-075 #jp #gen1 #shooter 今夜はdance the night!  ダンスレッスン頑張るぞ！ roll a die once for every [mascot and fan] on your stage. this arts gets +10 for each time it is 4 or greater. however, the die can be rolled only up to 4 times."
   },
@@ -11404,6 +11837,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP06",
     "searchString": "natsuiro matsuri hbp06-076 #jp #gen1 #shooter レッツパフォーミング　: reveal 1 [<ebifrion> or <matsurisu>] from your deck, and add it to hand. then, shuffle the deck. if this holomem is downed, you get life-2 まつりちゃんにメロメロになれよ❤︎ if the target of this arts is your opponent's 2nd holomem, and you have used a limited event this turn, this arts gets +70."
   },
@@ -11426,6 +11860,7 @@
     ],
     "hasFullArt": true,
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP06",
     "searchString": "natsuiro matsuri hbp06-077 #jp #gen1 #shooter re:start: if your life is equal to or less than your opponent's life, you may send the top card of your cheer deck to your <natsuiro matsuri>. never give up!! 夏色魂 the arts gets +30 for each limited support card you used this turn."
   },
@@ -11446,6 +11881,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP06",
     "searchString": "oozora subaru hbp06-078 #jp #gen2 #bird 地球&テラ:you may archive 1 cheer from this holomem:reveal 1 debut holomem with the same name as your oshi holomem from your deck, and add it to hand. then, shuffle the deck. 取り敢えずpowerで頑張るっす！！！！ "
   },
@@ -11466,6 +11902,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP06",
     "searchString": "oozora subaru hbp06-079 #jp #gen2 #bird subaru duck dance: you may send 1 cheer from your archive to this holomem. さ゛さ゛な゛み゛の゛音゛ "
   },
@@ -11487,6 +11924,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP06",
     "searchString": "oozora subaru hbp06-080 #jp #gen2 #bird 手を繋ごう: reveal 1 [<subarudo duck> or <subatomo>] from your deck, and add it to hand. then, shuffle the deck. どこへだって行ける this arts gets +20 for every <subatomo> attached to this holomem."
   },
@@ -11509,6 +11947,7 @@
     ],
     "hasFullArt": true,
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP06",
     "searchString": "oozora subaru hbp06-081 #jp #gen2 #bird 出動！ ドタバタ大空警察!!: if your oshi holomem is <oozora subaru>, you may archive 1 cheer from your stage:reveal 1 <oozora subaru> from your deck, and add it to hand. then, shuffle the deck. guilty or innocent if your life is 3 or less, for each of this holomem's cheers, send the top card of your cheer deck to 1 of your yellow holomem."
   },
@@ -11530,6 +11969,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP06",
     "searchString": "anya melfissa hbp06-082 #id #idgen2 #language 眠らない街:　[collab position only]if your oshi holomem is <anya melfissa>, your [center holomem and collab holomem] with an <ancient weapon> attached take -30 arts damage. 奇妙な来客 if you used your oshi skill \"mystical ritual\" this turn, you may return 1~3 <anya melfissa> from your archive to hand."
   },
@@ -11552,6 +11992,7 @@
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP06",
     "searchString": "lambduck hbp06-083 #jp #gen2 #gen4 #bird #kemomimi #singing おしまいのあじまり: you may reveal 1 <oozora subaru> from your hand and return it to the bottom of your deck:return 1 <tsunomaki watame> or <oozora subaru> from your archive to hand. this holomem is also regarded as <tsunomaki watame> <oozora subaru> i am スバル＆わため！ yeah！！ [collab position only]if your oshi holomem is <tsunomaki watame> or <oozora subaru>, the cheer cost of this arts is reduced by 1 yellow cheer. if your center holomem is a 2nd <tsunomaki watame>, the cheer cost of this arts is reduced by 3 yellow cheer instead."
   },
@@ -11572,6 +12013,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 0,
     "setName": "hBP06",
     "searchString": "ai koyori hbp06-084 #jp #holox #kemomimi 「こんこよ」、古くなっちゃったかな？ : when this holomem moves to the back position using baton pass, during this turn, 1 of your <hakui koyori> gets arts+20. this holomem cannot bloom 「ハッピーリーフ！」 "
   },
@@ -11932,9 +12374,11 @@
     "skills": [
       {
         "name": "スプリングシープ",
+        "cost": "1 any color",
         "dmg": 20
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP07",
     "searchString": "tsunomaki watame hbp07-008 #jp #gen4 #kemomimi #singing もういっぺぇ : if you went second and it is your first turn, choose 1 of your <tsunomaki watame>. during this turn, after the chosen holomem used arts, use the same arts once more. スプリングシープ "
   },
@@ -11949,11 +12393,13 @@
     "skills": [
       {
         "name": "ガブガブ！",
+        "cost": "1 White",
         "dmg": "20+",
         "description": "[Center Position Only]This Arts gets +20."
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP07",
     "searchString": "tsunomaki watame hbp07-009 #jp #gen4 #kemomimi #singing ガブガブ！ [center position only]this arts gets +20."
   },
@@ -11969,10 +12415,12 @@
     "skills": [
       {
         "name": "みんなの声聞けるかなー？？？？？？？",
+        "cost": "1 White",
         "dmg": 40
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP07",
     "searchString": "tsunomaki watame hbp07-010 #jp #gen4 #kemomimi #singing みんなー！ 楽しむぞおおー！！！！！ : put the top card of your deck as holo power. look at your holo power, and add 1 card from among them to hand. then, shuffle your holo power. みんなの声聞けるかなー？？？？？？？ "
   },
@@ -11988,11 +12436,13 @@
     "skills": [
       {
         "name": "これボタン弾けちゃうよぉ",
+        "cost": "3 any color",
         "dmg": 70,
         "description": "If this holomem has 2 white cheers attached, this Arts requires -1 colorless."
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP07",
     "searchString": "tsunomaki watame hbp07-011 #jp #gen4 #kemomimi #singing グルグルシープ : reveal 1 1st holomem <tsunomaki watame> from your deck, and add it to hand. then, shuffle the deck. you may only use bloom effect \"guruguru sheep\" once per turn. これボタン弾けちゃうよぉ if this holomem has 2 white cheers attached, this arts requires -1 colorless."
   },
@@ -12008,11 +12458,13 @@
     "skills": [
       {
         "name": "わたキャノンもだ！",
+        "cost": "1 any color",
         "dmg": 20,
         "description": "Draw 1 card."
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP07",
     "searchString": "tsunomaki watame hbp07-012 #jp #gen4 #kemomimi #singing わたビーーーーーーーム！！！！！！ : deal 30 special damage to your opponent's center holomem or collab holomem. your opponent draws 1 card. わたキャノンもだ！ draw 1 card."
   },
@@ -12028,11 +12480,13 @@
     "skills": [
       {
         "name": "センキューオーバーシープ！",
+        "cost": "2 any color",
         "dmg": "90+, +50 vs purple",
         "description": "This Arts gets +50 for each <Watamates> attached to this holomem."
       }
     ],
     "hasFoils": true,
+    "batonTouch": 2,
     "setName": "hBP07",
     "searchString": "tsunomaki watame hbp07-013 #jp #gen4 #kemomimi #singing はばないすでーい！！！ : during this turn, all <tsunomaki watame> on your stage get arts+20. if 6 or more cheers are attached to your center holomem, draw 2 cards. センキューオーバーシープ！ this arts gets +50 for each <watamates> attached to this holomem."
   },
@@ -12048,12 +12502,14 @@
     "skills": [
       {
         "name": "脳天直撃わためハンマー！",
+        "cost": "2 White, 1 any color",
         "dmg": "160, +50 vs red",
         "description": "[Center Position Only]If your opponent's holomem is downed by this Arts, and the dealt damage was greater than the remaining HP, deal special damage to 1 of your opponent's 2nd holomem equal to the excess damage."
       }
     ],
     "hasFullArt": true,
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP07",
     "searchString": "tsunomaki watame hbp07-014 #jp #gen4 #kemomimi #singing キュートセクシー : this holomem gets +10 hp for each holomem stacked to this holomem. 脳天直撃わためハンマー！ [center position only]if your opponent's holomem is downed by this arts, and the dealt damage was greater than the remaining hp, deal special damage to 1 of your opponent's 2nd holomem equal to the excess damage."
   },
@@ -12069,9 +12525,11 @@
     "skills": [
       {
         "name": "ノラネコ見つけた~",
+        "cost": "1 any color",
         "dmg": 20
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP07",
     "searchString": "vestia zeta hbp07-015 #id #idgen3 adopt me？ : if you went second and it is your first turn, reveal 1 buzz holomem with #idgen3 from your deck, and add it to hand. then, shuffle the deck. ノラネコ見つけた~ "
   },
@@ -12087,10 +12545,12 @@
     "skills": [
       {
         "name": "So, Tell Me Your Secrets?",
+        "cost": "1 White",
         "dmg": 20
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP07",
     "searchString": "vestia zeta hbp07-016 #id #idgen3 pat the bazo : if this holomem has a mascot attached, this holomem gets +30 hp. so, tell me your secrets? "
   },
@@ -12106,10 +12566,12 @@
     "skills": [
       {
         "name": "みんなと一緒にいる時間が好き",
+        "cost": "2 any color",
         "dmg": 50
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP07",
     "searchString": "vestia zeta hbp07-017 #id #idgen3 holoh3ro shopping : [center position only]when your buzz holomem with #idgen3 collabs, choose 1 holomem on your stage. the chosen holomem gets arts+30. みんなと一緒にいる時間が好き "
   },
@@ -12125,11 +12587,13 @@
     "skills": [
       {
         "name": "うまみ～うまみ～♪",
+        "cost": "1 White",
         "dmg": "30+",
         "description": "If you have used an event this turn, this Arts gets +30."
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP07",
     "searchString": "vestia zeta hbp07-018 #id #idgen3 horse doko? : reveal the top card of your deck. if the revealed card is a support card, add it to your hand. if it is not a support card, return it to the top of the deck. うまみ～うまみ～♪ if you have used an event this turn, this arts gets +30."
   },
@@ -12147,11 +12611,13 @@
     "skills": [
       {
         "name": "ホロライブID初代ダンスクイーン",
+        "cost": "1 White, 1 any color",
         "dmg": 50,
         "description": "If this holomem has a mascot or fan attached, draw 1 card."
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP07",
     "searchString": "vestia zeta hbp07-019 #id #idgen3 準備万端！ : reveal 1 [<bazo> or <zecretary>] from your deck, and attach it to your <vestia zeta>. then, shuffle the deck. if this holomem is downed, you get life-2 ホロライブid初代ダンスクイーン if this holomem has a mascot or fan attached, draw 1 card."
   },
@@ -12167,10 +12633,12 @@
     "skills": [
       {
         "name": "もっとパフォーマンスしたい！",
+        "cost": "2 White",
         "dmg": "100, +50 vs red"
       }
     ],
     "hasFoils": true,
+    "batonTouch": 2,
     "setName": "hBP07",
     "searchString": "vestia zeta hbp07-020 #id #idgen3 ya ya ya ya ya～! : roll a die once. if it is odd, set your opponent's 2nd holomem in the center position's remaining hp to 100. もっとパフォーマンスしたい！ "
   },
@@ -12186,12 +12654,14 @@
     "skills": [
       {
         "name": "最高のシークレットエージェント",
+        "cost": "2 White, 2 any color",
         "dmg": "160+, +50 vs purple",
         "description": "If you have a Buzz holomem with #IDGen3 on your stage, this Arts gets +40."
       }
     ],
     "hasFullArt": true,
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP07",
     "searchString": "vestia zeta hbp07-021 #id #idgen3 任務手伝ってくれる？ : attach 1 [<bazo> or <zecretary>] from your archive to your holomem. 最高のシークレットエージェント if you have a buzz holomem with #idgen3 on your stage, this arts gets +40."
   },
@@ -12207,11 +12677,13 @@
     "skills": [
       {
         "name": "元気もりもりさんでーまっする",
+        "cost": "1 White",
         "dmg": "50, +50 vs purple",
         "description": "Choose 1 of your holomem with #Gen3. During this turn, the chosen holomem requires -1 colorless for its Arts. If that holomem is a 2nd <Shirogane Noel>, it requires -2 colorless for its Arts instead."
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP07",
     "searchString": "shirogane noel hbp07-022 #jp #gen3 #alcohol 筋肉は裏切らない！ : [collab position only]during your opponent's turn, when your center holomem with #gen3 is downed, return all of the stacked holomem including that downed holomem to hand. 元気もりもりさんでーまっする choose 1 of your holomem with #gen3. during this turn, the chosen holomem requires -1 colorless for its arts. if that holomem is a 2nd <shirogane noel>, it requires -2 colorless for its arts instead."
   },
@@ -12227,9 +12699,11 @@
     "skills": [
       {
         "name": "MIOON!",
+        "cost": "1 any color",
         "dmg": 30
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP07",
     "searchString": "ookami mio hbp07-023 #jp #gamers #kemomimi #cooking 占いパワー注入！ : if you went second and it is your first turn, look at the top 3 cards of your deck. add 1 card from among them to hand. then, return the remaining cards to the top of the deck in any order. mioon! "
   },
@@ -12245,11 +12719,13 @@
     "skills": [
       {
         "name": "今日もいっぱい笑っていこう",
+        "cost": "1 Green",
         "dmg": "10+",
         "description": "You may archive the top card of your deck. If the archived card is a support card, this Arts gets +30."
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP07",
     "searchString": "ookami mio hbp07-024 #jp #gamers #kemomimi #cooking ウチの大切な家族 : [1/turn]when <mio-fam> is attached to this holomem, draw 1 card. 今日もいっぱい笑っていこう you may archive the top card of your deck. if the archived card is a support card, this arts gets +30."
   },
@@ -12265,11 +12741,13 @@
     "skills": [
       {
         "name": "ゲーマーズカフェへようこそ",
+        "cost": "1 any color",
         "dmg": 20,
         "description": "Send 1 cheer from your archive to 1 of your holomem with #GAMERS."
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP07",
     "searchString": "ookami mio hbp07-025 #jp #gamers #kemomimi #cooking 抹茶パフェ～！きゅんです : choose 1 of your holomem with #gamers and with a support card attached. during this turn, the chosen holomem gets arts+20. ゲーマーズカフェへようこそ send 1 cheer from your archive to 1 of your holomem with #gamers."
   },
@@ -12285,10 +12763,12 @@
     "skills": [
       {
         "name": "ちょっとお洒落な感じでしょ？",
+        "cost": "1 any color",
         "dmg": 40
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP07",
     "searchString": "ookami mio hbp07-026 #jp #gamers #kemomimi #cooking 早く来ないかな… : reveal 1 [<pigeotaurus> or <mio-fam>] from your deck, and add it to hand. then, shuffle the deck. ちょっとお洒落な感じでしょ？ "
   },
@@ -12304,11 +12784,13 @@
     "skills": [
       {
         "name": "女王陛下と呼びなさい",
+        "cost": "2 Green",
         "dmg": 70,
         "description": "[Center Position Only]When this Arts downed your opponent's holomem, draw 1 card."
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP07",
     "searchString": "ookami mio hbp07-027 #jp #gamers #kemomimi #cooking ハートの女王の采配 : choose 1 of your back holomem other than this holomem. during this turn, the chosen holomem gets arts+30. 女王陛下と呼びなさい [center position only]when this arts downed your opponent's holomem, draw 1 card."
   },
@@ -12324,11 +12806,13 @@
     "skills": [
       {
         "name": "天まで届け、みんなの願い",
+        "cost": "1 Green, 1 any color",
         "dmg": "90+, +50 vs blue",
         "description": "You may archive the top card of your deck. If the archived card is a support card, this Arts gets +50."
       }
     ],
     "hasFoils": true,
+    "batonTouch": 2,
     "setName": "hBP07",
     "searchString": "ookami mio hbp07-028 #jp #gamers #kemomimi #cooking 金瞳の綺羅星 : look at the top 2 cards of your deck. add 1 card from among them to hand. then, return the remaining card to the top of the deck. 天まで届け、みんなの願い you may archive the top card of your deck. if the archived card is a support card, this arts gets +50."
   },
@@ -12344,12 +12828,14 @@
     "skills": [
       {
         "name": "Upright Leading",
+        "cost": "3 any color",
         "dmg": "130+, +50 vs yellow",
         "description": "You may archive the top card of your deck:If the archived card is a holomem, send the top card of your cheer deck to your holomem. If it is a support card, this Arts gets +50."
       }
     ],
     "hasFullArt": true,
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP07",
     "searchString": "ookami mio hbp07-029 #jp #gamers #kemomimi #cooking 緑の地母神 : [1/turn]during your opponent's turn, when this holomem takes damage, if this holomem has a support card attached, restore 50 hp to this holomem. upright leading you may archive the top card of your deck:if the archived card is a holomem, send the top card of your cheer deck to your holomem. if it is a support card, this arts gets +50."
   },
@@ -12365,11 +12851,13 @@
     "skills": [
       {
         "name": "たくさんの宝物",
+        "cost": "2 Green",
         "dmg": "100, +50 vs yellow",
         "description": "You may archive 2 cheers from this holomem:Draw 2 cards."
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP07",
     "searchString": "kazama iroha hbp07-030 #jp #holox holorêve -いろは- : when bloomed from a buzz holomem, restore 100 hp to 1 of your holomem. たくさんの宝物 you may archive 2 cheers from this holomem:draw 2 cards."
   },
@@ -12387,11 +12875,13 @@
     "skills": [
       {
         "name": "ひとつになる声",
+        "cost": "1 Green, 1 any color",
         "dmg": 50,
         "description": "If your oshi holomem is green, blue or yellow, put the top card of your deck as holo Power."
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP07",
     "searchString": "airani iofifteen hbp07-031 #id #idgen1 #painting この輝きが私達！ : you may archive the top 2 cards of your holo power:draw 2 cards. if this holomem is downed, you get life-2 ひとつになる声 if your oshi holomem is green, blue or yellow, put the top card of your deck as holo power."
   },
@@ -12407,9 +12897,11 @@
     "skills": [
       {
         "name": "一陣の夜風",
+        "cost": "1 any color",
         "dmg": 10
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP07",
     "searchString": "rindo chihaya hbp07-032 #dev_is #flowglow ドライブ行こうよ : if you went second and it is your first turn, reveal 1 [1st holomem <rindo chihaya> and/or <fugutaro>] each from your deck, and add them to hand. then, shuffle the deck. 一陣の夜風 "
   },
@@ -12425,10 +12917,12 @@
     "skills": [
       {
         "name": "～Something blue～ 千速",
+        "cost": "1 Green, 1 any color",
         "dmg": 50
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP07",
     "searchString": "rindo chihaya hbp07-033 #dev_is #flowglow ティールマーメイド : choose 1 of your holomem with #flow glow that has bloomed this turn. during this turn, the chosen holomem gets arts+30. ～something blue～ 千速 "
   },
@@ -12444,11 +12938,13 @@
     "skills": [
       {
         "name": "どっちが速いｶﾅ？！？！？！",
+        "cost": "1 any color",
         "dmg": "20+",
         "description": "If <Fugutaro> is attached to this holomem, this Arts gets +10."
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP07",
     "searchString": "rindo chihaya hbp07-034 #dev_is #flowglow ぶいぶい走らせるぞ！！！ : you may archive 1 cheer from your stage:reveal 1 [debut holomem, 1st holomem or spot holomem] with #flow glow from your deck, and add it to hand. then, shuffle the deck. どっちが速いｶﾅ？！？！？！ if <fugutaro> is attached to this holomem, this arts gets +10."
   },
@@ -12464,12 +12960,14 @@
     "skills": [
       {
         "name": "サージングエキゾースト",
+        "cost": "2 Green, 2 any color",
         "dmg": "160, +50 vs blue",
         "description": "Count the number of cheers attached to this holomem, and return all cheers attached to this holomem to the bottom of your cheer deck in any order. Draw cards until your hand has the same number of cards as the number of cheers returned."
       }
     ],
     "hasFullArt": true,
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP07",
     "searchString": "rindo chihaya hbp07-035 #dev_is #flowglow give me hype!! : send the top card of your cheer deck to this holomem for each time your holomem with #flow glow bloomed this turn. サージングエキゾースト count the number of cheers attached to this holomem, and return all cheers attached to this holomem to the bottom of your cheer deck in any order. draw cards until your hand has the same number of cards as the number of cheers returned."
   },
@@ -12485,9 +12983,11 @@
     "skills": [
       {
         "name": "どちらがお好き？♡",
+        "cost": "1 any color",
         "dmg": 30
       }
     ],
+    "batonTouch": 0,
     "setName": "hBP07",
     "searchString": "akai haato hbp07-036 #jp #gen1 #cooking akai haato vs haachama : if you went second and it is your first turn, reveal 2 debut holomem <akai haato> from your deck, and place them on stage. then, shuffle the deck. どちらがお好き？♡ "
   },
@@ -12503,10 +13003,12 @@
     "skills": [
       {
         "name": "旅はまだ、始まったばかり。",
+        "cost": "1 any color",
         "dmg": 20
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP07",
     "searchString": "akai haato hbp07-037 #jp #gen1 #cooking ちゃまと旅する！ : if your center holomem is <akai haato>, draw 1 card. 旅はまだ、始まったばかり。 "
   },
@@ -12522,11 +13024,13 @@
     "skills": [
       {
         "name": "hololiveEN0",
+        "cost": "1 any color",
         "dmg": 30,
         "description": "During this turn, all holomem on your stage with #EN get Arts+20."
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP07",
     "searchString": "akai haato hbp07-038 #jp #gen1 #cooking 幻獣グルメハンター : roll a die once. if it is odd, deal 20 special damage to your opponent's center holomem. if it is even, draw 1 card. hololiveen0 during this turn, all holomem on your stage with #en get arts+20."
   },
@@ -12542,11 +13046,13 @@
     "skills": [
       {
         "name": "俺の名は〝ちゃまお〟漢の中の漢だ！",
+        "cost": "1 Red, 1 any color",
         "dmg": 50,
         "description": "Deal 20 special damage to your opponent's center holomem."
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP07",
     "searchString": "akai haato hbp07-039 #jp #gen1 #cooking 血ゃ舞ってる奴いる！？ : [1/turn]during your turn, when your <akai haato> returns from your stage to deck, you may send 1 cheer from your archive to this holomem. 俺の名は〝ちゃまお〟漢の中の漢だ！ deal 20 special damage to your opponent's center holomem."
   },
@@ -12562,10 +13068,12 @@
     "skills": [
       {
         "name": "当店自慢のはあとんバーガー！",
+        "cost": "1 Red",
         "dmg": 40
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP07",
     "searchString": "akai haato hbp07-040 #jp #gen1 #cooking haachama ♥ restaurant : you may return 1 debut <akai haato> from your back position to the bottom of your deck:reveal 1 [1st holomem or 2nd holomem] other than buzz from your deck, and add it to hand. then, shuffle the deck. 当店自慢のはあとんバーガー！ "
   },
@@ -12581,11 +13089,13 @@
     "skills": [
       {
         "name": "万物に愛されちゃま計画",
+        "cost": "1 Red, 1 any color",
         "dmg": "80+, +50 vs green",
         "description": "If all cheers on your stage are red cheers, this Arts gets +20."
       }
     ],
     "hasFoils": true,
+    "batonTouch": 2,
     "setName": "hBP07",
     "searchString": "akai haato hbp07-041 #jp #gen1 #cooking everybody say hentai : deal 50 special damage to your opponent's collab holomem. 万物に愛されちゃま計画 if all cheers on your stage are red cheers, this arts gets +20."
   },
@@ -12600,17 +13110,20 @@
     "skills": [
       {
         "name": "純心タランテラ",
+        "cost": "2 Red",
         "dmg": "80, +50 vs purple",
         "description": "Deal 40 special damage to your opponent's center holomem and collab holomem."
       },
       {
         "name": "幸せへの旅路",
+        "cost": "1 Red, 2 any color",
         "dmg": "140+, +50 vs purple",
         "description": "If your holomem returned from your stage to deck this turn, this Arts gets +50."
       }
     ],
     "hasFullArt": true,
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP07",
     "searchString": "akai haato hbp07-042 #jp #gen1 #cooking 純心タランテラ deal 40 special damage to your opponent's center holomem and collab holomem. 幸せへの旅路 if your holomem returned from your stage to deck this turn, this arts gets +50."
   },
@@ -12626,11 +13139,13 @@
     "skills": [
       {
         "name": "桜は花に顕る",
+        "cost": "3 Red, 1 any color",
         "dmg": "70+, +50 vs purple",
         "description": "For each <35P> attached to this holomem, this Arts gets +70 and you draw 1 card."
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP07",
     "searchString": "sakura miko hbp07-043 #jp #gen0 #baby holorêve -みこ- : choose the number 3 or 5. during this turn, when you roll a die using the ability of your oshi holomem <sakura miko> or any <sakura miko> on your stage, regard all numbers on the faces of that die as the chosen number. 桜は花に顕る for each <35p> attached to this holomem, this arts gets +70 and you draw 1 card."
   },
@@ -12646,11 +13161,13 @@
     "skills": [
       {
         "name": "スタッフファーストです！",
+        "cost": "2 Red",
         "dmg": "120, +50 vs purple",
         "description": "Archive the top 2 cards of your deck. You may return 1 staff from your archive to hand."
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP07",
     "searchString": "omaru polka hbp07-044 #jp #gen5 #kemomimi the show must go on : [center position・collab position only]during your opponent's turn, when your buzz holomem with a fan attached is downed, if your oshi holomem is <omaru polka>, you take -1 life damage. スタッフファーストです！ archive the top 2 cards of your deck. you may return 1 staff from your archive to hand."
   },
@@ -12668,11 +13185,13 @@
     "skills": [
       {
         "name": "キミがいないと楽しくないもん",
+        "cost": "1 Red, 1 any color",
         "dmg": "20+",
         "description": "This Arts gets +20 for each card in your hand."
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP07",
     "searchString": "hakos baelz hbp07-045 #en #promise #kemomimi テンション上がってきた！ : [center position・collab position only]when you use your sp oshi skill, put the top card of your deck as holo power. if this holomem is downed, you get life-2 キミがいないと楽しくないもん this arts gets +20 for each card in your hand."
   },
@@ -12688,9 +13207,11 @@
     "skills": [
       {
         "name": "Onwards and Upwards!",
+        "cost": "1 any color",
         "dmg": 30
       }
     ],
+    "batonTouch": 2,
     "setName": "hBP07",
     "searchString": "elizabeth rose bloodflame hbp07-046 #en #justice #singing 後の先を取る！ : if you went second and it is your first turn, reveal 1 [1st holomem <elizabeth rose bloodflame> and/or <thorn>] each from your deck, and add them to hand. then, shuffle the deck. onwards and upwards! "
   },
@@ -12706,10 +13227,12 @@
     "skills": [
       {
         "name": "さあ、かかってくるといい",
+        "cost": "1 Red",
         "dmg": 50
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP07",
     "searchString": "elizabeth rose bloodflame hbp07-047 #en #justice #singing …very well. : if your oshi holomem is <elizabeth rose bloodflame>, put the top card of your deck as holo power. さあ、かかってくるといい "
   },
@@ -12727,11 +13250,13 @@
     "skills": [
       {
         "name": "Because I love people's voices",
+        "cost": "1 Red, 1 any color",
         "dmg": 60,
         "description": "Return 1 holomem with #EN from your archive to hand."
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 3,
     "setName": "hBP07",
     "searchString": "elizabeth rose bloodflame hbp07-048 #en #justice #singing queen of impersonation : this holomem may use the arts of any holomem on your stage with #en (correct cheer is required to use those arts). if this holomem is downed, you get life-2 because i love people's voices return 1 holomem with #en from your archive to hand."
   },
@@ -12747,12 +13272,14 @@
     "skills": [
       {
         "name": "不撓のコンチェルタート",
+        "cost": "1 Red, 2 any color",
         "dmg": "130+, +50 vs yellow",
         "description": "If your life is 4 or less, this Arts gets +30. If your life is 2 or less, this Arts gets +60 instead."
       }
     ],
     "hasFullArt": true,
     "hasAlternativeArt": true,
+    "batonTouch": 3,
     "setName": "hBP07",
     "searchString": "elizabeth rose bloodflame hbp07-049 #en #justice #singing 絢爛のアインザッツ : [center position・collab position only]when your holomem downs your opponent's holomem, choose 1 of your holomem. during this turn, the chosen holomem requires -2 colorless for its arts. 不撓のコンチェルタート if your life is 4 or less, this arts gets +30. if your life is 2 or less, this arts gets +60 instead."
   },
@@ -12768,9 +13295,11 @@
     "skills": [
       {
         "name": "金色のルアー",
+        "cost": "1 any color",
         "dmg": 10
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP07",
     "searchString": "ouro kronii hbp07-050 #en #promise この日が来た！ : if you went second and it is your first turn, you may bloom your center holomem <ouro kronii> using a 1st holomem in your hand. this ability allows you to bloom on your first turn. 金色のルアー "
   },
@@ -12786,10 +13315,12 @@
     "skills": [
       {
         "name": "Check This Out Yo 🕶️",
+        "cost": "1 any color",
         "dmg": 30
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP07",
     "searchString": "ouro kronii hbp07-051 #en #promise take your time : you may reattach 1 cheer from your stage to your other holomem with #promise. check this out yo 🕶️ "
   },
@@ -12805,11 +13336,13 @@
     "skills": [
       {
         "name": "私の新キャッチフレーズ。どうだい？",
+        "cost": "1 any color",
         "dmg": "30+",
         "description": "If your stage has a holomem with #Promise other than <Ouro Kronii>, this Arts gets +10."
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP07",
     "searchString": "ouro kronii hbp07-052 #en #promise お時間ですわ！ : you may attach 1 mascot from your archive to this holomem. 私の新キャッチフレーズ。どうだい？ if your stage has a holomem with #promise other than <ouro kronii>, this arts gets +10."
   },
@@ -12825,11 +13358,13 @@
     "skills": [
       {
         "name": "Everlasting Flower",
+        "cost": "1 Blue, 1 any color",
         "dmg": 50,
         "description": "Send the top card of your cheer deck to your holomem with #Promise."
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP07",
     "searchString": "ouro kronii hbp07-053 #en #promise 時を超えた約束 : choose 1 holomem with #promise on your stage. during this turn, the chosen holomem gets arts+20. everlasting flower send the top card of your cheer deck to your holomem with #promise."
   },
@@ -12846,11 +13381,13 @@
     "skills": [
       {
         "name": "I'm pretty shy…uwu",
+        "cost": "1 Blue",
         "dmg": 50,
         "description": "Send the top card of your cheer deck to your Buzz holomem with #Promise."
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP07",
     "searchString": "ouro kronii hbp07-054 #en #promise if this holomem is downed, you get life-2 i'm pretty shy…uwu send the top card of your cheer deck to your buzz holomem with #promise."
   },
@@ -12866,10 +13403,12 @@
     "skills": [
       {
         "name": "Life Goes On",
+        "cost": "1 Blue, 1 any color",
         "dmg": "90, +50 vs white"
       }
     ],
     "hasFoils": true,
+    "batonTouch": 2,
     "setName": "hBP07",
     "searchString": "ouro kronii hbp07-055 #en #promise 約束の未来へ : choose 1 holomem with #promise on your stage. during this turn, the chosen holomem gets arts+50. life goes on "
   },
@@ -12885,12 +13424,14 @@
     "skills": [
       {
         "name": "You're not ready for me.",
+        "cost": "2 Blue, 2 any color",
         "dmg": "80+, +50 vs red",
         "description": "You may reattach 1 cheer from this holomem to your other holomem with #Promise. If your Oshi holomem is <Ouro Kronii>, this Arts gets +100."
       }
     ],
     "hasFullArt": true,
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP07",
     "searchString": "ouro kronii hbp07-056 #en #promise 時界を統べし者 : [center position only]at the start of your performance phase, you may bloom 1 of your other <ouro kronii> using a holomem that is stacked to this holomem. you're not ready for me. you may reattach 1 cheer from this holomem to your other holomem with #promise. if your oshi holomem is <ouro kronii>, this arts gets +100."
   },
@@ -12906,11 +13447,13 @@
     "skills": [
       {
         "name": "おりゃー！！油断したでしょ～",
+        "cost": "2 Blue, 1 any color",
         "dmg": "100, +50 vs red",
         "description": "If your Oshi holomem is <Nekomata Okayu> and your opponent has a back holomem which has taken 100 or more damage, deal 50 special damage to 1 of your opponent's holomem."
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP07",
     "searchString": "nekomata okayu hbp07-057 #jp #gamers #kemomimi 君と遊ぶとドキドキしちゃう… : deal 30 special damage to 1 of your opponent's holomem. おりゃー！！油断したでしょ～ if your oshi holomem is <nekomata okayu> and your opponent has a back holomem which has taken 100 or more damage, deal 50 special damage to 1 of your opponent's holomem."
   },
@@ -12926,11 +13469,13 @@
     "skills": [
       {
         "name": "MANTAP LEE!!",
+        "cost": "1 Blue, 2 any color",
         "dmg": 60,
         "description": "If your opponent has 3 or more back holomem with reduced HP, draw 2 cards."
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP07",
     "searchString": "kobo kanaeru hbp07-058 #id #idgen3 happy for you : reveal 1 cheer from your cheer deck with the same color as 1 holomem with #idgen3 on your stage, and send it to your holomem. then, shuffle the cheer deck. mantap lee!! if your opponent has 3 or more back holomem with reduced hp, draw 2 cards."
   },
@@ -12946,10 +13491,12 @@
     "skills": [
       {
         "name": "A Cozy, Spooky Night Together",
+        "cost": "1 any color",
         "dmg": 10,
         "description": "Deal 10 special damage to 1 of your opponent's holomem."
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP07",
     "searchString": "shiori novella hbp07-059 #en #advent it's time to play dress-up! : if you went second and it is your first turn, return 1 support card from your archive to hand. a cozy, spooky night together deal 10 special damage to 1 of your opponent's holomem."
   },
@@ -12964,15 +13511,18 @@
     "skills": [
       {
         "name": "食料解剖",
+        "cost": "1 any color",
         "dmg": 10
       },
       {
         "name": "Don't Let Her Cook!",
+        "cost": "1 Blue",
         "dmg": 50,
         "description": "This Arts may not be used unless you have 4 or more support cards in your archive."
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP07",
     "searchString": "shiori novella hbp07-060 #en #advent 食料解剖  don't let her cook! this arts may not be used unless you have 4 or more support cards in your archive."
   },
@@ -12988,11 +13538,13 @@
     "skills": [
       {
         "name": "逃がす訳がないでしょう？",
+        "cost": "1 Blue",
         "dmg": 20,
         "description": "Deal 20 special damage to 1 of your opponent's back holomem."
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP07",
     "searchString": "shiori novella hbp07-061 #en #advent a new chapter begins! : if your oshi holomem is <shiori novella>, look at the top 4 cards of your deck. reveal 1 support card from among them, and add it to hand. then, return the remaining cards to the bottom of the deck in any order. 逃がす訳がないでしょう？ deal 20 special damage to 1 of your opponent's back holomem."
   },
@@ -13008,12 +13560,14 @@
     "skills": [
       {
         "name": "解き放たれた禁断の知識",
+        "cost": "1 Blue",
         "dmg": "60+, +50 vs red",
         "description": "Send 1 cheer from your archive to your holomem with #Advent. If your Oshi holomem is <Shiori Novella> and 4 or more cheers are attached to this holomem, this Arts gets +100."
       }
     ],
     "hasFullArt": true,
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP07",
     "searchString": "shiori novella hbp07-062 #en #advent a new crime & a new me : you may archive 2 support cards from your hand:choose 1 holomem on your stage. during this turn, the chosen holomem gets arts+50. 解き放たれた禁断の知識 send 1 cheer from your archive to your holomem with #advent. if your oshi holomem is <shiori novella> and 4 or more cheers are attached to this holomem, this arts gets +100."
   },
@@ -13029,9 +13583,11 @@
     "skills": [
       {
         "name": "君とぴったり密着空間",
+        "cost": "1 any color",
         "dmg": 30
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP07",
     "searchString": "azki hbp07-063 #jp #gen0 #singing ドキドキ夜キャンプ… : if you went second, it is your first turn, and your oshi holomem is <azki>, return 1 cheer from your opponent's stage to the bottom of the cheer deck. 君とぴったり密着空間 "
   },
@@ -13046,11 +13602,13 @@
     "skills": [
       {
         "name": "ゆっくりしにおいで♡",
+        "cost": "1 any color",
         "dmg": 20,
         "description": "Reveal 1 <Pioneers> from your deck, and attach it to your <AZKi>. Then, shuffle the deck."
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP07",
     "searchString": "azki hbp07-064 #jp #gen0 #singing ゆっくりしにおいで♡ reveal 1 <pioneers> from your deck, and attach it to your <azki>. then, shuffle the deck."
   },
@@ -13065,15 +13623,18 @@
     "skills": [
       {
         "name": "盛り上がっていこう！",
+        "cost": "1 any color",
         "dmg": 30,
         "description": "Draw 1 card, and archive 1 card from your hand."
       },
       {
         "name": "みんなの声聞かせてええええええ！！！",
+        "cost": "1 Purple, 3 any color",
         "dmg": 120
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP07",
     "searchString": "azki hbp07-065 #jp #gen0 #singing 盛り上がっていこう！ draw 1 card, and archive 1 card from your hand. みんなの声聞かせてええええええ！！！ "
   },
@@ -13089,10 +13650,12 @@
     "skills": [
       {
         "name": "音楽と歌うことが大好き！",
+        "cost": "1 any color",
         "dmg": 40
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP07",
     "searchString": "azki hbp07-066 #jp #gen0 #singing 仮想世界の伴走する歌姫 : restore 30 hp to 1 of your holomem. choose 1 holomem on your stage. during this turn, the chosen holomem gets arts+10. 音楽と歌うことが大好き！ "
   },
@@ -13108,11 +13671,13 @@
     "skills": [
       {
         "name": "君と二人きりの夜",
+        "cost": "1 Purple, 1 any color",
         "dmg": 40,
         "description": "You may archive 1 card from your hand:Deal 20 special damage to your opponent's center holomem or collab holomem."
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP07",
     "searchString": "azki hbp07-067 #jp #gen0 #singing romantic night : look at the top 4 cards of your deck. reveal 1 <azki> from among them, and add it to hand. then, return the remaining cards to the bottom of the deck in any order. 君と二人きりの夜 you may archive 1 card from your hand:deal 20 special damage to your opponent's center holomem or collab holomem."
   },
@@ -13129,10 +13694,12 @@
     "skills": [
       {
         "name": "ホワイトデーのお返し、待ってるね",
+        "cost": "2 any color",
         "dmg": "100, +50 vs yellow"
       }
     ],
     "hasFoils": true,
+    "batonTouch": 2,
     "setName": "hBP07",
     "searchString": "azki hbp07-068 #jp #gen0 #singing 共に歩んできた軌跡 : during this turn, this holomem gets arts+20 for each differently named holomem with #gen0 on your stage. cost : 2 any color power: 100, +50 vs yellow ホワイトデーのお返し、待ってるね "
   },
@@ -13147,17 +13714,20 @@
     "skills": [
       {
         "name": "君と新たな開拓の地へ",
+        "cost": "1 Purple, 2 any color",
         "dmg": "140, +50 vs green",
         "description": "Draw 2 cards."
       },
       {
         "name": "紡いだ軌跡 すべてに捧ぐ歌",
+        "cost": "3 Purple, 1 any color",
         "dmg": "200, +50 vs green",
         "description": "If your Oshi holomem is <AZKi>, you may archive 4 of your holo Power:If you have 4 <Frontier Spirit> in your archive, your opponent gets life-1."
       }
     ],
     "hasFullArt": true,
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP07",
     "searchString": "azki hbp07-069 #jp #gen0 #singing 君と新たな開拓の地へ draw 2 cards. 紡いだ軌跡 すべてに捧ぐ歌 if your oshi holomem is <azki>, you may archive 4 of your holo power:if you have 4 <frontier spirit> in your archive, your opponent gets life-1."
   },
@@ -13173,11 +13743,13 @@
     "skills": [
       {
         "name": "がんばって美味しいの作るね♡",
+        "cost": "1 Purple",
         "dmg": 30,
         "description": "Choose 1 of your holomem with #Cooking. During this turn, for each event with #Food you used this turn, the chosen holomem requires -1 colorless for its Arts."
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP07",
     "searchString": "yuzuki choco hbp07-070 #jp #gen2 #cooking 今日のご飯、何がいーい？ : look at the top 3 cards of your deck. reveal 1 holomem with #cooking from among them, and add it to hand. then, return the remaining cards to the bottom of the deck in any order. がんばって美味しいの作るね♡ choose 1 of your holomem with #cooking. during this turn, for each event with #food you used this turn, the chosen holomem requires -1 colorless for its arts."
   },
@@ -13193,10 +13765,12 @@
     "skills": [
       {
         "name": "手作りの朝ごはんを要求する",
+        "cost": "1 Purple",
         "dmg": 30
       }
     ],
     "hasFoils": true,
+    "batonTouch": 0,
     "setName": "hBP07",
     "searchString": "la+ darknesss hbp07-071 #jp #holox #shooter おい、お前 : look at the top 5 cards of your deck. reveal 1 purple debut holomem from among them, and add it to hand. then, return the remaining cards to the bottom of the deck in any order. 手作りの朝ごはんを要求する "
   },
@@ -13212,10 +13786,12 @@
     "skills": [
       {
         "name": "吾輩との秘密だぞ",
+        "cost": "1 Purple, 1 any color",
         "dmg": 60
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP07",
     "searchString": "la+ darknesss hbp07-072 #jp #holox #shooter secret love -la+- : choose 1 of your holomem with #holox, and roll a die 3 times. during this turn, for each odd result rolled, the chosen holomem gets arts+10. 吾輩との秘密だぞ "
   },
@@ -13231,11 +13807,13 @@
     "skills": [
       {
         "name": "吾輩の歌聴いてくれる奴いるううう！？！？",
+        "cost": "2 any color",
         "dmg": 30,
         "description": "Reveal 1 <La+ Darknesss> from your deck, and add it to hand. Then, shuffle the deck."
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP07",
     "searchString": "la+ darknesss hbp07-073 #jp #holox #shooter #singing ライブだー！！！！！！！！！ : during this turn, this holomem requires -2 colorless for its arts. 吾輩の歌聴いてくれる奴いるううう！？！？ reveal 1 <la+ darknesss> from your deck, and add it to hand. then, shuffle the deck."
   },
@@ -13251,12 +13829,14 @@
     "skills": [
       {
         "name": "吾輩の歌を聴けえええええええ！！！！",
+        "cost": "1 Purple, 2 any color",
         "dmg": "110+, +50 vs green",
         "description": "If your center holomem is purple, this Arts gets +40."
       }
     ],
     "hasFullArt": true,
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP07",
     "searchString": "la+ darknesss hbp07-074 #jp #holox #shooter #singing ラッシュ行きます : look at the top 3 cards of your deck. reveal any number of holomem from among them, and add the revealed cards to hand. then, return the remaining cards to the bottom of the deck in any order. 吾輩の歌を聴けえええええええ！！！！ if your center holomem is purple, this arts gets +40."
   },
@@ -13272,11 +13852,13 @@
     "skills": [
       {
         "name": "CODE:81800",
+        "cost": "1 Purple",
         "dmg": "70+, +50 vs blue",
         "description": "If 3 or more cheers are attached to this holomem, this Arts gets +10 for each cheer in both players' archive."
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP07",
     "searchString": "koseki bijou hbp07-075 #en #advent #baby 闇夜のハンター : if the target of this holomem's arts is your opponent's holomem with the same color as a cheer in your archive, damage from that arts cannot be reduced. code:81800 if 3 or more cheers are attached to this holomem, this arts gets +10 for each cheer in both players' archive."
   },
@@ -13294,11 +13876,13 @@
     "skills": [
       {
         "name": "あら、捕まえられちゃった！",
+        "cost": "1 Purple, 1 any color",
         "dmg": "50+",
         "description": "You may archive 1 of your holo Power:This Arts gets +30."
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP07",
     "searchString": "nerissa ravencroft hbp07-076 #en #advent #singing #bird sugoisugoidekai : if your oshi holomem is <nerissa ravencroft>, draw 1 card and put 1 card from your hand to holo power. if this holomem is downed, you get life-2 あら、捕まえられちゃった！ you may archive 1 of your holo power:this arts gets +30."
   },
@@ -13314,9 +13898,11 @@
     "skills": [
       {
         "name": "ねね、酔っちゃった～",
+        "cost": "1 any color",
         "dmg": 10
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP07",
     "searchString": "momosuzu nene hbp07-077 #jp #gen5 #singing #painting あぱぱ : if you went second and it is your first turn, reveal 1 2nd holomem with #gen5 from your deck, and add it to hand. then, shuffle the deck. ねね、酔っちゃった～ "
   },
@@ -13332,10 +13918,12 @@
     "skills": [
       {
         "name": "ねねと一緒に楽しもう！！",
+        "cost": "1 any color",
         "dmg": 20
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP07",
     "searchString": "momosuzu nene hbp07-078 #jp #gen5 #singing #painting 君もこっちにおいで～！ : look at the top 5 cards of your deck. reveal 1 <nekko> from among them, and add it to hand. then, return the remaining cards to the bottom of the deck in any order. ねねと一緒に楽しもう！！ "
   },
@@ -13351,11 +13939,13 @@
     "skills": [
       {
         "name": "ご自由にお使いください！",
+        "cost": "1 any color",
         "dmg": 30,
         "description": "Reveal 1 <Yamena> from your deck, and attach it to your holomem. Then, shuffle the deck."
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP07",
     "searchString": "momosuzu nene hbp07-079 #jp #gen5 #singing #painting ねねちライブスタート！ : you may send 1 cheer from your archive to this holomem. ご自由にお使いください！ reveal 1 <yamena> from your deck, and attach it to your holomem. then, shuffle the deck."
   },
@@ -13371,10 +13961,12 @@
     "skills": [
       {
         "name": "さいくーにくぅわいい",
+        "cost": "1 Yellow",
         "dmg": 40
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP07",
     "searchString": "momosuzu nene hbp07-080 #jp #gen5 #singing #painting オレンジアイドル！ : [1/turn]usable during your main phase if your oshi holomem is <momosuzu nene>:attach 1 <nekko> from your archive to this holomem. さいくーにくぅわいい "
   },
@@ -13390,11 +13982,13 @@
     "skills": [
       {
         "name": "君のハートをブルロック！",
+        "cost": "2 Yellow",
         "dmg": 30,
         "description": "If this holomem has <Giraffe Stag Beetle> attached, this Arts damage is dealt to your opponent's center holomem and collab holomem, instead of only the holomem targeted by this Arts."
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP07",
     "searchString": "momosuzu nene hbp07-081 #jp #gen5 #singing #painting 桃鈴ねねは昆虫博士になる！ : if you have 4 or more holo power and your opponent has no collab holomem, your opponent moves 1 of their back holomem to the collab position (moving is not regarded as collab). 君のハートをブルロック！ if this holomem has <giraffe stag beetle> attached, this arts damage is dealt to your opponent's center holomem and collab holomem, instead of only the holomem targeted by this arts."
   },
@@ -13410,10 +14004,12 @@
     "skills": [
       {
         "name": "アチョ～～～！",
+        "cost": "1 any color",
         "dmg": "50, +50 vs blue"
       }
     ],
     "hasFoils": true,
+    "batonTouch": 2,
     "setName": "hBP07",
     "searchString": "momosuzu nene hbp07-082 #jp #gen5 #singing #painting ねぽらぼが最強です！！！！！！！！！！！！！ : reveal 1 2nd holomem with #gen5 from your deck, and add it to hand. then, shuffle the deck. アチョ～～～！ "
   },
@@ -13429,12 +14025,14 @@
     "skills": [
       {
         "name": "オーバーチアリーディング",
+        "cost": "1 Yellow, 2 any color",
         "dmg": "100, +50 vs red",
         "description": "Return 1 cheer from your opponent's [center holomem or collab holomem] to the bottom of the cheer deck."
       }
     ],
     "hasFullArt": true,
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP07",
     "searchString": "momosuzu nene hbp07-083 #jp #gen5 #singing #painting みんなのエナジードリンク : [center position only]until the end of your opponent's next turn, all holomem on both players' stage get arts+40. then, all 2nd holomem <momosuzu nene> on your stage get arts+60. オーバーチアリーディング return 1 cheer from your opponent's [center holomem or collab holomem] to the bottom of the cheer deck."
   },
@@ -13450,11 +14048,13 @@
     "skills": [
       {
         "name": "やっぱり、FPSとか？",
+        "cost": "1 Yellow, 1 any color",
         "dmg": "90, +50 vs blue",
         "description": "Send 1 cheer from your archive to your holomem."
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP07",
     "searchString": "natsuiro matsuri hbp07-084 #jp #gen1 #shooter 一緒にゲームしよ : during your opponent's turn, when this holomem is downed, you may return 1 limited support card from your archive to the bottom of your deck. if you do, return this holomem to hand instead of archiving it. やっぱり、fpsとか？ send 1 cheer from your archive to your holomem."
   },
@@ -13470,11 +14070,13 @@
     "skills": [
       {
         "name": "元気いっぱいカラフルパフェ",
+        "cost": "1 Yellow",
         "dmg": "20+",
         "description": "If your Oshi holomem is <Shiranui Flare>, choose 1 of your <Shiranui Flare>. During this turn, the chosen holomem gets Arts+20 for each of the chosen holomem's cheers."
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP07",
     "searchString": "shiranui flare hbp07-085 #jp #gen3 #half-elf 私のとっておき！ : during your turn, when this holomem moves to the collab position, look at the top 3 cards of your deck. reveal 1 <shiranui flare> from among them, and add it to hand. then, archive the remaining cards. 元気いっぱいカラフルパフェ if your oshi holomem is <shiranui flare>, choose 1 of your <shiranui flare>. during this turn, the chosen holomem gets arts+20 for each of the chosen holomem's cheers."
   },
@@ -13490,11 +14092,13 @@
     "skills": [
       {
         "name": "追撃のライオット",
+        "cost": "2 Yellow, 1 any color",
         "dmg": "160+, +50 vs blue",
         "description": "If the target of this Arts is a holomem with reduced HP, this Arts gets +30."
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP07",
     "searchString": "gigi murin hbp07-086 #en #justice 執念のチェイサー : choose 1 of your <gigi murin>. during this turn, you may also target your opponent's back holomem with reduced hp with the chosen holomem's arts. 追撃のライオット if the target of this arts is a holomem with reduced hp, this arts gets +30."
   },
@@ -13510,9 +14114,11 @@
     "skills": [
       {
         "name": "現行犯逮捕だ",
+        "cost": "1 any color",
         "dmg": 20
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP07",
     "searchString": "koganei niko hbp07-087 #dev_is #flowglow ニコたん出動！ : if you went second and it is your first turn, you may archive the top 2 cards of your cheer deck:choose 1 holomem with #flow glow on your stage. during this turn, the chosen holomem gets arts+20. 現行犯逮捕だ "
   },
@@ -13528,11 +14134,13 @@
     "skills": [
       {
         "name": "みんなが居るから幸せだ！",
+        "cost": "1 Yellow, 1 any color",
         "dmg": "50+",
         "description": "If cheer has been archived from your stage this turn, this Arts gets +30."
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP07",
     "searchString": "koganei niko hbp07-088 #dev_is #flowglow 虎の威 : all of your 1st holomem in the back position with #flow glow do not take special damage from your opponent. みんなが居るから幸せだ！ if cheer has been archived from your stage this turn, this arts gets +30."
   },
@@ -13548,10 +14156,12 @@
     "skills": [
       {
         "name": "スッゲーワクワクするしょ！！",
+        "cost": "1 Yellow",
         "dmg": 50
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP07",
     "searchString": "koganei niko hbp07-089 #dev_is #flowglow っしゃ反撃抜刀 : if your holomem with #flow glow was downed during your opponent's previous turn, draw 2 cards. you may only use bloom effect \"swift riposte!\" once per turn. スッゲーワクワクするしょ！！ "
   },
@@ -13567,12 +14177,14 @@
     "skills": [
       {
         "name": "ぶち上げる気合いだ！",
+        "cost": "2 Yellow",
         "dmg": "80+, +50 vs white",
         "description": "This Arts gets +20 for each of this holomem's cheers."
       }
     ],
     "hasFullArt": true,
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP07",
     "searchString": "koganei niko hbp07-090 #dev_is #flowglow ここで終わっちゃう虎じゃないんだ！ : you may send 2 cheers from your archive to 1 of your holomem with #flow glow. ぶち上げる気合いだ！ this arts gets +20 for each of this holomem's cheers."
   },
@@ -13923,9 +14535,11 @@
     "skills": [
       {
         "name": "芽吹く春",
+        "cost": "1 any color",
         "dmg": 30
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP08",
     "searchString": "irys hbp08-008 #en #promise #singing promise of spring : if you went second and it is your first turn, choose 1 holomem on your stage with #promise. during this turn, the chosen holomem gets arts+30. then, if there is purple cheer on your stage, draw 1 card. 芽吹く春 "
   },
@@ -13941,10 +14555,12 @@
     "skills": [
       {
         "name": "あたしはもっと深いところを見てるの",
+        "cost": "1 any color",
         "dmg": 20
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP08",
     "searchString": "irys hbp08-009 #en #promise #singing 分かり合える日が来るかもね : look at your holo power. reveal 1 support card from among them, and add it to hand. then, shuffle your holo power. if you added a card to hand, put the top card of your deck to holo power. あたしはもっと深いところを見てるの "
   },
@@ -13960,10 +14576,12 @@
     "skills": [
       {
         "name": "I am Lightning Speed",
+        "cost": "1 any color",
         "dmg": 40
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP08",
     "searchString": "irys hbp08-010 #en #promise #singing race with me!! : reveal 1 [<bloom&gloom> or <guyrys>] from your deck, and add it to hand. then, shuffle the deck. i am lightning speed "
   },
@@ -13979,11 +14597,13 @@
     "skills": [
       {
         "name": "Hot Ending",
+        "cost": "1 any color",
         "dmg": 30,
         "description": "If a purple cheer is attached to this holomem, draw 1 card."
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP08",
     "searchString": "irys hbp08-011 #en #promise #singing the hot pink one : if a white cheer is attached to this holomem, draw 1 card. hot ending if a purple cheer is attached to this holomem, draw 1 card."
   },
@@ -13999,11 +14619,13 @@
     "skills": [
       {
         "name": "片や天使 片や悪魔",
+        "cost": "1 White, 1 any color",
         "dmg": 50,
         "description": "If a purple cheer is attached to this holomem, deal 20 special damage to your opponent's center holomem."
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP08",
     "searchString": "irys hbp08-012 #en #promise #singing 希望が照らす轍 : you may return 1 cheer from your stage to the bottom of the cheer deck: send the top card of your cheer deck to your <irys>. 片や天使 片や悪魔 if a purple cheer is attached to this holomem, deal 20 special damage to your opponent's center holomem."
   },
@@ -14019,11 +14641,13 @@
     "skills": [
       {
         "name": "萌え萌えキュンしちゃった？",
+        "cost": "1 White, 1 any color",
         "dmg": "70+, +50 vs purple",
         "description": "If this holomem has purple cheer attached, this Arts gets +50."
       }
     ],
     "hasFoils": true,
+    "batonTouch": 2,
     "setName": "hBP08",
     "searchString": "irys hbp08-013 #en #promise #singing 勝利のティータイム : when this holomem downs your opponent's holomem, put the top card of your deck as holo power. 萌え萌えキュンしちゃった？ if this holomem has purple cheer attached, this arts gets +50."
   },
@@ -14039,12 +14663,14 @@
     "skills": [
       {
         "name": "プリズマティック・アンセム",
+        "cost": "1 White, 2 any color",
         "dmg": "130+, +50 vs red",
         "description": "During this turn, all holomem on your stage get Arts+20 for each purple cheer attached to this holomem."
       }
     ],
     "hasFullArt": true,
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP08",
     "searchString": "irys hbp08-014 #en #promise #singing 絶望に残った光 : deal 30 special damage to your opponent's center holomem. additionally, if a purple cheer is attached to this holomem, deal 30 special damage to your opponent's collab holomem. プリズマティック・アンセム during this turn, all holomem on your stage get arts+20 for each purple cheer attached to this holomem."
   },
@@ -14060,10 +14686,12 @@
     "skills": [
       {
         "name": "ナインダーツ",
+        "cost": "1 any color",
         "dmg": 20
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP08",
     "searchString": "tokino sora hbp08-015 #jp #gen0 #singing 私に勝てるかな？ : this holomem takes -10 arts damage from your opponent's holomem. ナインダーツ "
   },
@@ -14078,15 +14706,18 @@
     "skills": [
       {
         "name": "Stairway to the Stars",
+        "cost": "1 any color",
         "dmg": 30,
         "description": "If there are 3 or more <Tokino Sora> on your stage, draw 1 card."
       },
       {
         "name": "あの時の空へ…",
+        "cost": "1 White, 2 any color",
         "dmg": 90
       }
     ],
     "hasFoils": true,
+    "batonTouch": 2,
     "setName": "hBP08",
     "searchString": "tokino sora hbp08-016 #jp #gen0 #singing stairway to the stars if there are 3 or more <tokino sora> on your stage, draw 1 card. あの時の空へ… "
   },
@@ -14102,11 +14733,13 @@
     "skills": [
       {
         "name": "みんな、ぬんぬん進んでいこーう",
+        "cost": "1 White, 1 any color",
         "dmg": "40+",
         "description": "If you have a 2nd holomem with #Gen 0 on your stage, this Arts gets +20."
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP08",
     "searchString": "tokino sora hbp08-017 #jp #gen0 #singing 「ヴァ！」 : reveal 1 <ankimo> from your deck, and add it to hand. then, shuffle the deck. みんな、ぬんぬん進んでいこーう if you have a 2nd holomem with #gen 0 on your stage, this arts gets +20."
   },
@@ -14122,12 +14755,14 @@
     "skills": [
       {
         "name": "盛り上がってくれたらうれしいな！",
+        "cost": "1 White, 3 any color",
         "dmg": "150, +50 vs red",
         "description": "If your Oshi holomem is Tokino Sora, choose 1 other <Tokino Sora> on your stage. During this turn, you may also target your opponent's back 2nd holomem with the chosen holomem's Arts."
       }
     ],
     "hasFullArt": true,
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP08",
     "searchString": "tokino sora hbp08-018 #jp #gen0 #singing アイドルになりたいわたし : [center position・collab position only] draw 2 cards. 盛り上がってくれたらうれしいな！ if your oshi holomem is tokino sora, choose 1 other <tokino sora> on your stage. during this turn, you may also target your opponent's back 2nd holomem with the chosen holomem's arts."
   },
@@ -14152,6 +14787,7 @@
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP08",
     "searchString": "raora panthera hbp08-019 #en #justice #kemomimi #painting ボナペティート -楽しい食事- : ■while this holomem does not have <chattino> attached, this holomem requires -1 white cheer for its arts.\n■while this holomem has <chattino> attached, this holomem gets +30 hp. この幸せをシェアしよう ■while this holomem has <chattino> attached, this holomem gets +30 hp. let's share this happiness if this holomem does not have <chattino> attached, attach 1 <chattino> from your deck to this holomem. then, shuffle the deck."
   },
@@ -14167,11 +14803,13 @@
     "skills": [
       {
         "name": "挑戦のまなざし",
+        "cost": "1 White, 1 any color",
         "dmg": "110+, +50 vs red",
         "description": "If you have archived 3 cards from your deck this turn, this Arts gets +40."
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP08",
     "searchString": "isaki riona hbp08-020 #dev_is #flowglow セクシーダンスクィーン : you may archive 1~2 cards from the top of your deck: draw 1 card for each card archived. 挑戦のまなざし if you have archived 3 cards from your deck this turn, this arts gets +40."
   },
@@ -14187,9 +14825,11 @@
     "skills": [
       {
         "name": "祝祭を響かせよう",
+        "cost": "1 any color",
         "dmg": 30
       }
     ],
+    "batonTouch": 0,
     "setName": "hBP08",
     "searchString": "cecilia immergreen hbp08-021 #en #justice #language automaton，roll out! : if you went second and it is your first turn, reveal 2 <otomo> from your deck, and add them to hand. then, shuffle the deck. 祝祭を響かせよう "
   },
@@ -14205,10 +14845,12 @@
     "skills": [
       {
         "name": "エレガントに行くのです",
+        "cost": "1 any color",
         "dmg": 20
       }
     ],
     "hasFoils": true,
+    "batonTouch": 0,
     "setName": "hBP08",
     "searchString": "cecilia immergreen hbp08-022 #en #justice #language エスケープメント : when this holomem uses baton pass and moves to the back position, this holomem is rested. エレガントに行くのです "
   },
@@ -14224,10 +14866,12 @@
     "skills": [
       {
         "name": "とってもとっても特別！",
+        "cost": "1 Green",
         "dmg": 40
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP08",
     "searchString": "cecilia immergreen hbp08-023 #en #justice #language 一緒に居てくれる時間 : you may rest this holomem. then, if you have 2 or more resting holomem with #justice, restore 50 hp to 1 of your holomem. とってもとっても特別！ "
   },
@@ -14243,11 +14887,13 @@
     "skills": [
       {
         "name": "風の赴くままに",
+        "cost": "1 Green",
         "dmg": 60,
         "description": "Rest this holomem."
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP08",
     "searchString": "cecilia immergreen hbp08-024 #en #justice #language グーテ・ライゼ -良き旅を- : [center position・collab position only] during your opponent's main phase, the hp of all of your resting <cecilia immergreen> cannot be reduced or changed by your opponent's abilities. 風の赴くままに rest this holomem."
   },
@@ -14263,10 +14909,12 @@
     "skills": [
       {
         "name": "休憩も大事でしょ？",
+        "cost": "1 any color",
         "dmg": 30
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP08",
     "searchString": "cecilia immergreen hbp08-025 #en #justice #language 喫茶の時間 : if you have 2 or more resting holomem with #justice, during this turn, all holomem on your stage get arts+20. 休憩も大事でしょ？ "
   },
@@ -14282,10 +14930,12 @@
     "skills": [
       {
         "name": "奏楽のヴィンデ",
+        "cost": "1 Green, 1 any color",
         "dmg": "90, +50 vs blue"
       }
     ],
     "hasFoils": true,
+    "batonTouch": 2,
     "setName": "hBP08",
     "searchString": "cecilia immergreen hbp08-026 #en #justice #language 機巧のシュトライヒ : if you have 2 or more resting holomem with #justice, during this turn, this holomem gets arts+50. 奏楽のヴィンデ "
   },
@@ -14301,12 +14951,14 @@
     "skills": [
       {
         "name": "翠嵐のシュトルム",
+        "cost": "1 Green, 3 any color",
         "dmg": "200, +50 vs yellow",
         "description": "Draw 1 card for each of your resting holomem with #Justice. Then, rest this holomem."
       }
     ],
     "hasFullArt": true,
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP08",
     "searchString": "cecilia immergreen hbp08-027 #en #justice #language 絡繰のラプソディー : send 1 cheer from your archive to this holomem for each of your resting holomem with #justice. 翠嵐のシュトルム draw 1 card for each of your resting holomem with #justice. then, rest this holomem."
   },
@@ -14323,11 +14975,13 @@
     "skills": [
       {
         "name": "一口食べる？",
+        "cost": "1 Green, 1 any color",
         "dmg": 50,
         "description": "Restore 30 HP to 1 of your holomem with tool attached."
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP08",
     "searchString": "aki rosenthal hbp08-028 #jp #gen1 #half-elf #alcohol #summer ホロナツ大盛りパフェ : choose 1 of your <aki rosenthal> with tool attached. during this turn, the chosen holomem gets arts+20. if the chosen holomem is a buzz holomem or 2nd holomem, that holomem gets arts+50 instead. large parfait\nchoose 1 of your <aki rosenthal> with tool attached. during this turn, the chosen holomem gets arts+20. if the chosen holomem is a buzz holomem or 2nd holomem, that holomem gets arts+50 instead. 一口食べる？ restore 30 hp to 1 of your holomem with tool attached."
   },
@@ -14343,10 +14997,12 @@
     "skills": [
       {
         "name": "極秘任務遂行中でござる",
+        "cost": "1 Green",
         "dmg": 20
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP08",
     "searchString": "kazama iroha hbp08-029 #jp #holox secret love -iroha- : [collab position only] [1/turn] during your opponent's turn, when your center holomem with #holox takes arts damage, put the top card of your deck to holo power. 極秘任務遂行中でござる "
   },
@@ -14362,10 +15018,12 @@
     "skills": [
       {
         "name": "以後　お見知りおきを…",
+        "cost": "1 any color",
         "dmg": 10
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP08",
     "searchString": "pavolia reine hbp08-030 #id #idgen2 #bird #painting 一歩ずつ : you may archive 1 holomem with #id gen 2 from your hand: send the top card of your cheer deck to your back holomem. 以後　お見知りおきを… "
   },
@@ -14383,11 +15041,13 @@
     "skills": [
       {
         "name": "GWS+",
+        "cost": "1 Green, 1 any color",
         "dmg": 60,
         "description": "Archive the top card of your cheer deck. For every cheer color on your stage, restore 10 HP to 1 of your holomem."
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP08",
     "searchString": "pavolia reine hbp08-031 #id #idgen2 #bird #painting spy-c1000 : [center position・collab position only][1/turn] during your turn, when your cheer is moved to archive, draw 1 card. if this holomem is downed, you get life-2 gws+ archive the top card of your cheer deck. for every cheer color on your stage, restore 10 hp to 1 of your holomem."
   },
@@ -14403,11 +15063,13 @@
     "skills": [
       {
         "name": "ストラクチュラル・カラー",
+        "cost": "2 any color",
         "dmg": "80+, +50 vs blue",
         "description": "If you have a holomem with #ID Gen 2 other than <Pavolia Reine> with purple cheer or yellow cheer attached, this Arts gets +70."
       }
     ],
     "hasFoils": true,
+    "batonTouch": 2,
     "setName": "hBP08",
     "searchString": "pavolia reine hbp08-032 #id #idgen2 #bird #painting 新しい旅へ : choose 1 2nd holomem [<kureiji ollie> or <anya melfissa>] on your stage. during this turn, the chosen holomem gets arts+70. ストラクチュラル・カラー if you have a holomem with #id gen 2 other than <pavolia reine> with purple cheer or yellow cheer attached, this arts gets +70."
   },
@@ -14423,12 +15085,14 @@
     "skills": [
       {
         "name": "ノックアウト・ツイスト",
+        "cost": "1 Green, 2 any color",
         "dmg": "140, +50 vs blue",
         "description": "Send 1~2 cheers from your archive to 1 of your <Pavolia Reine>."
       }
     ],
     "hasFullArt": true,
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP08",
     "searchString": "pavolia reine hbp08-033 #id #idgen2 #bird #painting 監視者の眼差し : send 1 cheer from your cheer deck to your holomem with #id. then, shuffle the cheer deck. ノックアウト・ツイスト send 1~2 cheers from your archive to 1 of your <pavolia reine>."
   },
@@ -14444,9 +15108,11 @@
     "skills": [
       {
         "name": "あなたのもこもこなモココ",
+        "cost": "1 any color",
         "dmg": 30
       }
     ],
+    "batonTouch": 0,
     "setName": "hBP08",
     "searchString": "mococo abyssgard hbp08-034 #en #advent #kemomimi fuwamocoを信じて！ : if you went second and it is your first turn, place 1 debut holomem [<fuwawa abyssgard> and <mococo abyssgard>] each from your deck on stage. then, shuffle the deck. あなたのもこもこなモココ "
   },
@@ -14461,11 +15127,13 @@
     "skills": [
       {
         "name": "やったぁ大勝ちだ！！",
+        "cost": "1 Red",
         "dmg": "10+",
         "description": "If a blue cheer is attached to this holomem, this Arts gets +30."
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP08",
     "searchString": "mococo abyssgard hbp08-035 #en #advent #kemomimi やったぁ大勝ちだ！！ if a blue cheer is attached to this holomem, this arts gets +30."
   },
@@ -14481,10 +15149,12 @@
     "skills": [
       {
         "name": "ふたりは“BAU” DOL☆★",
+        "cost": "1 any color",
         "dmg": 40
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP08",
     "searchString": "mococo abyssgard hbp08-036 #en #advent #kemomimi ドキドキdoggy -mococo- : reveal 1 [<pero>, <ruffians> or <mischievous ruffians>] from your deck, and add it to hand. then, shuffle the deck. ふたりは“bau” dol☆★ "
   },
@@ -14500,11 +15170,13 @@
     "skills": [
       {
         "name": "がんBAUるねー！",
+        "cost": "2 Red",
         "dmg": 30,
         "description": "If 2 blue cheers are attached to this holomem, send the top card of your cheer deck to your <Fuwawa Abyssgard>."
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP08",
     "searchString": "mococo abyssgard hbp08-037 #en #advent #kemomimi トゥインクル・アイドル : if you have <fuwawa abyssgard> on your stage, deal 20 special damage to your opponent's center holomem or collab holomem. がんbauるねー！ if 2 blue cheers are attached to this holomem, send the top card of your cheer deck to your <fuwawa abyssgard>."
   },
@@ -14520,10 +15192,12 @@
     "skills": [
       {
         "name": "勝つのはモココだよ！",
+        "cost": "2 any color",
         "dmg": "100, +50 vs green"
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP08",
     "searchString": "mococo abyssgard hbp08-038 #en #advent #kemomimi 魔法の武器だもん！ : if your oshi holomem is blue <fuwamoco>, return 1 holomem with #advent from your archive to hand. 勝つのはモココだよ！ "
   },
@@ -14539,12 +15213,14 @@
     "skills": [
       {
         "name": "もこもこバウンティハンター",
+        "cost": "3 Red",
         "dmg": "90+, +50 vs purple",
         "description": "For each blue cheer attached to this holomem, this Arts gets +20. Then, choose any number of blue cheers attached to this holomem, and reattach them to 1 of your <Fuwawa Abyssgard>."
       }
     ],
     "hasFullArt": true,
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP08",
     "searchString": "mococo abyssgard hbp08-039 #en #advent #kemomimi 深淵からの信頼 : if your stage has 6 or more blue cheers, set 1 of your resting <fuwawa abyssgard> to active. もこもこバウンティハンター for each blue cheer attached to this holomem, this arts gets +20. then, choose any number of blue cheers attached to this holomem, and reattach them to 1 of your <fuwawa abyssgard>."
   },
@@ -14562,11 +15238,13 @@
     "skills": [
       {
         "name": "お花見デート",
+        "cost": "1 Red, 1 any color",
         "dmg": "30+",
         "description": "This Arts gets +10 for each red cheer in your archive."
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP08",
     "searchString": "nakiri ayame hbp08-040 #jp #gen2 #shooter 桜の気配に誘われて : if this holomem has <demon blade asura> attached, and your opponent has no collab holomem, your opponent moves 1 of their back holomem to the collab position (moving is not regarded as collab). if this holomem is downed, you get life-2 お花見デート this arts gets +10 for each red cheer in your archive."
   },
@@ -14582,11 +15260,13 @@
     "skills": [
       {
         "name": "\"熱狂的な夜\"は実在する!!!",
+        "cost": "1 any color",
         "dmg": 20,
         "description": "Archive the top card of your deck."
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP08",
     "searchString": "takanashi kiara hbp08-041 #en #myth #bird 不死鳥式エアロビ : during your opponent's turn, when this holomem is downed, you may return this holomem to hand instead of archive. \"熱狂的な夜\"は実在する!!! archive the top card of your deck."
   },
@@ -14602,10 +15282,12 @@
     "skills": [
       {
         "name": "キワワとチョンカーズ＆スムージー",
+        "cost": "1 Red",
         "dmg": 40
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP08",
     "searchString": "takanashi kiara hbp08-042 #en #myth #bird グーテンモルゲン -穏やかな朝- : you may archive 1~3 cards from your hand: choose 1 holomem on your stage. during this turn, the chosen holomem gets arts+10 for each card archived by this ability. キワワとチョンカーズ＆スムージー "
   },
@@ -14623,11 +15305,13 @@
     "skills": [
       {
         "name": "生き抜く覚悟",
+        "cost": "2 Red",
         "dmg": 50,
         "description": "If all holomem on your stage have #Myth, put the top card of your deck to holo Power."
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP08",
     "searchString": "takanashi kiara hbp08-043 #en #myth #bird 火ノ鳥剣舞 : if you have 10 or more holomem in your archive, during this turn, this holomem requires -2 red cheer for its arts. if this holomem is downed, you get life-2 生き抜く覚悟 if all holomem on your stage have #myth, put the top card of your deck to holo power."
   },
@@ -14643,12 +15327,14 @@
     "skills": [
       {
         "name": "不敵なるファイヤーフォーゲル",
+        "cost": "2 Red",
         "dmg": "100, +50 vs purple",
         "description": "Archive 1~3 cards from the top of your deck."
       }
     ],
     "hasFullArt": true,
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP08",
     "searchString": "takanashi kiara hbp08-044 #en #myth #bird 光、再び灯りて : during your main phase, if your archive has 10 or more holomem, you may bloom 1 of your holomem using this holomem from your archive. (this ability can only be used while this holomem is in archive) 不敵なるファイヤーフォーゲル archive 1~3 cards from the top of your deck."
   },
@@ -14664,11 +15350,13 @@
     "skills": [
       {
         "name": "ボクはボクらしく生きたい。",
+        "cost": "1 Red",
         "dmg": "50+, +50 vs green",
         "description": "Choose 1 holomem on your stage and roll a die once. During this turn, the chosen holomem gets Arts+10x the result."
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP08",
     "searchString": "hakos baelz hbp08-045 #en #promise #kemomimi 今年は豊作になりそうやねん！ : during this turn, when you roll a die for the ability of your oshi holomem <hakos baelz> or your holomem <hakos baelz>, regard all numbers on the die as doubled. ボクはボクらしく生きたい。 choose 1 holomem on your stage and roll a die once. during this turn, the chosen holomem gets arts+10x the result."
   },
@@ -14684,10 +15372,12 @@
     "skills": [
       {
         "name": "スイートトゥース",
+        "cost": "1 Red",
         "dmg": 30
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP08",
     "searchString": "elizabeth rose bloodflame hbp08-046 #en #justice #singing マジェスティック・デヴォーション : [collab position only] during your opponent's turn, when your holomem with #justice other than this holomem is downed, reveal 1 2nd holomem from your deck and add it to hand. then, shuffle the deck. スイートトゥース "
   },
@@ -14703,9 +15393,11 @@
     "skills": [
       {
         "name": "すうの充電たりてる？",
+        "cost": "1 Blue",
         "dmg": 30
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP08",
     "searchString": "mizumiya su hbp08-047 #dev_is #flowglow はい、天才！ : if you went second and it is your first turn, draw 1 card, and draw 1 more card for each colorless required for your opponent's center holomem's baton pass. すうの充電たりてる？ "
   },
@@ -14721,10 +15413,12 @@
     "skills": [
       {
         "name": "つよい。でかい。大きい。",
+        "cost": "1 any color",
         "dmg": 30
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP08",
     "searchString": "mizumiya su hbp08-048 #dev_is #flowglow けはいあり183cm : you may archive 1 cheer from your stage: reveal 1 <aura> from your deck, and add it to hand. then, shuffle the deck. つよい。でかい。大きい。 "
   },
@@ -14740,10 +15434,12 @@
     "skills": [
       {
         "name": "君さえよかったらもっとはなそ",
+        "cost": "1 Blue, 1 any color",
         "dmg": 50
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP08",
     "searchString": "mizumiya su hbp08-049 #dev_is #flowglow 君との電話ひとりじめ : [collab position only]while you have a center holomem with #flow glow, your opponent's holomem's arts can only target your collab holomem. however, it excludes special damage. 君さえよかったらもっとはなそ "
   },
@@ -14759,11 +15455,13 @@
     "skills": [
       {
         "name": "雪だるまつくろっ",
+        "cost": "1 Blue",
         "dmg": 20,
         "description": "Send 1 cheer from your archive to your holomem."
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP08",
     "searchString": "mizumiya su hbp08-050 #dev_is #flowglow 君に任せちゃおうかな？ : during your opponent's turn, when this holomem is downed, send the top card of your cheer deck to your back holomem. 雪だるまつくろっ send 1 cheer from your archive to your holomem."
   },
@@ -14779,11 +15477,13 @@
     "skills": [
       {
         "name": "8時間35分",
+        "cost": "1 Blue, 1 any color",
         "dmg": 40,
         "description": "Send the top card of your cheer deck to your <Mizumiya Su>."
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP08",
     "searchString": "mizumiya su hbp08-051 #dev_is #flowglow 愛のエゴサ : [center position only] when your <mizumiya su> collabs, choose your opponent's center holomem. until the end of your opponent's next turn, the chosen holomem requires +1 colorless for its baton pass. 8時間35分 send the top card of your cheer deck to your <mizumiya su>."
   },
@@ -14798,15 +15498,18 @@
     "skills": [
       {
         "name": "元気の出るグミ",
+        "cost": "1 Blue",
         "dmg": "70, +50 vs red",
         "description": "If your opponent's center holomem requires 5 or more colorless cheers for its baton pass, send the top card of your cheer deck to your <Mizumiya Su>."
       },
       {
         "name": "グミうまい",
+        "cost": "1 Blue, 3 any color",
         "dmg": "180, +50 vs red"
       }
     ],
     "hasFoils": true,
+    "batonTouch": 2,
     "setName": "hBP08",
     "searchString": "mizumiya su hbp08-052 #dev_is #flowglow 元気の出るグミ if your opponent's center holomem requires 5 or more colorless cheers for its baton pass, send the top card of your cheer deck to your <mizumiya su>. グミうまい "
   },
@@ -14822,12 +15525,14 @@
     "skills": [
       {
         "name": "届け、この愛",
+        "cost": "2 Blue, 1 any color",
         "dmg": "50, +50 vs white",
         "description": "If your opponent's center holomem requires 5 or more colorless cheers for its baton pass, deal 100 special damage to 1 of your opponent's holomem other than Debut."
       }
     ],
     "hasFullArt": true,
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP08",
     "searchString": "mizumiya su hbp08-053 #dev_is #flowglow しゅぴしゅわ～～っ！！！！ : [center position only] while your opponent's center holomem requires 5 or more colorless cheers for its baton pass, your opponent's center holomem requires +2 colorless cheers for its arts. 届け、この愛 if your opponent's center holomem requires 5 or more colorless cheers for its baton pass, deal 100 special damage to 1 of your opponent's holomem other than debut."
   },
@@ -14843,11 +15548,13 @@
     "skills": [
       {
         "name": "ひとりじゃない、今は共に",
+        "cost": "3 any color",
         "dmg": "130, +50 vs red",
         "description": "You may archive 3 cheers from this holomem: Draw 3 cards."
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP08",
     "searchString": "moona hoshinova hbp08-054 #id #idgen1 #singing この絆が私達！ : if your oshi holomem's color is green, blue or yellow, send 1 blue cheer each from your archive to 1~3 of your holomem with #id gen 1. ひとりじゃない、今は共に you may archive 3 cheers from this holomem: draw 3 cards."
   },
@@ -14863,11 +15570,13 @@
     "skills": [
       {
         "name": "あなたのふわふわなフワワ",
+        "cost": "1 Blue",
         "dmg": 20,
         "description": "If a red cheer is attached to this holomem, draw 1 card."
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP08",
     "searchString": "fuwawa abyssgard hbp08-055 #en #advent #kemomimi fuwamocoとなら大丈夫 : send 1 cheer from your archive to your holomem with #advent. あなたのふわふわなフワワ if a red cheer is attached to this holomem, draw 1 card."
   },
@@ -14883,10 +15592,12 @@
     "skills": [
       {
         "name": "思いっきりやってくるよ！",
+        "cost": "1 any color",
         "dmg": 40
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP08",
     "searchString": "fuwawa abyssgard hbp08-056 #en #advent #kemomimi ドキドキdoggy -fuwawa- : reveal 1 1st holomem <mococo abyssgard> from your deck, and add it to hand. then, shuffle the deck. 思いっきりやってくるよ！ "
   },
@@ -14902,11 +15613,13 @@
     "skills": [
       {
         "name": "寄り添うふたり",
+        "cost": "1 Blue",
         "dmg": "30+",
         "description": "If a red cheer is attached to this holomem, this Arts gets +20."
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP08",
     "searchString": "fuwawa abyssgard hbp08-057 #en #advent #kemomimi 木漏れ日のブランコ : you may choose any number of cheers on your stage, and reattach them to 1 of your <mococo abyssgard>. then, if your stage has 8 or more cheers, during this turn, this holomem gets arts+40. 寄り添うふたり if a red cheer is attached to this holomem, this arts gets +20."
   },
@@ -14921,16 +15634,19 @@
     "skills": [
       {
         "name": "勝てるわけないでしょ！",
+        "cost": "1 Blue, 1 any color",
         "dmg": "100, +50 vs white",
         "description": "Choose 1-2 blue cheers from your archive, and send them to your holomem with #Advent as you choose."
       },
       {
         "name": "今度はこっちの番だよ！",
+        "cost": "2 Blue, 2 any color",
         "dmg": "160, +50 vs white",
         "description": "If your Oshi holomem is blue <FUWAMOCO>, you may archive 2 cheers from this holomem: Deal 50 special damage to 1 of your opponent's holomem other than Debut."
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP08",
     "searchString": "fuwawa abyssgard hbp08-058 #en #advent #kemomimi 勝てるわけないでしょ！ choose 1-2 blue cheers from your archive, and send them to your holomem with #advent as you choose. 今度はこっちの番だよ！ if your oshi holomem is blue <fuwamoco>, you may archive 2 cheers from this holomem: deal 50 special damage to 1 of your opponent's holomem other than debut."
   },
@@ -14946,12 +15662,14 @@
     "skills": [
       {
         "name": "ふわふわバウンダリースパナー",
+        "cost": "3 Blue",
         "dmg": "80+, +50 vs white",
         "description": "If your <Mococo Abyssgard> used Arts this turn, this Arts gets +50. Then, choose any number of red cheers attached to this holomem, and reattach them to 1 of your <Mococo Abyssgard>."
       }
     ],
     "hasFullArt": true,
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP08",
     "searchString": "fuwawa abyssgard hbp08-059 #en #advent #kemomimi 深淵からの愛情 : while your stage has 6 or more red cheers, you may also target your opponent's back holomem other than debut with this holomem's arts. ふわふわバウンダリースパナー if your <mococo abyssgard> used arts this turn, this arts gets +50. then, choose any number of red cheers attached to this holomem, and reattach them to 1 of your <mococo abyssgard>."
   },
@@ -14968,11 +15686,13 @@
     "skills": [
       {
         "name": "いっしょういっしょ♡",
+        "cost": "2 any color",
         "dmg": 50,
         "description": "If your Oshi holomem is blue <FUWAMOCO>, put the top card of your deck to holo Power."
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP08",
     "searchString": "fuwamoco hbp08-060 #en #advent #kemomimi “bau” dol♡ : [collab position only] your oshi skill \"moco-chan!\" has its \"[holo power:-3]\" changed to \"[holo power:-2]\". this holomem is also regarded as <fuwawa abyssgard> <mococo abyssgard> いっしょういっしょ♡ if your oshi holomem is blue <fuwamoco>, put the top card of your deck to holo power."
   },
@@ -14988,9 +15708,11 @@
     "skills": [
       {
         "name": "holoX Coffeeをどうぞ",
+        "cost": "1 any color",
         "dmg": 30
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP08",
     "searchString": "takane lui hbp08-061 #jp #holox #bird #alcohol 秘密結社のおもてなし : if you went second and it is your first turn, and your oshi holomem is <takane lui>, your opponent adds the top card of their holo power to hand. holox coffeeをどうぞ "
   },
@@ -15007,10 +15729,12 @@
     "skills": [
       {
         "name": "ダウンさせる意志",
+        "cost": "1 any color",
         "dmg": 20
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP08",
     "searchString": "takane lui hbp08-062 #jp #holox #bird #alcohol ダウンさせられる覚悟 : you may archive 1 card from your hand: place 1 debut holomem with extra \"you may include any number of this holomem in the deck\" from your deck on stage. then, shuffle the deck. \"you may include any number of this holomem in the deck\" from your deck on stage. then, shuffle the deck. ダウンさせる意志 "
   },
@@ -15026,10 +15750,12 @@
     "skills": [
       {
         "name": "どう似合ってる？？？",
+        "cost": "1 Purple",
         "dmg": 40
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP08",
     "searchString": "takane lui hbp08-063 #jp #holox #bird #alcohol ホロックス・ディール : look at the top 3 cards of your deck. reveal 1 holomem with #holox from among them, and add it to hand. then, return the remaining cards to the bottom of the deck in any order. どう似合ってる？？？ "
   },
@@ -15045,11 +15771,13 @@
     "skills": [
       {
         "name": "眠らない街の仕事屋",
+        "cost": "1 any color",
         "dmg": 20,
         "description": "Attach 1 <Lui-tomo> from your deck to 1 of your holomem. Then, shuffle the deck."
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP08",
     "searchString": "takane lui hbp08-064 #jp #holox #bird #alcohol 荒事上等 : you may archive 1 card from your hand: deal 30 special damage to your opponent's center holomem or collab holomem. 眠らない街の仕事屋 attach 1 <lui-tomo> from your deck to 1 of your holomem. then, shuffle the deck."
   },
@@ -15065,11 +15793,13 @@
     "skills": [
       {
         "name": "差していくよ！",
+        "cost": "2 Purple",
         "dmg": "50+",
         "description": "If your hand has 2 or less cards, this Arts gets +30."
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP08",
     "searchString": "takane lui hbp08-065 #jp #holox #bird #alcohol 大穴きちゃーーー！ : [center position only] you may archive 1 card from your hand: roll a die once. if it is 1, draw 3 cards. if it is a number other than 1, draw 1 card. 差していくよ！ if your hand has 2 or less cards, this arts gets +30."
   },
@@ -15085,11 +15815,13 @@
     "skills": [
       {
         "name": "酔い、覚ましていこ？",
+        "cost": "1 any color",
         "dmg": "60+, +50 vs yellow",
         "description": "You may archive 1~2 cards from your hand: This Arts gets +20 for each card archived."
       }
     ],
     "hasFoils": true,
+    "batonTouch": 2,
     "setName": "hBP08",
     "searchString": "takane lui hbp08-066 #jp #holox #bird #alcohol そんなに顔赤い？ : you may return 1 support card from your archive to the top of your deck. 酔い、覚ましていこ？ you may archive 1~2 cards from your hand: this arts gets +20 for each card archived."
   },
@@ -15105,12 +15837,14 @@
     "skills": [
       {
         "name": "逆転の一手",
+        "cost": "3 Purple",
         "dmg": "130+, +50 vs green",
         "description": "If your hand has 2 or less cards, this Arts gets +50. If your hand has no cards, this Arts gets +70 instead."
       }
     ],
     "hasFullArt": true,
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP08",
     "searchString": "takane lui hbp08-067 #jp #holox #bird #alcohol ヴァイオレットドミネーション : [center position only] you may archive 2 cards from your hand: reattach 1 cheer on your opponent's stage to their holomem. 逆転の一手 if your hand has 2 or less cards, this arts gets +50. if your hand has no cards, this arts gets +70 instead."
   },
@@ -15126,10 +15860,12 @@
     "skills": [
       {
         "name": "引きこもり娘は外出の夢を見た",
+        "cost": "1 Purple",
         "dmg": 10,
         "description": "Deal 20 special damage to your opponent's center holomem and collab holomem with a different color to their Oshi holomem."
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP08",
     "searchString": "ninomae ina'nis hbp08-068 #en #myth #painting #sea きタコれ！ : if you went second and it is your first turn, all of your opponent's holomem are regarded as holomem with all colors. 引きこもり娘は外出の夢を見た deal 20 special damage to your opponent's center holomem and collab holomem with a different color to their oshi holomem."
   },
@@ -15145,10 +15881,12 @@
     "skills": [
       {
         "name": "うまくいったでしょ、もっといけるよ",
+        "cost": "1 any color",
         "dmg": 30
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP08",
     "searchString": "ninomae ina'nis hbp08-069 #en #myth #painting #sea 夏の訪れ : if there are 3 or more holomem with #painting on your stage, draw 1 card. うまくいったでしょ、もっといけるよ "
   },
@@ -15164,11 +15902,13 @@
     "skills": [
       {
         "name": "私の生涯の友人",
+        "cost": "1 Purple",
         "dmg": 30,
         "description": "Restore 10 HP to 1 of your holomem with #Myth for each holomem on your opponent's stage with a different color to their Oshi holomem."
       }
     ],
     "hasFoils": true,
+    "batonTouch": 2,
     "setName": "hBP08",
     "searchString": "ninomae ina'nis hbp08-070 #en #myth #painting #sea イナ・イマジネーション : reveal 1 <takodachi> from your deck, and add it to hand. then, shuffle the deck. 私の生涯の友人 restore 10 hp to 1 of your holomem with #myth for each holomem on your opponent's stage with a different color to their oshi holomem."
   },
@@ -15184,10 +15924,12 @@
     "skills": [
       {
         "name": "Bonk!",
+        "cost": "2 any color",
         "dmg": 50
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP08",
     "searchString": "ninomae ina'nis hbp08-071 #en #myth #painting #sea tomorrow!? : deal 20 special damage to 1 of your opponent's holomem with a different color to their oshi holomem. bonk! "
   },
@@ -15203,11 +15945,13 @@
     "skills": [
       {
         "name": "マルチカラー・スケッチ",
+        "cost": "1 Purple",
         "dmg": "30+",
         "description": "The Arts gets +10 for each holomem on your opponent's stage with a different color to their Oshi holomem."
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP08",
     "searchString": "ninomae ina'nis hbp08-072 #en #myth #painting #sea #summer natsu ina!! : if you have 8 or more holomem with #myth in your archive, return 1 holomem with #myth from your archive to hand. you may only use bloom effect \"natsu ina!!\" once per turn. マルチカラー・スケッチ the arts gets +10 for each holomem on your opponent's stage with a different color to their oshi holomem."
   },
@@ -15223,10 +15967,12 @@
     "skills": [
       {
         "name": "おやつのクッキー抜きだよ！",
+        "cost": "2 any color",
         "dmg": "90, +50 vs blue"
       }
     ],
     "hasFoils": true,
+    "batonTouch": 2,
     "setName": "hBP08",
     "searchString": "ninomae ina'nis hbp08-073 #en #myth #painting #sea お行儀よくしてね？ : choose 2 holomem on your opponent's stage. during this turn, the chosen holomem are regarded as holomem with all colors. おやつのクッキー抜きだよ！ "
   },
@@ -15242,12 +15988,14 @@
     "skills": [
       {
         "name": "ネクロ・エリミネーション!!",
+        "cost": "3 any color",
         "dmg": "110, +50 vs yellow",
         "description": "You may archive 1~3 cards from your hand: Choose 1 of your opponent's holomem for each card archived with this ability. During this turn, the chosen holomem are regarded as holomem with all colors."
       }
     ],
     "hasFullArt": true,
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP08",
     "searchString": "ninomae ina'nis hbp08-074 #en #myth #painting #sea 目覚めよ、赤き眼の黒龍 : [center position only] draw 1 card for each holomem on your opponent's stage with a different color to their oshi holomem. ネクロ・エリミネーション!! you may archive 1~3 cards from your hand: choose 1 of your opponent's holomem for each card archived with this ability. during this turn, the chosen holomem are regarded as holomem with all colors."
   },
@@ -15263,11 +16011,13 @@
     "skills": [
       {
         "name": "一緒に外に行こうよ",
+        "cost": "2 Purple",
         "dmg": "110+, +50 vs yellow",
         "description": "This Arts gets +20 for each <Roboser> attached to this holomem."
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP08",
     "searchString": "robocosan hbp08-075 #jp #gen0 #shooter ロボ子さん↔ろぼさー : reveal 1 <roboser> from your deck, and add it to hand. then, shuffle the deck. 一緒に外に行こうよ this arts gets +20 for each <roboser> attached to this holomem."
   },
@@ -15283,11 +16033,13 @@
     "skills": [
       {
         "name": "ごはんをいっぱい食べたあとには……",
+        "cost": "1 Purple, 2 any color",
         "dmg": "120, +50 vs blue",
         "description": "If you have 3 or more events with #Food in your archive, restore 100 HP to this holomem."
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP08",
     "searchString": "yuzuki choco hbp08-076 #jp #gen2 #cooking おいしいごはんの夢 : look at the top 3 cards of your deck. reveal 1 [holomem with #cooking and/or event with #food] each from among them, and add the revealed ccards to hand. then, return the remaining cards to the bottom of the deck in any order. ごはんをいっぱい食べたあとには…… if you have 3 or more events with #food in your archive, restore 100 hp to this holomem."
   },
@@ -15303,9 +16055,11 @@
     "skills": [
       {
         "name": "奏スタンバイ",
+        "cost": "1 any color",
         "dmg": 20
       }
     ],
+    "batonTouch": 1,
     "setName": "hBP08",
     "searchString": "otonose kanade hbp08-077 #dev_is #regloss #singing 歌ってみた、聴いてください : if you went second and it is your first turn, reveal 1 [1st holomem <otonose kanade> and/or <recorder>] each from your deck, and add them to hand. then, shuffle the deck. 奏スタンバイ "
   },
@@ -15321,10 +16075,12 @@
     "skills": [
       {
         "name": "れろれろれろれろ",
+        "cost": "1 any color",
         "dmg": 20
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP08",
     "searchString": "otonose kanade hbp08-078 #dev_is #regloss #singing 楽しい月曜日だよー！！！！！！！！ : choose 1 2nd holomem with #singing on your stage. during this turn, the chosen holomem gets arts+20. れろれろれろれろ "
   },
@@ -15340,11 +16096,13 @@
     "skills": [
       {
         "name": "清廉なる歌声",
+        "cost": "1 any color",
         "dmg": 10,
         "description": "You may send 1 cheer from your archive to your center holomem with #ReGLOSS."
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP08",
     "searchString": "otonose kanade hbp08-079 #dev_is #regloss #singing 黎明の歌姫 : while you have a 2nd holomem with #regloss on your stage, this holomem gets +50 hp. 清廉なる歌声 you may send 1 cheer from your archive to your center holomem with #regloss."
   },
@@ -15361,10 +16119,12 @@
     "skills": [
       {
         "name": "奏ストラクション",
+        "cost": "1 any color",
         "dmg": 20
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP08",
     "searchString": "otonose kanade hbp08-080 #dev_is #regloss #singing ファイティングエール : if the number of cheers on your stage is more than your opponent's, you may place 1 debut holomem with #regloss from your deck on stage. then, shuffle the deck. ction\ncost: 1 any color\npower: 20 奏ストラクション "
   },
@@ -15380,11 +16140,13 @@
     "skills": [
       {
         "name": "今年も伸び盛り",
+        "cost": "1 Yellow, 1 any color",
         "dmg": "40+",
         "description": "[Center Position Only] If you have 1 more cheer on your stage than your opponent, this Arts gets +20. If you have 2 or more, this Arts gets +40 instead."
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP08",
     "searchString": "otonose kanade hbp08-081 #dev_is #regloss #singing 音の饗宴 : send 1 cheer from your archive to your center holomem <otonose kanade>. 今年も伸び盛り [center position only] if you have 1 more cheer on your stage than your opponent, this arts gets +20. if you have 2 or more, this arts gets +40 instead."
   },
@@ -15400,10 +16162,12 @@
     "skills": [
       {
         "name": "涙が止まらないよ～",
+        "cost": "1 Yellow, 1 any color",
         "dmg": "100, +50 vs white"
       }
     ],
     "hasFoils": true,
+    "batonTouch": 2,
     "setName": "hBP08",
     "searchString": "otonose kanade hbp08-082 #dev_is #regloss #singing めでたい日なのに…… : if the number of cheers on your stage is more than your opponent's, during this turn, this holomem gets arts+40. 涙が止まらないよ～ "
   },
@@ -15419,12 +16183,14 @@
     "skills": [
       {
         "name": "奏オンステージ",
+        "cost": "2 Yellow, 1 any color",
         "dmg": "120+, +50 vs blue",
         "description": "If the number of cheers on your stage is more than your opponent's, this Arts gets +20 for each cheer more."
       }
     ],
     "hasFullArt": true,
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP08",
     "searchString": "otonose kanade hbp08-083 #dev_is #regloss #singing テンション超アップ！ : if the number of cheers on your stage is less than or equal to your opponent's, send 1~2 cheers from your archive to this holomem. 奏オンステージ if the number of cheers on your stage is more than your opponent's, this arts gets +20 for each cheer more."
   },
@@ -15440,11 +16206,13 @@
     "skills": [
       {
         "name": "まちゅだってお姫さま♡",
+        "cost": "1 any color",
         "dmg": "30+",
         "description": "If there is a 2nd holomem with #Gen 1 on your stage, this Arts gets +30."
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP08",
     "searchString": "natsuiro matsuri hbp08-084 #jp #gen1 #shooter 優雅なてぃーたいむ！ : if your life is 3 or less, during this turn, all holomem with #gen 1 on your stage get arts+20. まちゅだってお姫さま♡ if there is a 2nd holomem with #gen 1 on your stage, this arts gets +30."
   },
@@ -15460,10 +16228,12 @@
     "skills": [
       {
         "name": "テレ隠しが下手ですな～",
+        "cost": "1 any color",
         "dmg": 10
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP08",
     "searchString": "shiranui flare hbp08-085 #jp #gen3 #half-elf 手、繋いでいると温かいね : you may archive 1 card from your hand: return 1 [debut holomem, 1st holomem or spot holomem] from your archive to hand. テレ隠しが下手ですな～ "
   },
@@ -15479,11 +16249,13 @@
     "skills": [
       {
         "name": "最高のともだち",
+        "cost": "1 any color",
         "dmg": "20+",
         "description": "If your center holomem is a 2nd holomem, this Arts gets +30."
       }
     ],
     "hasFoils": true,
+    "batonTouch": 1,
     "setName": "hBP08",
     "searchString": "shiranui flare hbp08-086 #jp #gen3 #half-elf 俺のイナー！ : you may send the top card of your cheer deck to your [<shiranui flare> or holomem with #en]. 最高のともだち if your center holomem is a 2nd holomem, this arts gets +30."
   },
@@ -15499,10 +16271,12 @@
     "skills": [
       {
         "name": "夢から醒めたら",
+        "cost": "2 any color",
         "dmg": "90, +50 vs blue"
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hBP08",
     "searchString": "shiranui flare hbp08-087 #jp #gen3 #half-elf ドリーミングエール : you may send 1~2 cheers from your archive to your [<shiranui flare> or holomem with #en] center holomem. 夢から醒めたら "
   },
@@ -15518,12 +16292,14 @@
     "skills": [
       {
         "name": "リレーションファンタジー",
+        "cost": "2 Yellow, 1 any color",
         "dmg": "140+, +50 vs white",
         "description": "[Collab Position Only] If your center holomem is a holomem with #Gen 3, this Arts gets +30."
       }
     ],
     "hasFullArt": true,
     "hasAlternativeArt": true,
+    "batonTouch": 2,
     "setName": "hBP08",
     "searchString": "shiranui flare hbp08-088 #jp #gen3 #half-elf メロゥ・フラワリー : [1/turn] during your turn, when this holomem moves to the collab position, deal 20 special damage to your opponent's center holomem and collab holomem. リレーションファンタジー [collab position only] if your center holomem is a holomem with #gen 3, this arts gets +30."
   },
@@ -15539,11 +16315,13 @@
     "skills": [
       {
         "name": "アイアムアゲーマー",
+        "cost": "1 Yellow",
         "dmg": 30,
         "description": "Send 1 cheer from your archive to your holomem with #Justice."
       }
     ],
     "hasFullArt": true,
+    "batonTouch": 1,
     "setName": "hBP08",
     "searchString": "gigi murin hbp08-089 #en #justice ラピッドファイア・ウィット : you may archive 1 holomem that is stacked to this holomem: attach 1 <popo> from your deck to your holomem. then, shuffle the deck. アイアムアゲーマー send 1 cheer from your archive to your holomem with #justice."
   },
@@ -17189,12 +17967,14 @@
     "skills": [
       {
         "name": "Konnakiri~",
+        "cost": "1 Red",
         "dmg": 30
       }
     ],
     "extraEffect": "You may include any number of this holomem in the deck.",
     "hasHolomenRare": true,
     "imageSet": "hBP06",
+    "batonTouch": 0,
     "setName": "hSD02",
     "searchString": "nakiri ayame hsd02-002 #jp #gen2 #shooter you may include any number of this holomem in the deck. konnakiri~ "
   },
@@ -17435,10 +18215,12 @@
     "skills": [
       {
         "name": "もぐもぐ～おかゆ～",
+        "cost": "1 any color",
         "dmg": 30
       }
     ],
     "extraEffect": "You may include any number of this holomem in the deck.",
+    "batonTouch": 1,
     "setName": "hSD03",
     "searchString": "nekomata okayu hsd03-002 #jp #gamers #kemomimi you may include any number of this holomem in the deck. もぐもぐ～おかゆ～ "
   },
@@ -17683,10 +18465,12 @@
     "skills": [
       {
         "name": "魔界の保健医",
+        "cost": "1 any color",
         "dmg": 30
       }
     ],
     "extraEffect": "You may include any number of this holomem in the deck.",
+    "batonTouch": 1,
     "setName": "hSD04",
     "searchString": "yuzuki choco hsd04-002 #jp #gen2 #cooking you may include any number of this holomem in the deck. 魔界の保健医 "
   },
@@ -18062,12 +18846,14 @@
     "skills": [
       {
         "name": "滅紫の雷",
+        "cost": "2 White, 1 any color",
         "dmg": "80+",
         "description": "If you have a Holomem with #ReGLOSS other than <Todoroki Hajime> on your Stage, this arts gains +30."
       }
     ],
     "imageSet": "hBP03",
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hSD05",
     "searchString": "todoroki hajime hsd05-009 #dev_is #regloss #baby ダンスでこの世界に彩を！ : reveal 1 debut holomem or 1st holomem card with #regloss from your deck and add it to your hand. then, shuffle your deck. 滅紫の雷 if you have a holomem with #regloss other than <todoroki hajime> on your stage, this arts gains +30."
   },
@@ -18273,12 +19059,14 @@
     "skills": [
       {
         "name": "天才では？",
+        "cost": "1 Green, 2 any color",
         "dmg": "70+",
         "description": "If there are at least 5 Cheers on your stage, this Art gains +50 power."
       }
     ],
     "imageSet": "hBP03",
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hSD06",
     "searchString": "kazama iroha hsd06-007 #jp #holox 元気をお届け : restore 30 hp to one of your holomems with $holox. 天才では？ if there are at least 5 cheers on your stage, this art gains +50 power."
   },
@@ -18385,16 +19173,19 @@
     "skills": [
       {
         "name": "こんぬいー！",
+        "cost": "1 any color",
         "dmg": 20
       },
       {
         "name": "不知火フレアだよ！",
+        "cost": "3 any color",
         "dmg": 60
       }
     ],
     "extraEffect": "You may include any number of this holomem in the deck.",
     "hasHolomenRare": true,
     "imageSet": "hBP05",
+    "batonTouch": 1,
     "setName": "hSD07",
     "searchString": "shiranui flare hsd07-002 #jp #gen3 #half-elf you may include any number of this holomem in the deck. こんぬいー！  不知火フレアだよ！ "
   },
@@ -18491,11 +19282,13 @@
     "skills": [
       {
         "name": "キミに見てほしいな！",
+        "cost": "1 Yellow, 1 any color",
         "dmg": 40
       }
     ],
     "hasFullArt": true,
     "imageSet": "hBP06",
+    "batonTouch": 2,
     "setName": "hSD07",
     "searchString": "shiranui flare hsd07-007 #jp #gen3 #half-elf また一つ成長した私を　 : [back position only] if your collab holomem has 70 of less hp remaining, you may switch this holomem with your collab holomem. キミに見てほしいな！ "
   },
@@ -18531,12 +19324,14 @@
     "skills": [
       {
         "name": "情熱ステージ",
+        "cost": "1 Yellow, 2 any color",
         "dmg": "70+",
         "description": "If you have 3 or less LIFE, this Art gains +70 power."
       }
     ],
     "imageSet": "hBP03",
     "hasFullArt": true,
+    "batonTouch": 2,
     "setName": "hSD07",
     "searchString": "shiranui flare hsd07-009 #jp #gen3 #half-elf 疲れ知らず : [center position only] whenever this holomem takes damage, it takes -10 damage. 情熱ステージ if you have 3 or less life, this art gains +70 power."
   },
@@ -18928,6 +19723,7 @@
         "dmg": "30"
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD10",
     "searchString": "rindo chihaya hsd10-002 #dev_is #flowglow you may include any number of this holomem in the deck はじまりんど～～～！ "
   },
@@ -19160,6 +19956,7 @@
         "dmg": "20"
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD11",
     "searchString": "koganei niko hsd11-002 #dev_is #flowglow you may include any number of this holomem in the deck ニコたんが～来たァー！ "
   },
@@ -19265,6 +20062,7 @@
         "description": "Until the end of your opponent's next turn, the Baton Pass cheer cost of the holomem currently in your opponent's center position is increased by +1 colorless cheer."
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD11",
     "searchString": "mizumiya su hsd11-007 #dev_is #flowglow you may include any number of this holomem in the deck しゅぴしゅわー until the end of your opponent's next turn, the baton pass cheer cost of the holomem currently in your opponent's center position is increased by +1 colorless cheer."
   },
@@ -19966,9 +20764,11 @@
     "skills": [
       {
         "name": "はじまんぼう！",
+        "cost": "1 any color",
         "dmg": 20
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD14",
     "searchString": "shirakami fubuki hsd14-002 #jp #gen1 #gamers #kemomimi #painting はじまんぼう！ "
   },
@@ -19983,9 +20783,11 @@
     "skills": [
       {
         "name": "今日もあなたのそばに -フブキ-",
+        "cost": "1 White",
         "dmg": 30
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD14",
     "searchString": "shirakami fubuki hsd14-003 #jp #gen1 #gamers #kemomimi #painting 今日もあなたのそばに -フブキ- "
   },
@@ -20001,9 +20803,11 @@
     "skills": [
       {
         "name": "ハイ　フレンズ！",
+        "cost": "1 any color",
         "dmg": 20
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD14",
     "searchString": "shirakami fubuki hsd14-004 #jp #gen1 #gamers #kemomimi #painting 白上のとこにおいでー : if you went second and it is your first turn, reveal 1 mascot from your deck, and add it to hand. then, shuffle the deck. ハイ　フレンズ！ "
   },
@@ -20019,9 +20823,11 @@
     "skills": [
       {
         "name": "いつでもいけるよ！",
+        "cost": "1 any color",
         "dmg": 20
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD14",
     "searchString": "shirakami fubuki hsd14-005 #jp #gen1 #gamers #kemomimi #painting いっちにー、さんしー : choose your center holomem. during this turn, the chosen holomem gets arts+10. いつでもいけるよ！ "
   },
@@ -20036,13 +20842,16 @@
     "skills": [
       {
         "name": "ようやくキミに会えた！！！",
+        "cost": "1 any color",
         "dmg": 30
       },
       {
         "name": "キラキラなきーつね！",
+        "cost": "1 White, 1 any color",
         "dmg": 50
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD14",
     "searchString": "shirakami fubuki hsd14-006 #jp #gen1 #gamers #kemomimi #painting ようやくキミに会えた！！！  キラキラなきーつね！ "
   },
@@ -20058,9 +20867,11 @@
     "skills": [
       {
         "name": "あーまいーこのきーもちー",
+        "cost": "1 any color",
         "dmg": 20
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD14",
     "searchString": "shirakami fubuki hsd14-007 #jp #gen1 #gamers #kemomimi #painting message for you -フブキ- : choose your center holomem. during this turn, the chosen holomem gets arts+10. あーまいーこのきーもちー "
   },
@@ -20076,10 +20887,12 @@
     "skills": [
       {
         "name": "一緒に行こう(??????)??",
+        "cost": "1 any color",
         "dmg": "20+",
         "description": "[Collab Position Only]If a mascot is attached to this holomem, this Arts gets +20."
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD14",
     "searchString": "shirakami fubuki hsd14-008 #jp #gen1 #gamers #kemomimi #painting 大丈夫ですよ！ : attach 1 mascot from your archive to this holomem. 一緒に行こう(??????)?? [collab position only]if a mascot is attached to this holomem, this arts gets +20."
   },
@@ -20095,9 +20908,11 @@
     "skills": [
       {
         "name": "胸を張って歌い続けるよ",
+        "cost": "1 White, 1 any color",
         "dmg": "90, +30 vs red"
       }
     ],
+    "batonTouch": 2,
     "setName": "hSD14",
     "searchString": "shirakami fubuki hsd14-009 #jp #gen1 #gamers #kemomimi #painting 私は倒れちゃいけないな : during your opponent's turn, when this holomem is downed, if this holomem has a mascot attached, draw 1 card. 胸を張って歌い続けるよ "
   },
@@ -20150,9 +20965,11 @@
     "skills": [
       {
         "name": "寄ってらっしゃい見てらっしゃい",
+        "cost": "1 any color",
         "dmg": 20
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD15",
     "searchString": "juufuutei raden hsd15-002 #dev_is #regloss #alcohol 寄ってらっしゃい見てらっしゃい "
   },
@@ -20167,9 +20984,11 @@
     "skills": [
       {
         "name": "今日もあなたのそばに -らでん-",
+        "cost": "1 Green",
         "dmg": 30
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD15",
     "searchString": "juufuutei raden hsd15-003 #dev_is #regloss #alcohol 今日もあなたのそばに -らでん- "
   },
@@ -20185,9 +21004,11 @@
     "skills": [
       {
         "name": "散歩でもいかがですかな？",
+        "cost": "1 any color",
         "dmg": 20
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD15",
     "searchString": "juufuutei raden hsd15-004 #dev_is #regloss #alcohol 一服朝っぱらでん : if you went second and it is your first turn, send the top card of your cheer deck to your back holomem. 散歩でもいかがですかな？ "
   },
@@ -20203,9 +21024,11 @@
     "skills": [
       {
         "name": "そろそろ始めちゃいますか",
+        "cost": "1 any color",
         "dmg": 20
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD15",
     "searchString": "juufuutei raden hsd15-005 #dev_is #regloss #alcohol 体力作り頑張るぞー！！！！！ : during your opponent's turn, when this holomem is downed, you may reattach 1 of this holomem's cheers to your other holomem. そろそろ始めちゃいますか "
   },
@@ -20220,13 +21043,16 @@
     "skills": [
       {
         "name": "世界を彩る -らでん-",
+        "cost": "1 Green, 1 any color",
         "dmg": 40
       },
       {
         "name": "ちょいと一席付き合ってみませんか？",
+        "cost": "1 Green, 2 any color",
         "dmg": 60
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD15",
     "searchString": "juufuutei raden hsd15-006 #dev_is #regloss #alcohol 世界を彩る -らでん-  ちょいと一席付き合ってみませんか？ "
   },
@@ -20242,9 +21068,11 @@
     "skills": [
       {
         "name": "この博物館おもしろそう！",
+        "cost": "1 any color",
         "dmg": 30
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD15",
     "searchString": "juufuutei raden hsd15-007 #dev_is #regloss #alcohol 旅の前日 : archive the top card of your deck. you may place 1 debut holomem from your archive on stage. この博物館おもしろそう！ "
   },
@@ -20260,10 +21088,12 @@
     "skills": [
       {
         "name": "きのこ狩り",
+        "cost": "1 Green, 1 any color",
         "dmg": "40+",
         "description": "If you have used an event with #Mushroom this turn, this Arts gets +10."
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD15",
     "searchString": "juufuutei raden hsd15-008 #dev_is #regloss #alcohol 薄明 : when this holomem downed your opponent's holomem, restore 20 hp to this holomem. きのこ狩り if you have used an event with #mushroom this turn, this arts gets +10."
   },
@@ -20279,9 +21109,11 @@
     "skills": [
       {
         "name": "伝統と革新をあなたに",
+        "cost": "1 Green, 2 any color",
         "dmg": "90, +30 vs blue"
       }
     ],
+    "batonTouch": 2,
     "setName": "hSD15",
     "searchString": "juufuutei raden hsd15-009 #dev_is #regloss #alcohol ザ・破天荒 : [center position only]during this turn, this holomem gets arts+20. 伝統と革新をあなたに "
   },
@@ -20324,9 +21156,11 @@
     "skills": [
       {
         "name": "さくらみこだよ～",
+        "cost": "1 any color",
         "dmg": 20
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD16",
     "searchString": "sakura miko hsd16-002 #jp #gen0 #baby さくらみこだよ～ "
   },
@@ -20341,9 +21175,11 @@
     "skills": [
       {
         "name": "エリート巫女アイドル！ さくらみこだよ～",
+        "cost": "1 Red",
         "dmg": 30
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD16",
     "searchString": "sakura miko hsd16-003 #jp #gen0 #baby エリート巫女アイドル！ さくらみこだよ～ "
   },
@@ -20359,9 +21195,11 @@
     "skills": [
       {
         "name": "でゃまれ！",
+        "cost": "1 any color",
         "dmg": 20
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD16",
     "searchString": "sakura miko hsd16-004 #jp #gen0 #baby 後攻なんですｹｰﾄﾞ : if you went second and it is your first turn, reveal 1 <35p> from your deck, and attach it to this holomem. then, shuffle the deck. でゃまれ！ "
   },
@@ -20376,10 +21214,12 @@
     "skills": [
       {
         "name": "桜風ランニング",
+        "cost": "1 any color",
         "dmg": 20,
         "description": "Roll a die once. If it is 3 or 5, draw 1 card."
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD16",
     "searchString": "sakura miko hsd16-005 #jp #gen0 #baby 桜風ランニング roll a die once. if it is 3 or 5, draw 1 card."
   },
@@ -20394,13 +21234,16 @@
     "skills": [
       {
         "name": "みんなみててにぇ",
+        "cost": "1 any color",
         "dmg": 20
       },
       {
         "name": "いっくぞぉおおおお",
+        "cost": "1 Red, 1 any color",
         "dmg": 50
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD16",
     "searchString": "sakura miko hsd16-006 #jp #gen0 #baby みんなみててにぇ  いっくぞぉおおおお "
   },
@@ -20416,10 +21259,12 @@
     "skills": [
       {
         "name": "みこの耳かきスキルに蕩けちゃえ",
+        "cost": "1 any color",
         "dmg": "30+",
         "description": "[Center Position Only]Roll a die once. If it is 3 or 5, this Arts gets +10."
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD16",
     "searchString": "sakura miko hsd16-007 #jp #gen0 #baby みこの膝にごろーんってして : during your opponent's turn, when this holomem is downed, draw 1 card. みこの耳かきスキルに蕩けちゃえ [center position only]roll a die once. if it is 3 or 5, this arts gets +10."
   },
@@ -20435,9 +21280,11 @@
     "skills": [
       {
         "name": "いっぱい遊ぼっ",
+        "cost": "1 any color",
         "dmg": 30
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD16",
     "searchString": "sakura miko hsd16-008 #jp #gen0 #baby 待ってたにぇ : roll a die once. if it is 3 or 5, return 1 <35p> from your archive to hand. いっぱい遊ぼっ "
   },
@@ -20453,9 +21300,11 @@
     "skills": [
       {
         "name": "この瞬間を見せてあげたいなって",
+        "cost": "1 Red, 2 any color",
         "dmg": "100, +30 vs yellow"
       }
     ],
+    "batonTouch": 2,
     "setName": "hSD16",
     "searchString": "sakura miko hsd16-009 #jp #gen0 #baby 35p、ありがとうだよー！ : during this turn, for each <35p> on your stage, this holomem gets arts+10. この瞬間を見せてあげたいなって "
   },
@@ -20489,9 +21338,11 @@
     "skills": [
       {
         "name": "バーチャルアイドル・星街すいせい",
+        "cost": "1 any color",
         "dmg": 20
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD17",
     "searchString": "hoshimachi suisei hsd17-002 #jp #gen0 #singing バーチャルアイドル・星街すいせい "
   },
@@ -20506,9 +21357,11 @@
     "skills": [
       {
         "name": "今日もあなたのそばに -すいせい-",
+        "cost": "1 Blue",
         "dmg": 30
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD17",
     "searchString": "hoshimachi suisei hsd17-003 #jp #gen0 #singing 今日もあなたのそばに -すいせい- "
   },
@@ -20524,9 +21377,11 @@
     "skills": [
       {
         "name": "私だけの輝き",
+        "cost": "1 any color",
         "dmg": 20
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD17",
     "searchString": "hoshimachi suisei hsd17-004 #jp #gen0 #singing ファーストスター : if you went second and it is your first turn, deal 20 special damage to 1 of your opponent's back holomem. 私だけの輝き "
   },
@@ -20541,10 +21396,12 @@
     "skills": [
       {
         "name": "よーし、レッスン開始だー！",
+        "cost": "1 any color",
         "dmg": 20,
         "description": "Deal 10 special damage to 1 of your opponent's back holomem."
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD17",
     "searchString": "hoshimachi suisei hsd17-005 #jp #gen0 #singing よーし、レッスン開始だー！ deal 10 special damage to 1 of your opponent's back holomem."
   },
@@ -20559,13 +21416,16 @@
     "skills": [
       {
         "name": "そろそろ始まるよ！",
+        "cost": "1 any color",
         "dmg": 30
       },
       {
         "name": "みんな準備はできてる？",
+        "cost": "1 Blue, 1 any color",
         "dmg": 50
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD17",
     "searchString": "hoshimachi suisei hsd17-006 #jp #gen0 #singing そろそろ始まるよ！  みんな準備はできてる？ "
   },
@@ -20581,9 +21441,11 @@
     "skills": [
       {
         "name": "バレンタイン……か……",
+        "cost": "1 any color",
         "dmg": 30
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD17",
     "searchString": "hoshimachi suisei hsd17-007 #jp #gen0 #singing message for you -すいせい- : [back position only]deal 10 special damage to 1 of your opponent's back holomem. バレンタイン……か…… "
   },
@@ -20599,10 +21461,12 @@
     "skills": [
       {
         "name": "あなたの一番星",
+        "cost": "1 Blue, 1 any color",
         "dmg": 40,
         "description": "Deal 10 special damage to 1 of your opponent's back holomem."
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD17",
     "searchString": "hoshimachi suisei hsd17-008 #jp #gen0 #singing 明日への歌 : during your opponent's turn, when this holomem is downed, draw 1 card. あなたの一番星 deal 10 special damage to 1 of your opponent's back holomem."
   },
@@ -20618,9 +21482,11 @@
     "skills": [
       {
         "name": "キラキラの向こう側へ",
+        "cost": "2 Blue, 1 any color",
         "dmg": "110, +30 vs purple"
       }
     ],
+    "batonTouch": 2,
     "setName": "hSD17",
     "searchString": "hoshimachi suisei hsd17-009 #jp #gen0 #singing 踊ったもん勝ち！ : during this turn, this holomem gets arts+20. キラキラの向こう側へ "
   },
@@ -20663,9 +21529,11 @@
     "skills": [
       {
         "name": "Nice to reap you",
+        "cost": "1 any color",
         "dmg": 20
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD18",
     "searchString": "mori calliope hsd18-002 #en #myth #singing nice to reap you "
   },
@@ -20680,9 +21548,11 @@
     "skills": [
       {
         "name": "今日もあなたのそばに -カリオペ-",
+        "cost": "1 Purple",
         "dmg": 30
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD18",
     "searchString": "mori calliope hsd18-003 #en #myth #singing 今日もあなたのそばに -カリオペ- "
   },
@@ -20698,9 +21568,11 @@
     "skills": [
       {
         "name": "あたためて貰えますか…？",
+        "cost": "1 any color",
         "dmg": 20
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD18",
     "searchString": "mori calliope hsd18-004 #en #myth #singing みーなさんっ : if you went second and it is your first turn, archive the top card of your deck. then, draw 1 card. あたためて貰えますか…？ "
   },
@@ -20716,9 +21588,11 @@
     "skills": [
       {
         "name": "一緒に、どう？",
+        "cost": "1 any color",
         "dmg": 20
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD18",
     "searchString": "mori calliope hsd18-005 #en #myth #singing 死神式ストレッチ : if you have a holomem with tool attached, deal 10 special damage to your opponent's center holomem. 一緒に、どう？ "
   },
@@ -20733,13 +21607,16 @@
     "skills": [
       {
         "name": "これから、頑張る。",
+        "cost": "1 any color",
         "dmg": 30
       },
       {
         "name": "負けない。諦めない。",
+        "cost": "1 Purple, 1 any color",
         "dmg": 50
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD18",
     "searchString": "mori calliope hsd18-006 #en #myth #singing これから、頑張る。  負けない。諦めない。 "
   },
@@ -20755,10 +21632,12 @@
     "skills": [
       {
         "name": "手伝ってもらって助かるよ",
+        "cost": "1 any color",
         "dmg": "30+",
         "description": "If a tool is attached to this holomem, this Arts gets +10."
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD18",
     "searchString": "mori calliope hsd18-007 #en #myth #singing ちょっとした特別なプレゼント : during your opponent's turn, when this holomem is downed, archive the top card of your deck. 手伝ってもらって助かるよ if a tool is attached to this holomem, this arts gets +10."
   },
@@ -20774,10 +21653,12 @@
     "skills": [
       {
         "name": "OK、もう一曲行こう！",
+        "cost": "1 Purple, 1 any color",
         "dmg": 40,
         "description": "[Center Position Only]Return 1 tool from your archive to hand."
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD18",
     "searchString": "mori calliope hsd18-008 #en #myth #singing ロックンロールリッパー : archive the top card of your deck. ok、もう一曲行こう！ [center position only]return 1 tool from your archive to hand."
   },
@@ -20793,9 +21674,11 @@
     "skills": [
       {
         "name": "刻むぞ冥界のビート",
+        "cost": "2 Purple",
         "dmg": "90, +30 vs green"
       }
     ],
+    "batonTouch": 2,
     "setName": "hSD18",
     "searchString": "mori calliope hsd18-009 #en #myth #singing ペイルライダー : if you have 6 or more holomem in your archive, deal 20 special damage to your opponent's center holomem. 刻むぞ冥界のビート "
   },
@@ -20829,9 +21712,11 @@
     "skills": [
       {
         "name": "あじまるあじまる～",
+        "cost": "1 any color",
         "dmg": 10
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD19",
     "searchString": "oozora subaru hsd19-002 #jp #gen2 #bird あじまるあじまる～ "
   },
@@ -20846,10 +21731,12 @@
     "skills": [
       {
         "name": "今日もあなたのそばに -スバル-",
+        "cost": "1 Yellow",
         "dmg": "20+",
         "description": "If your life is 2 or less, this Arts gets +10."
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD19",
     "searchString": "oozora subaru hsd19-003 #jp #gen2 #bird 今日もあなたのそばに -スバル- if your life is 2 or less, this arts gets +10."
   },
@@ -20865,9 +21752,11 @@
     "skills": [
       {
         "name": "しゅばぁ",
+        "cost": "1 any color",
         "dmg": 20
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD19",
     "searchString": "oozora subaru hsd19-004 #jp #gen2 #bird 大空スマイル : if you went second and it is your first turn, reveal 1 debut holomem from your deck, and place it on stage. then, shuffle the deck. しゅばぁ "
   },
@@ -20883,9 +21772,11 @@
     "skills": [
       {
         "name": "いっちにー、ホワッ、ホワッ！",
+        "cost": "1 any color",
         "dmg": 20
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD19",
     "searchString": "oozora subaru hsd19-005 #jp #gen2 #bird ダンスレッスンなんですｹｰﾄﾞ : this holomem takes -10 damage from your opponent's center holomem. いっちにー、ホワッ、ホワッ！ "
   },
@@ -20900,13 +21791,16 @@
     "skills": [
       {
         "name": "いっぱい頑張る！",
+        "cost": "1 any color",
         "dmg": 20
       },
       {
         "name": "いっぱい楽しむ！",
+        "cost": "1 Yellow, 1 any color",
         "dmg": 40
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD19",
     "searchString": "oozora subaru hsd19-006 #jp #gen2 #bird いっぱい頑張る！  いっぱい楽しむ！ "
   },
@@ -20922,10 +21816,12 @@
     "skills": [
       {
         "name": "忘れてなんかやるもんか",
+        "cost": "1 any color",
         "dmg": "30+",
         "description": "If 2 or more cheers are attached to this holomem, this Arts gets +20."
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD19",
     "searchString": "oozora subaru hsd19-007 #jp #gen2 #bird 青春エール : send 1 cheer from your archive to this holomem. 忘れてなんかやるもんか if 2 or more cheers are attached to this holomem, this arts gets +20."
   },
@@ -20940,10 +21836,12 @@
     "skills": [
       {
         "name": "萌え萌えギュン",
+        "cost": "1 any color",
         "dmg": "20+",
         "description": "[Collab Position Only]If there is a 2nd holomem on your opponent's stage, this Arts gets +20."
       }
     ],
+    "batonTouch": 1,
     "setName": "hSD19",
     "searchString": "oozora subaru hsd19-008 #jp #gen2 #bird 萌え萌えギュン [collab position only]if there is a 2nd holomem on your opponent's stage, this arts gets +20."
   },
@@ -20958,10 +21856,12 @@
     "skills": [
       {
         "name": "ダンシング・プレアデス",
+        "cost": "2 Yellow",
         "dmg": "80+, +30 vs white",
         "description": "If your life is 2 or less, this Arts gets +10."
       }
     ],
+    "batonTouch": 2,
     "setName": "hSD19",
     "searchString": "oozora subaru hsd19-009 #jp #gen2 #bird ダンシング・プレアデス if your life is 2 or less, this arts gets +10."
   },

--- a/sets/hBP/hBP01.json
+++ b/sets/hBP/hBP01.json
@@ -406,12 +406,14 @@
         "skills": [
             {
                 "name": "ミッションスタート",
+                "cost": "1 any color",
                 "dmg": "30"
             }
         ],
         "extraEffect": "You may include any number of this holomem in the deck",
         "hasHolomenRare": true,
-        "imageSet": "hBP07"
+        "imageSet": "hBP07",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-025",
@@ -479,10 +481,12 @@
         "skills": [
             {
                 "name": "ハイRyS！",
+                "cost": "1 any color",
                 "dmg": "30"
             }
         ],
-        "extraEffect": "You may include any number of this holomem in the deck."
+        "extraEffect": "You may include any number of this holomem in the deck.",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-029",
@@ -543,12 +547,14 @@
         "skills": [
             {
                 "name": "アロ～ナ！",
+                "cost": "1 any color",
                 "dmg": "30"
             }
         ],
         "extraEffect": "You may include any number of this holomem in the deck.",
         "hasHolomenRare": true,
-        "imageSet": "hBP05"
+        "imageSet": "hBP05",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-033",
@@ -646,11 +652,13 @@
         "skills": [
             {
                 "name": "こんぺこー!",
+                "cost": "1 Green",
                 "dmg": "20+",
                 "description": "Roll a die once: If the result is even, this art gains +20"
             }
         ],
-        "extraEffect": "You may include any number of this holomem in the deck."
+        "extraEffect": "You may include any number of this holomem in the deck.",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-039",
@@ -696,11 +704,13 @@
         "skills": [
             {
                 "name": "見逃しちゃだめべこだよ!",
+                "cost": "1 any color",
                 "dmg": 30
             }
         ],
         "hasFullArt": true,
-        "imageSet": "hBP06"
+        "imageSet": "hBP06",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-042",
@@ -751,12 +761,14 @@
         "skills": [
             {
                 "name": "こんあずき～!",
+                "cost": "1 any color",
                 "dmg": "20"
             }
         ],
         "hasHolomenRare": true,
         "imageSet": "hBP07",
-        "extraEffect": "You may include any number of this holomem in the deck."
+        "extraEffect": "You may include any number of this holomem in the deck.",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-045",
@@ -819,10 +831,12 @@
         "skills": [
             {
                 "name": "皆殿、風真いろはでござる-",
+                "cost": "1 any color",
                 "dmg": "20"
             }
         ],
-        "extraEffect": "You may include any number of this holomem in the deck."
+        "extraEffect": "You may include any number of this holomem in the deck.",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-049",
@@ -894,11 +908,13 @@
         "skills": [
             {
                 "name": "スラマッパギ!",
+                "cost": "1 any color",
                 "dmg": "10",
                 "description": "You may reattach 1 cheer from your stage to your holomem with #ID."
             }
         ],
-        "extraEffect": "You may include any number of this holomem in the deck."
+        "extraEffect": "You may include any number of this holomem in the deck.",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-053",
@@ -959,10 +975,12 @@
         "skills": [
             {
                 "name": "皆さん、待っ鷹ね?",
+                "cost": "1 any color",
                 "dmg": "30"
             }
         ],
-        "extraEffect": "You may include any number of this holomem in the deck."
+        "extraEffect": "You may include any number of this holomem in the deck.",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-057",
@@ -1064,11 +1082,13 @@
         "skills": [
             {
                 "name": "キッケリキー!",
+                "cost": "1 any color",
                 "dmg": "20+",
                 "description": "You may archive 1 card from your hand:This Arts gets +20."
             }
         ],
-        "extraEffect": "You may include any number of this holomem in the deck."
+        "extraEffect": "You may include any number of this holomem in the deck.",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-063",
@@ -1169,12 +1189,14 @@
         "skills": [
             {
                 "name": "ポルカおるよ！",
+                "cost": "1 any color",
                 "dmg": "20+"
             }
         ],
         "extraEffect": "You may include any number of this holomem in the deck.",
         "hasHolomenRare": true,
-        "imageSet": "hBP05"
+        "imageSet": "hBP05",
+        "batonTouch": 0
     },
     {
         "cardNumber": "hBP01-069",
@@ -1243,11 +1265,13 @@
         "skills": [
             {
                 "name": "WAZZUP!!",
+                "cost": "1 any color",
                 "dmg": "20",
                 "description": "If a red cheer is attached to this holomem, you may roll a die once:If it is odd, deal 20 Special Damage to your opponent's collab holomem.m"
             }
         ],
-        "extraEffect": "You may include any number of this holomem in the deck"
+        "extraEffect": "You may include any number of this holomem in the deck",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-073",
@@ -1307,13 +1331,15 @@
         "skills": [
             {
                 "name": "スターの原石",
+                "cost": "1 any color",
                 "dmg": "20",
                 "description": "Deal 10 Special Damage to 1 of your opponent's back holomem. However, your opponent's Life does not reduce even if downed."
             }
         ],
         "extraEffect": "You may include any number of this holomem in the deck.",
         "hasHolomenRare": true,
-        "imageSet": "hBP05"
+        "imageSet": "hBP05",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-077",
@@ -1410,10 +1436,12 @@
         "skills": [
             {
                 "name": "ぼこぼこぼこぼ",
+                "cost": "1 Blue",
                 "dmg": "30"
             }
         ],
-        "extraEffect": "You may include any number of this holomem in the deck."
+        "extraEffect": "You may include any number of this holomem in the deck.",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-083",
@@ -1514,11 +1542,13 @@
         "skills": [
             {
                 "name": "ムーン　ムーン　ムーナだよ！",
+                "cost": "1 Blue",
                 "dmg": "10",
                 "description": "You may roll a die once:If it is even, deal 20 Special Damage to 1 of your opponent's back holomem. However, your opponent's Life does not reduce even if downed."
             }
         ],
-        "extraEffect": "You may include any number of this holomem in the deck."
+        "extraEffect": "You may include any number of this holomem in the deck.",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-089",
@@ -1585,13 +1615,15 @@
         "skills": [
             {
                 "name": "クロにちは~",
+                "cost": "1 Blue",
                 "dmg": "10",
                 "description": "You may reattach 1 cheer from this holomem to your other holomem with #Promise."
             }
         ],
         "hasHolomenRare": true,
         "imageSet": "hBP07",
-        "extraEffect": "You may include any number of this holomem in the deck."
+        "extraEffect": "You may include any number of this holomem in the deck.",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-093",

--- a/sets/hBP/hBP01.json
+++ b/sets/hBP/hBP01.json
@@ -158,11 +158,13 @@
         "skills": [
             {
                 "name": "こんかなた〜",
+                "cost": "1 White",
                 "dmg": "40",
                 "description": "This Arts can only target the opponent's center holomem."
             }
         ],
-        "extraEffect": "You may include any number of this holomem in the deck."
+        "extraEffect": "You may include any number of this holomem in the deck.",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-010",
@@ -176,9 +178,11 @@
         "skills": [
             {
                 "name": "行ってきまーす",
+                "cost": "1 any color",
                 "dmg": "20"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-011",
@@ -191,9 +195,11 @@
         "skills": [
             {
                 "name": "塩対応かなたそ",
+                "cost": "1 White",
                 "dmg": "20"
             }
-        ]
+        ],
+        "batonTouch": 0
     },
     {
         "cardNumber": "hBP01-012",
@@ -207,9 +213,11 @@
         "skills": [
             {
                 "name": "い~っぱい応援して!",
+                "cost": "1 any color",
                 "dmg": "40"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-013",
@@ -223,9 +231,11 @@
         "skills": [
             {
                 "name": "エンジェルステージ",
+                "cost": "1 White, 1 any color",
                 "dmg": "50"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-014",
@@ -239,11 +249,13 @@
         "skills": [
             {
                 "name": "+漆黒の翼+",
+                "cost": "3 White",
                 "dmg": "100",
                 "description": "If your opponent's holomem is downed by this Arts, and the dealt Damage was greater than the remaining HP by 50 or more, your opponent gets Life-1.."
             }
         ],
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP01-015",
@@ -256,10 +268,12 @@
         "skills": [
             {
                 "name": "Oh, Hi",
+                "cost": "1 White",
                 "dmg": "10+",
                 "description": "If you have used a Support Card this turn, this Arts gets +20.0"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-016",
@@ -273,9 +287,11 @@
         "skills": [
             {
                 "name": "リラックスタイム",
+                "cost": "1 any color",
                 "dmg": "10"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-017",
@@ -288,13 +304,16 @@
         "skills": [
             {
                 "name": "一緒にお出かけ",
+                "cost": "1 White",
                 "dmg": "20"
             },
             {
                 "name": "コーヒーブレイク",
+                "cost": "1 White, 1 any color",
                 "dmg": "60"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-018",
@@ -307,10 +326,12 @@
         "skills": [
             {
                 "name": "思い出の欠片",
+                "cost": "1 White",
                 "dmg": "20+",
                 "description": "You may reveal the top card of your deck:If the revealed card has #Promise, this Arts gets +20. Then, add the revealed card to hand."
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-019",
@@ -324,9 +345,11 @@
         "skills": [
             {
                 "name": "いつも応援してくれてありがとう!",
+                "cost": "1 any color",
                 "dmg": "30"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-020",
@@ -340,10 +363,12 @@
         "skills": [
             {
                 "name": "みんな一緒に",
+                "cost": "1 White, 2 any color",
                 "dmg": "70",
                 "description": "During this turn, your center holomem and collab holomem get Arts+10 for each of your back holomem.."
             }
-        ]
+        ],
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP01-021",
@@ -356,6 +381,7 @@
         "skills": [
             {
                 "name": "みんな～こんそめ～",
+                "cost": "1 White",
                 "dmg": "30"
             }
         ],
@@ -373,9 +399,11 @@
         "skills": [
             {
                 "name": "みんな～こんそめ～",
-                "dmg": "30"
+                "cost": "1 any color",
+                "dmg": "40"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-023",
@@ -389,11 +417,13 @@
         "skills": [
             {
                 "name": "止まらねえぞ",
+                "cost": "2 White, 1 any color",
                 "dmg": "80",
                 "description": "You may roll a die once:If it is odd, use this Arts once more on the same holomem (This Arts may be repeated until that holomem is downed)."
             }
         ],
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP01-024",
@@ -426,13 +456,16 @@
         "skills": [
             {
                 "name": "温泉は飲まないでね！",
+                "cost": "1 White",
                 "dmg": "40"
             },
             {
                 "name": "温泉でくつろぐ一日を",
+                "cost": "1 White, 1 any color",
                 "dmg": "60"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-026",
@@ -446,9 +479,11 @@
         "skills": [
             {
                 "name": "ステージみんな「私のもの」",
+                "cost": "1 any color",
                 "dmg": "30"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-027",
@@ -463,12 +498,14 @@
         "skills": [
             {
                 "name": "アクセスコード: ID",
+                "cost": "1 White, 2 any color",
                 "dmg": "70+",
                 "description": "If you Center holomem has #ID, this Art gains +50 power."
             }
         ],
         "extraEffect": "When this holomem is downed, your life is reduced by 2.",
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP01-028",
@@ -499,9 +536,11 @@
         "skills": [
             {
                 "name": "清楚なネフィリムです！",
+                "cost": "1 White, 1 any color",
                 "dmg": "50"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-030",
@@ -515,9 +554,11 @@
         "skills": [
             {
                 "name": "一生懸命歌うから見ててね!",
+                "cost": "1 any color",
                 "dmg": "40"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-031",
@@ -531,10 +572,12 @@
         "skills": [
             {
                 "name": "約束の力",
+                "cost": "1 White, 2 any color",
                 "dmg": "50",
                 "description": "This Arts gets +20 for each of your holomem with #Promise."
             }
-        ]
+        ],
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP01-032",
@@ -568,9 +611,11 @@
         "skills": [
             {
                 "name": "アフターパーティ",
+                "cost": "1 Green",
                 "dmg": "20"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-034",
@@ -583,13 +628,16 @@
         "skills": [
             {
                 "name": "あらあら",
+                "cost": "1 Green",
                 "dmg": "30"
             },
             {
                 "name": "むぎゅむぎゅ雑談",
+                "cost": "1 Green, 1 any color",
                 "dmg": "50"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-035",
@@ -603,10 +651,12 @@
         "skills": [
             {
                 "name": "アキロゼ幻想曲",
+                "cost": "1 Green",
                 "dmg": "40",
                 "description": "If a tool is attached to this holomem, send the top card of your cheer deck to your holomem."
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-036",
@@ -620,9 +670,11 @@
         "skills": [
             {
                 "name": "今日もがんばローゼ!",
+                "cost": "1 any color",
                 "dmg": "30"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-037",
@@ -636,10 +688,12 @@
         "skills": [
             {
                 "name": "秘密の合鍵",
+                "cost": "3 Green",
                 "dmg": "70+",
                 "description": "If a tool is attached to this holomem, this Arts gets +50.."
             }
-        ]
+        ],
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP01-038",
@@ -672,10 +726,12 @@
         "skills": [
             {
                 "name": "こんぺこー!",
-                "dmg": "20+",
+                "cost": "1 any color",
+                "dmg": "30",
                 "description": "Roll a die once: If the result is even, this art gains +20"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-040",
@@ -688,9 +744,11 @@
         "skills": [
             {
                 "name": "無重力ジャンプ!",
-                "dmg": 30
+                "cost": "1 Green, 1 any color",
+                "dmg": "60"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-041",
@@ -723,14 +781,17 @@
         "skills": [
             {
                 "name": "白い砂浜と兎少女",
+                "cost": "1 Green",
                 "dmg": 40
             },
             {
                 "name": "きtらあああ",
+                "cost": "2 Green",
                 "dmg": "50+",
                 "description": "You may roll a die once:This Arts gets +10x the number rolled."
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-043",
@@ -744,11 +805,13 @@
         "skills": [
             {
                 "name": "全人類兎化計画",
+                "cost": "3 Green, 1 any color",
                 "dmg": "60+",
                 "description": "Roll a die three times, for each total of 1 on the rolled dice, this art +10."
             }
         ],
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP01-044",
@@ -782,9 +845,11 @@
         "skills": [
             {
                 "name": "海辺の街できみと～!",
+                "cost": "1 Green",
                 "dmg": "20"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-046",
@@ -798,10 +863,12 @@
         "skills": [
             {
                 "name": "こんな素敵な世界に来れました!",
+                "cost": "1 any color",
                 "dmg": "30",
                 "description": "Roll a die three times, for each total of 1 on the rolled dice, this art +10."
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-047",
@@ -815,10 +882,12 @@
         "skills": [
             {
                 "name": "新たな地図!",
+                "cost": "3 Green, 1 any color",
                 "dmg": "120"
             }
         ],
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP01-048",
@@ -849,13 +918,16 @@
         "skills": [
             {
                 "name": "とれたてナス",
+                "cost": "1 Green",
                 "dmg": "30"
             },
             {
                 "name": "おひとついかがでござるか？",
-                "dmg": "350"
+                "cost": "1 Green, 1 any color",
+                "dmg": "50"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-050",
@@ -869,10 +941,12 @@
         "skills": [
             {
                 "name": "元気を全力でお届けします!",
+                "cost": "1 Green, 1 any color",
                 "dmg": "20",
                 "description": "Send the top card of your cheer deck to your holomem with #HoloX other than 〈Kazama Iroha〉."
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-051",
@@ -886,16 +960,19 @@
         "skills": [
             {
                 "name": "エールを束ねて",
+                "cost": "1 Green, 1 any color",
                 "dmg": "50+",
                 "description": "[Collab Position only] This Arts gets +20 for each of this holomem's cheer. However, only up to 5 cheers are counted."
             },
             {
                 "name": "風華の輝き",
+                "cost": "1 Green, 2 any color",
                 "dmg": 70
             }
         ],
         "extraEffect": "When this holomem is downed, your life is reduced by 2.",
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP01-052",
@@ -927,9 +1004,11 @@
         "skills": [
             {
                 "name": "あなたの愛しの宇宙人",
+                "cost": "2 any color",
                 "dmg": "50"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-054",
@@ -943,9 +1022,11 @@
         "skills": [
             {
                 "name": "楽しみにしてるよ!!",
+                "cost": "1 any color",
                 "dmg": "30"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-055",
@@ -959,10 +1040,12 @@
         "skills": [
             {
                 "name": "リレーションスカイ",
+                "cost": "1 Green, 2 any color",
                 "dmg": "100",
                 "description": "IfIf your stage has a holomem with #ID other than 〈Airani Iofifteen〉, this Arts gets +50."
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-056",
@@ -994,10 +1077,12 @@
         "skills": [
             {
                 "name": "漆黒の翼で誘おう",
+                "cost": "1 Red",
                 "dmg": "20",
                 "description": "Deal 10 Special Damage to your opponent's collab holomem."
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-058",
@@ -1010,13 +1095,16 @@
         "skills": [
             {
                 "name": "こんルイルイ",
+                "cost": "1 Red",
                 "dmg": "30"
             },
             {
                 "name": "おつルイルイ",
+                "cost": "1 Red, 1 any color",
                 "dmg": "50"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-059",
@@ -1029,14 +1117,17 @@
         "skills": [
             {
                 "name": "パーティーへようこそ",
+                "cost": "1 Red",
                 "dmg": 30
             },
             {
                 "name": "Lui's Party",
+                "cost": "2 Red",
                 "dmg": 50,
                 "description": "You may archive 1 card from your hand:Reveal 1 1st holomem other than Buzz from your deck, and add it to hand. Then, shuffle the deck."
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-060",
@@ -1050,9 +1141,11 @@
         "skills": [
             {
                 "name": "しっかりついてきてよね!!",
+                "cost": "1 any color",
                 "dmg": "40"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-061",
@@ -1066,10 +1159,12 @@
         "skills": [
             {
                 "name": "ホークレイヴ",
+                "cost": "2 Red, 1 any color",
                 "dmg": "60",
                 "description": "You may archive 1~5 cards from your hand:Deal 20 Special Damage for each archived card to your opponent's center holomem or collab holomem.."
             }
-        ]
+        ],
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP01-062",
@@ -1102,9 +1197,11 @@
         "skills": [
             {
                 "name": "もふもふタイム",
+                "cost": "1 Red",
                 "dmg": "20"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-064",
@@ -1117,9 +1214,11 @@
         "skills": [
             {
                 "name": "auf Wiedersehen",
+                "cost": "1 Red",
                 "dmg": "20"
             }
-        ]
+        ],
+        "batonTouch": 0
     },
     {
         "cardNumber": "hBP01-065",
@@ -1133,9 +1232,11 @@
         "skills": [
             {
                 "name": "盛り上げたいとおもいます！",
+                "cost": "1 any color",
                 "dmg": "40"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-066",
@@ -1148,14 +1249,17 @@
         "skills": [
             {
                 "name": "不死鳥の剣姫",
+                "cost": "1 Red",
                 "dmg": "50"
             },
             {
                 "name": "跪きなさい。",
+                "cost": "2 Red",
                 "dmg": "40",
                 "description": "You may archive 1 holomem that is stacked to this holomem:Deal 40 Special Damage to your opponent's collab holomem."
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-067",
@@ -1168,15 +1272,18 @@
         "skills": [
             {
                 "name": "焔色の導き",
+                "cost": "2 Red",
                 "dmg": "70"
             },
             {
                 "name": "マジェスティック・フェニックス",
+                "cost": "3 Red",
                 "dmg": "80+",
                 "description": "This Arts gets +10 for each holomem in your archive. Then, return 6 holomem from your archive to deck and shuffle it."
             }
         ],
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP01-068",
@@ -1209,13 +1316,16 @@
         "skills": [
             {
                 "name": "おはぽる",
+                "cost": "1 Red",
                 "dmg": "20"
             },
             {
                 "name": "おそぽる",
+                "cost": "1 Red, 1 any color",
                 "dmg": "40"
             }
-        ]
+        ],
+        "batonTouch": 0
     },
     {
         "cardNumber": "hBP01-070",
@@ -1229,10 +1339,12 @@
         "skills": [
             {
                 "name": "共依存",
+                "cost": "1 Red, 1 any color",
                 "dmg": "70",
                 "description": "This Arts can only be used if a 〈Zain〉is attached to this holomem."
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-071",
@@ -1247,12 +1359,14 @@
         "skills": [
             {
                 "name": "ポルカサーカス",
-                "dmg": "60+",
+                "cost": "1 Red, 1 any color",
+                "dmg": "50+",
                 "description": "This Arts gets +20 for each fan attached to all of your holomem."
             }
         ],
         "extraEffect": "When this holomem is downed, your life is reduced by 2.",
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-072",
@@ -1284,9 +1398,11 @@
         "skills": [
             {
                 "name": "WITNESS ME!!",
+                "cost": "1 Red, 1 any color",
                 "dmg": "60"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-074",
@@ -1300,9 +1416,11 @@
         "skills": [
             {
                 "name": "楽しい時間の始まりだ!",
+                "cost": "1 any color",
                 "dmg": "30"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-075",
@@ -1316,9 +1434,11 @@
         "skills": [
             {
                 "name": "Disorder!",
+                "cost": "1 Red, 1 any color",
                 "dmg": "100"
             }
-        ]
+        ],
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP01-076",
@@ -1353,9 +1473,11 @@
         "skills": [
             {
                 "name": "新しい衣装",
+                "cost": "1 Blue",
                 "dmg": "30"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-078",
@@ -1368,13 +1490,16 @@
         "skills": [
             {
                 "name": "ストリートスナップ",
+                "cost": "1 Blue",
                 "dmg": "30"
             },
             {
                 "name": "木漏れ日のひと時",
+                "cost": "1 Blue, 1 any color",
                 "dmg": "50"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-079",
@@ -1388,9 +1513,11 @@
         "skills": [
             {
                 "name": "すいちゃんはーー今日もかわいいーー！！",
+                "cost": "2 any color",
                 "dmg": "50"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-080",
@@ -1404,9 +1531,11 @@
         "skills": [
             {
                 "name": "戦うメイドさん",
+                "cost": "2 Blue",
                 "dmg": "70"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-081",
@@ -1420,11 +1549,13 @@
         "skills": [
             {
                 "name": "輝く彗星",
+                "cost": "3 Blue, 1 any color",
                 "dmg": "60+",
                 "description": "You may archive 2 blue cheers from this holomem:This Arts gets +60 for each holomem that is stacked to this holomem (This Arts can target your opponent's back holomem too)."
             }
         ],
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP01-082",
@@ -1455,9 +1586,11 @@
         "skills": [
             {
                 "name": "波だ~! 泳げ~!",
+                "cost": "1 any color",
                 "dmg": "10"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-084",
@@ -1470,9 +1603,11 @@
         "skills": [
             {
                 "name": "になる～　",
+                "cost": "1 Blue, 1 any color",
                 "dmg": "50"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-085",
@@ -1485,14 +1620,17 @@
         "skills": [
             {
                 "name": "perayaan",
+                "cost": "1 Blue",
                 "dmg": "40"
             },
             {
                 "name": "レインドロップス",
+                "cost": "1 Blue, 1 any color",
                 "dmg": "50",
                 "description": "Deal 10 Special Damage to 3 of your opponent's back holomem. However, your opponent's Life does not reduce even if downed."
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-086",
@@ -1506,9 +1644,11 @@
         "skills": [
             {
                 "name": "OnAeru",
+                "cost": "1 any color",
                 "dmg": "40"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-087",
@@ -1521,15 +1661,18 @@
         "skills": [
             {
                 "name": "雨のマントラ",
+                "cost": "1 Blue, 1 any color",
                 "dmg": "40",
                 "description": "You may archive 1 cheer from this holomem:Deal 20 Special Damage to all of your opponent's back holomem. However, your opponent's Life does not reduce even if downed."
             },
             {
                 "name": "波のマントラ",
+                "cost": "2 Blue, 1 any color",
                 "dmg": 40,
                 "description": "You may archive 2 cheers from this holomem:Deal the same amount of Special Damage to the opponent's center holomem as the total number of Damage taken by all of your opponent's back holomem."
             }
-        ]
+        ],
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP01-088",
@@ -1561,9 +1704,11 @@
         "skills": [
             {
                 "name": "おつムーナ",
+                "cost": "1 Blue, 1 any color",
                 "dmg": "60"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-090",
@@ -1577,9 +1722,11 @@
         "skills": [
             {
                 "name": "楽しみにしてて!!",
+                "cost": "1 any color",
                 "dmg": "20"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-091",
@@ -1593,16 +1740,19 @@
         "skills": [
             {
                 "name": "月は夜に。",
+                "cost": "2 any color",
                 "dmg": "50"
             },
             {
                 "name": "ムーンナイトディーパ",
+                "cost": "1 Blue, 2 any color",
                 "dmg": 80,
                 "description": "You may archive 1 [green cheer or blue cheer] from this holomem:Deal 30 Special Damage to 1 of your opponent's back holomem."
             }
         ],
         "extraEffect": "When this holomem is downed, your life is reduced by 2.",
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP01-092",
@@ -1636,13 +1786,16 @@
         "skills": [
             {
                 "name": "クロやすみ～",
+                "cost": "1 any color",
                 "dmg": "40"
             },
             {
                 "name": "お休みクロタイム",
+                "cost": "1 Blue, 1 any color",
                 "dmg": "60"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-094",
@@ -1656,9 +1809,11 @@
         "skills": [
             {
                 "name": "忘れられないfesにしよう!!",
+                "cost": "1 any color",
                 "dmg": "40"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-095",
@@ -1672,10 +1827,12 @@
         "skills": [
             {
                 "name": "早送り",
+                "cost": "1 Blue, 2 any color",
                 "dmg": "60",
                 "description": "You may Bloom a 1st holomem from your hand on 1 of your Debut back holomem placed this turn"
             }
-        ]
+        ],
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP01-096",
@@ -1689,10 +1846,12 @@
         "skills": [
             {
                 "name": "ぺこら~扉の向こう側へ~",
+                "cost": "1 any color",
                 "dmg": 10
             }
         ],
-        "extraEffect": "This holomem cannot Bloom."
+        "extraEffect": "This holomem cannot Bloom.",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-097",
@@ -1706,10 +1865,12 @@
         "skills": [
             {
                 "name": "フレア~扉の向こう側へ~",
+                "cost": "1 any color",
                 "dmg": "20"
             }
         ],
-        "extraEffect": "This holomem cannot Bloom."
+        "extraEffect": "This holomem cannot Bloom.",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-098",
@@ -1723,10 +1884,12 @@
         "skills": [
             {
                 "name": "ノエル~扉の向こう側へ~",
+                "cost": "2 any color",
                 "dmg": 20
             }
         ],
-        "extraEffect": "This holomem cannot Bloom."
+        "extraEffect": "This holomem cannot Bloom.",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-099",
@@ -1740,10 +1903,12 @@
         "skills": [
             {
                 "name": "マリン~扉の向こう側へ~",
+                "cost": "1 any color",
                 "dmg": 10
             }
         ],
-        "extraEffect": "This holomem cannot Bloom."
+        "extraEffect": "This holomem cannot Bloom.",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-100",
@@ -1757,10 +1922,12 @@
         "skills": [
             {
                 "name": "ソウルご案内",
+                "cost": "1 any color",
                 "dmg": 30
             }
         ],
-        "extraEffect": "This holomem cannot Bloom."
+        "extraEffect": "This holomem cannot Bloom.",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-101",
@@ -1774,10 +1941,12 @@
         "skills": [
             {
                 "name": "初歩的なことなんでしょう？",
+                "cost": "2 any color",
                 "dmg": 20
             }
         ],
-        "extraEffect": "This holomem cannot Bloom."
+        "extraEffect": "This holomem cannot Bloom.",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP01-102",

--- a/sets/hBP/hBP02.json
+++ b/sets/hBP/hBP02.json
@@ -158,9 +158,11 @@
         "skills": [
             {
                 "name": "Otsu-kon-deshita",
+                "cost": "1 White",
                 "dmg": "20"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP02-010",
@@ -173,14 +175,17 @@
         "skills": [
             {
                 "name": "キンモクセイの花フブキ",
+                "cost": "1 White",
                 "dmg": "40"
             },
             {
                 "name": "Thank You Friends♥",
+                "cost": "1 White, 1 any color",
                 "dmg": "60"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP02-011",
@@ -194,10 +199,12 @@
         "skills": [
             {
                 "name": "ダメですよっ！",
+                "cost": "1 any color",
                 "dmg": "40"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP02-012",
@@ -211,11 +218,13 @@
         "skills": [
             {
                 "name": "力をかしてくださいね",
+                "cost": "1 White, 1 any color",
                 "dmg": "50+",
                 "description": "During this turn, your [center holomem and collab holomem] with mascot attached get Arts+20."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP02-013",
@@ -229,12 +238,14 @@
         "skills": [
             {
                 "name": "マスコットたちの舞宴",
+                "cost": "2 White, 1 any color",
                 "dmg": "80+",
                 "description": "This Arts gets +20 for each mascot on your stage."
             }
         ],
         "hasAlternativeArt": true,
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP02-014",
@@ -267,14 +278,17 @@
         "skills": [
             {
                 "name": "おはまっする〜!",
+                "cost": "1 any color",
                 "dmg": "30"
             },
             {
                 "name": "おつまっする~",
+                "cost": "1 White, 1 any color",
                 "dmg": "60"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP02-016",
@@ -308,17 +322,20 @@
         "skills": [
             {
                 "name": "ゆるふわ脳筋女騎士",
+                "cost": "2 any color",
                 "dmg": "50"
             },
             {
                 "name": "3期生ぱわー",
+                "cost": "1 White, 2 any color",
                 "dmg": "60+",
                 "description": "(Collab position only) For each other Holomen on your stage with the #Gen3 tag, this Arts gets +20. However, the number of Holomen counted is limited to 4.."
             }
         ],
         "extraEffect": "If this holomem is downed, you get Life-2",
         "hasAlternativeArt": true,
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP02-018",
@@ -350,10 +367,12 @@
         "skills": [
             {
                 "name": "Very Easy",
+                "cost": "1 any color",
                 "dmg": "20"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP02-020",
@@ -366,10 +385,12 @@
         "skills": [
             {
                 "name": "Royal Halu Sleepover",
+                "cost": "1 Green, 1 any color",
                 "dmg": "50"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP02-021",
@@ -383,11 +404,13 @@
         "skills": [
             {
                 "name": "だから見ててね！大好き！",
+                "cost": "1 any color",
                 "dmg": "20",
                 "description": "You may send 1 Cheer from your Archive to any of your holomems."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP02-022",
@@ -401,11 +424,13 @@
         "skills": [
             {
                 "name": "Spicy Night",
+                "cost": "1 Green, 1 any color",
                 "dmg": "40+",
                 "description": "If your stage has 2 or more cheer colors, this Arts gets +20."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP02-023",
@@ -419,12 +444,14 @@
         "skills": [
             {
                 "name": "孔雀の舞",
+                "cost": "1 Green, 3 any color",
                 "dmg": "100+",
                 "description": "This Arts gets +20 for every cheer color on your stage."
             }
         ],
         "hasAlternativeArt": true,
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP02-024",
@@ -456,14 +483,17 @@
         "skills": [
             {
                 "name": "おはみぉーん",
+                "cost": "1 any color",
                 "dmg": "30"
             },
             {
                 "name": "おつみぉーん",
+                "cost": "1 Green, 1 any color",
                 "dmg": "50"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP02-026",
@@ -477,10 +507,12 @@
         "skills": [
             {
                 "name": "今年も見守っててね！",
+                "cost": "1 any color",
                 "dmg": "20"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP02-027",
@@ -493,13 +525,15 @@
         "skills": [
             {
                 "name": "タロットの導き",
+                "cost": "1 Green, 1 any color",
                 "dmg": "60+",
                 "description": "You may archive the top card of your deck:If the archived card is a holomem, this Arts gets +20. If it is a support card, this Arts gets +50."
             }
         ],
         "extraEffect": "If this holomem is downed, you get Life-2",
         "hasAlternativeArt": true,
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP02-028",
@@ -512,10 +546,12 @@
         "skills": [
             {
                 "name": "宝鐘海賊団船長の宝鐘マリンですぅー!",
+                "cost": "1 any color",
                 "dmg": "30"
             }
         ],
-        "extraEffect": "You may include any number of this holomem in the deck."
+        "extraEffect": "You may include any number of this holomem in the deck.",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP02-029",
@@ -529,9 +565,11 @@
         "skills": [
             {
                 "name": "マリン“船長”だろぉぉん！？",
+                "cost": "1 Red, 1 any color",
                 "dmg": "30"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP02-030",
@@ -544,14 +582,17 @@
         "skills": [
             {
                 "name": "船長、何されちゃうのかな？",
+                "cost": "1 Red",
                 "dmg": "40"
             },
             {
                 "name": "もう、どスケベ♥",
+                "cost": "1 Red, 1 any color",
                 "dmg": "60"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP02-031",
@@ -585,10 +626,12 @@
         "skills": [
             {
                 "name": "ヨーソロー",
+                "cost": "2 any color",
                 "dmg": "50"
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP02-033",
@@ -602,12 +645,14 @@
         "skills": [
             {
                 "name": "キミたち～？: 船長、かわいい？",
+                "cost": "1 Red, 2 any color",
                 "dmg": "80+",
                 "description": "This Arts gets +20 for each holomem stacked to this holomem."
             }
         ],
         "hasAlternativeArt": true,
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP02-034",
@@ -621,17 +666,20 @@
         "skills": [
             {
                 "name": "余は草",
+                "cost": "1 Red, 1 any color",
                 "dmg": "50"
             },
             {
                 "name": "オーガニックショット",
+                "cost": "1 Red, 2 any color",
                 "dmg": "80",
                 "description": "If a tool or mascot is attached to this holomem, deal 30 special damage to your opponent's center holomem or collab holomem."
             }
         ],
         "extraEffect": "If this holomem is downed, you get Life-2",
         "hasAlternativeArt": true,
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP02-035",
@@ -644,10 +692,12 @@
         "skills": [
             {
                 "name": "ばっくばっくばく～ん",
+                "cost": "1 any color",
                 "dmg": "30"
             }
         ],
-        "extraEffect": "You may include any number of this holomem in the deck."
+        "extraEffect": "You may include any number of this holomem in the deck.",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP02-036",
@@ -661,10 +711,12 @@
         "skills": [
             {
                 "name": "吐いて捨てるような現実を！",
+                "cost": "1 any color",
                 "dmg": "20"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP02-037",
@@ -677,10 +729,12 @@
         "skills": [
             {
                 "name": "ふたりじめビーチ",
+                "cost": "1 Blue, 1 any color",
                 "dmg": "60"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP02-038",
@@ -694,10 +748,12 @@
         "skills": [
             {
                 "name": "(ここ喜ぶ所です）",
+                "cost": "1 any color",
                 "dmg": "30"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP02-039",
@@ -711,11 +767,13 @@
         "skills": [
             {
                 "name": "ホロックスロット",
+                "cost": "1 Blue, 1 any color",
                 "dmg": "20+",
                 "description": "You may reveal the top 3 cards of your deck:This Arts gets +20 for each holomem revealed. Then, archive the revealed cards."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP02-040",
@@ -729,12 +787,14 @@
         "skills": [
             {
                 "name": "ホロックスロット",
+                "cost": "2 Blue, 1 any color",
                 "dmg": "100+",
                 "description": "You may reveal the top 3 cards of your deck:This Arts gets +20 for each holomem revealed. Then, archive the revealed cards."
             }
         ],
         "hasAlternativeArt": true,
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP02-041",
@@ -749,13 +809,15 @@
         "skills": [
             {
                 "name": "ぽいずん猫",
+                "cost": "1 Blue, 2 any color",
                 "dmg": "50",
                 "description": "You may archive 1 ▲blue▲ cheer from this holomem:Deal 20 special damage to your opponent's center holomem and 1 of their back holomem."
             }
         ],
         "extraEffect": "If this holomem is downed, you get Life-2",
         "hasAlternativeArt": true,
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP02-042",
@@ -768,10 +830,12 @@
         "skills": [
             {
                 "name": "どうも～",
+                "cost": "1 any color",
                 "dmg": "20"
             }
         ],
-        "extraEffect": "You may include any number of this holomem in the deck."
+        "extraEffect": "You may include any number of this holomem in the deck.",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP02-043",
@@ -785,9 +849,11 @@
         "skills": [
             {
                 "name": "一緒に行こう",
+                "cost": "1 Purple",
                 "dmg": "30"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP02-044",
@@ -800,14 +866,17 @@
         "skills": [
             {
                 "name": "照れくさ",
+                "cost": "1 any color",
                 "dmg": "30"
             },
             {
                 "name": "やだ、もー",
+                "cost": "1 Purple, 1 any color",
                 "dmg": "60"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP02-045",
@@ -821,10 +890,12 @@
         "skills": [
             {
                 "name": "最高にハッピーです！！",
+                "cost": "1 any color",
                 "dmg": "40"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP02-046",
@@ -838,11 +909,13 @@
         "skills": [
             {
                 "name": "チェンジ・ザ・エール",
+                "cost": "2 Purple",
                 "dmg": "30",
                 "description": "You may roll a die once:If it is 5 or greater, reattach 1 of your opponent's cheers from stage to your opponent's holomem."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP02-047",
@@ -856,6 +929,7 @@
         "skills": [
             {
                 "name": "ヴァイオレットマジック",
+                "cost": "2 Purple, 1 any color",
                 "dmg": "80",
                 "description": "Deal 20 special damage for each of your opponent's center holomem's cheers to your opponent's center holomem and collab holomem."
             }
@@ -863,7 +937,8 @@
         "hasAlternativeArt": true,
         "hasFullArt": true,
         "hasGrandPrix": true,
-        "source": "Top 8 WGP2025"
+        "source": "Top 8 WGP2025",
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP02-048",
@@ -876,10 +951,12 @@
         "skills": [
             {
                 "name": "ゾンばんは！",
+                "cost": "1 any color",
                 "dmg": "20"
             }
         ],
-        "extraEffect": "You may include any number of this holomem in the deck."
+        "extraEffect": "You may include any number of this holomem in the deck.",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP02-049",
@@ -893,10 +970,12 @@
         "skills": [
             {
                 "name": "おつクレイジー！",
+                "cost": "1 any color",
                 "dmg": "20"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP02-050",
@@ -909,14 +988,17 @@
         "skills": [
             {
                 "name": "君を大好きな後輩",
+                "cost": "1 any color",
                 "dmg": "20"
             },
             {
                 "name": "きゃ～！先輩ごめ～ん！",
-                "dmg": "20"
+                "cost": "1 Purple, 1 any color",
+                "dmg": "60"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP02-051",
@@ -930,10 +1012,12 @@
         "skills": [
             {
                 "name": "推しを見て叫びまくるぞ！！",
+                "cost": "1 any color",
                 "dmg": "20"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP02-052",
@@ -947,11 +1031,13 @@
         "skills": [
             {
                 "name": "推しを見て叫びまくるぞ！！",
-                "dmg": "20",
+                "cost": "2 any color",
+                "dmg": "40+",
                 "description": "If a non-purple cheer is attached to this holomem, this Arts gets +20."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP02-053",
@@ -965,12 +1051,14 @@
         "skills": [
             {
                 "name": "計算された戦術",
+                "cost": "1 Purple, 2 any color",
                 "dmg": "100+",
                 "description": "If you have 2 or more 2nd holomem with #IDGen2 on your stage, this Arts gets +40."
             }
         ],
         "hasAlternativeArt": true,
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP02-054",
@@ -1005,10 +1093,12 @@
         "skills": [
             {
                 "name": "マイステージ",
+                "cost": "2 Purple",
                 "dmg": "20"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP02-056",
@@ -1021,10 +1111,12 @@
         "skills": [
             {
                 "name": "Cash-Money",
+                "cost": "1 Purple",
                 "dmg": "50"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP02-057",
@@ -1038,10 +1130,12 @@
         "skills": [
             {
                 "name": "一緒にブチアガろうぜ！",
+                "cost": "1 Purple, 1 any color",
                 "dmg": "50"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP02-058",
@@ -1055,11 +1149,13 @@
         "skills": [
             {
                 "name": "Dead Beat",
+                "cost": "1 Purple, 1 any color",
                 "dmg": "30+",
                 "description": "If this holomem has a Tool or a Mascot attached, this Art gains +30 power."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP02-059",
@@ -1073,12 +1169,14 @@
         "skills": [
             {
                 "name": "Featuring Myth",
+                "cost": "2 Purple, 1 any color",
                 "dmg": "80+",
                 "description": "If you have 4 or more holomem with #Myth in your archive, this Arts gets +40. Then, if you have 8 or more, this Arts gets +40."
             }
         ],
         "hasAlternativeArt": true,
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP02-060",
@@ -1092,11 +1190,13 @@
         "skills": [
             {
                 "name": "隠しきれない魅力",
+                "cost": "1 Purple, 2 any color",
                 "dmg": "80+"
             }
         ],
         "extraEffect": "If this holomem is downed, you get Life-2",
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP02-061",
@@ -1127,10 +1227,12 @@
         "skills": [
             {
                 "name": "君とタコグラム",
+                "cost": "2 Purple",
                 "dmg": "60"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP02-063",
@@ -1144,10 +1246,12 @@
         "skills": [
             {
                 "name": "楽しんでいこう！！！",
+                "cost": "1 any color",
                 "dmg": "30"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP02-064",
@@ -1161,13 +1265,15 @@
         "skills": [
             {
                 "name": "アルカイックスマイル",
+                "cost": "1 Purple, 1 any color",
                 "dmg": "60+",
                 "description": "If you have 5 or more holomem with #Myth in your archive, you may reattach 1 cheer from this holomem to your other holomem. Then, if you have 10 or more, this Arts gets +50."
             }
         ],
         "extraEffect": "If this holomem is downed, you get Life-2",
         "hasAlternativeArt": true,
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP02-065",
@@ -1201,14 +1307,17 @@
         "skills": [
             {
                 "name": "良い響きですね",
+                "cost": "1 any color",
                 "dmg": "30"
             },
             {
                 "name": "アイドルソングというものは",
+                "cost": "1 Purple, 1 any color",
                 "dmg": "60"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP02-067",
@@ -1222,10 +1331,12 @@
         "skills": [
             {
                 "name": "コーヒーよりも紅茶です",
+                "cost": "1 any color",
                 "dmg": "20"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP02-068",
@@ -1239,10 +1350,12 @@
         "skills": [
             {
                 "name": "歌に宿りし愛情",
+                "cost": "1 Purple, 2 any color",
                 "dmg": "80"
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP02-069",
@@ -1256,11 +1369,13 @@
         "skills": [
             {
                 "name": "『巫女』の『ホロ』！",
+                "cost": "1 any color",
                 "dmg": 20
             }
         ],
         "extraEffect": "This holomem cannot Bloom.",
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP02-070",
@@ -1274,11 +1389,13 @@
         "skills": [
             {
                 "name": "『天使』の『ホロ』！",
+                "cost": "1 any color",
                 "dmg": 20
             }
         ],
         "extraEffect": "This holomem cannot Bloom.",
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP02-071",
@@ -1292,11 +1409,13 @@
         "skills": [
             {
                 "name": "『姫』の『ホロ』！",
+                "cost": "1 any color",
                 "dmg": 20
             }
         ],
         "extraEffect": "This holomem cannot Bloom.",
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP02-072",
@@ -1310,11 +1429,13 @@
         "skills": [
             {
                 "name": "『魔女』の『ホロ』！",
+                "cost": "1 any color",
                 "dmg": 20
             }
         ],
         "extraEffect": "This holomem cannot Bloom.",
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP02-073",
@@ -1328,11 +1449,13 @@
         "skills": [
             {
                 "name": "『海賊』の『ホロ』！",
+                "cost": "1 any color",
                 "dmg": 20
             }
         ],
         "extraEffect": "This holomem cannot Bloom.",
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP02-074",
@@ -1346,11 +1469,13 @@
         "skills": [
             {
                 "name": "『シャチ』の『ホロ』！",
+                "cost": "1 any color",
                 "dmg": 20
             }
         ],
         "extraEffect": "This holomem cannot Bloom.",
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP02-075",

--- a/sets/hBP/hBP02.json
+++ b/sets/hBP/hBP02.json
@@ -139,10 +139,12 @@
         "skills": [
             {
                 "name": "こんこんきーつね！",
+                "cost": "1 any color",
                 "dmg": "30"
             }
         ],
-        "extraEffect": "You may include any number of this holomem in the deck."
+        "extraEffect": "You may include any number of this holomem in the deck.",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP02-009",
@@ -245,12 +247,14 @@
         "skills": [
             {
                 "name": "こんまっする〜!",
+                "cost": "1 any color",
                 "dmg": "20"
             }
         ],
         "extraEffect": "You may include any number of this holomem in the deck.",
         "hasHolomenRare": true,
-        "imageSet": "hBP05"
+        "imageSet": "hBP05",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP02-015",
@@ -284,11 +288,13 @@
         "skills": [
             {
                 "name": "目に焼き付けるんだゾ♡",
+                "cost": "2 any color",
                 "dmg": "30"
             }
         ],
         "hasFullArt": true,
-        "imageSet": "hBP06"
+        "imageSet": "hBP06",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP02-017",
@@ -325,10 +331,12 @@
         "skills": [
             {
                 "name": "ペルハティアン！",
+                "cost": "1 any color",
                 "dmg": "30"
             }
         ],
-        "extraEffect": "You may include any number of this holomem in the deck."
+        "extraEffect": "You may include any number of this holomem in the deck.",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP02-019",
@@ -429,11 +437,13 @@
         "skills": [
             {
                 "name": "うちうち、うちだよ～大神ミオだよ～",
+                "cost": "1 any color",
                 "dmg": "10",
                 "description": "You may reattach 1 cheer from your stage to your holomem with #JP."
             }
         ],
-        "extraEffect": "You may include any number of this holomem in the deck."
+        "extraEffect": "You may include any number of this holomem in the deck.",
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP02-025",
@@ -555,11 +565,13 @@
         "skills": [
             {
                 "name": "いっしょに出航しましょう！（健全)",
+                "cost": "1 any color",
                 "dmg": "30"
             }
         ],
         "hasFullArt": true,
-        "imageSet": "hBP06"
+        "imageSet": "hBP06",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP02-032",
@@ -971,13 +983,15 @@
         "skills": [
             {
                 "name": "グリム・リーパーの第一弟子",
+                "cost": "1 any color",
                 "dmg": "30+",
                 "description": "If your archive has holomem, this Arts gets +10."
             }
         ],
         "extraEffect": "You may include any number of this holomem in the deck.",
         "hasHolomenRare": true,
-        "imageSet": "hBP06"
+        "imageSet": "hBP06",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP02-055",
@@ -1095,10 +1109,12 @@
         "skills": [
             {
                 "name": "WAH!",
+                "cost": "1 any color",
                 "dmg": "10"
             }
         ],
-        "extraEffect": "You may include any number of this holomem in the deck."
+        "extraEffect": "You may include any number of this holomem in the deck.",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP02-062",
@@ -1164,13 +1180,15 @@
         "skills": [
             {
                 "name": "Hiya darlings!",
+                "cost": "1 any color",
                 "dmg": "30",
                 "description": "If a red cheer is attached to this holomem, this Arts gets +10."
             }
         ],
         "extraEffect": "You may include any number of this holomem in the deck.",
         "hasHolomenRare": true,
-        "imageSet": "hBP05"
+        "imageSet": "hBP05",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP02-066",

--- a/sets/hBP/hBP03.json
+++ b/sets/hBP/hBP03.json
@@ -158,11 +158,13 @@
         "skills": [
             {
                 "name": "みんな～、おりゅ～？",
+                "cost": "1 any color",
                 "dmg": "10",
                 "description": "If you do not have a holomem with 〈Lu-knights〉 attached, reveal 1 〈Lu-knights〉 from your deck, and attach it to your holomem. Then, shuffle the deck."
             }
         ],
-        "extraEffect": "You may include any number of this holomem in the deck."
+        "extraEffect": "You may include any number of this holomem in the deck.",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP03-010",
@@ -176,10 +178,12 @@
         "skills": [
             {
                 "name": "お菓子たべるのら？",
+                "cost": "1 White",
                 "dmg": "20"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP03-011",
@@ -192,14 +196,17 @@
         "skills": [
             {
                 "name": "おつルーナ",
+                "cost": "1 White",
                 "dmg": "40"
             },
             {
                 "name": "ぐっどないと～",
+                "cost": "1 White, 1 any color",
                 "dmg": "60"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP03-012",
@@ -213,10 +220,12 @@
         "skills": [
             {
                 "name": "力をかしてくださいね",
+                "cost": "1 White, 1 any color",
                 "dmg": "40"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP03-013",
@@ -230,11 +239,13 @@
         "skills": [
             {
                 "name": "ムーンギャラクシー",
+                "cost": "1 White",
                 "dmg": "20",
                 "description": "You may attach 1 〈Lu-knights〉 from your archive to your 〈Himemori Luna〉."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP03-014",
@@ -248,12 +259,14 @@
         "skills": [
             {
                 "name": "お疲れ様なのらね",
+                "cost": "2 White, 1 any color",
                 "dmg": "100+",
                 "description": "If 〈Lu-knights〉 is attached to this holomen, this Arts gets +50.."
             }
         ],
         "hasAlternativeArt": true,
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP03-015",
@@ -267,12 +280,14 @@
         "skills": [
             {
                 "name": "これが番長の実力ってやつよ",
+                "cost": "1 White, 2 any color",
                 "dmg": "110",
                 "description": "If you have 4 or more back holomem with #ReGLOSS, this holomem gets Arts+40."
             }
         ],
         "hasAlternativeArt": true,
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP03-016",
@@ -285,10 +300,12 @@
         "skills": [
             {
                 "name": "ららーいおん♪",
+                "cost": "1 any color",
                 "dmg": "30"
             }
         ],
-        "extraEffect": "You may include any number of this holomem in the deck."
+        "extraEffect": "You may include any number of this holomem in the deck.",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP03-017",
@@ -302,10 +319,12 @@
         "skills": [
             {
                 "name": "ぼ。",
+                "cost": "1 Green",
                 "dmg": "20"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP03-018",
@@ -318,13 +337,16 @@
         "skills": [
             {
                 "name": "ぼたんがアイドルになったら…",
+                "cost": "1 Green",
                 "dmg": "40"
             },
             {
                 "name": "絶対、ドキドキさせるから",
+                "cost": "1 Green, 1 any color",
                 "dmg": "60"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP03-019",
@@ -338,11 +360,13 @@
         "skills": [
             {
                 "name": "じゅるり",
+                "cost": "1 any color",
                 "dmg": "30",
                 "description": "Reveal 1 〈Tsunomaki Watame〉 from your hand, and you may return it to the bottom of the deck:Restore 20 HP to this holomem."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP03-020",
@@ -356,10 +380,12 @@
         "skills": [
             {
                 "name": "ショッピングカートで来た",
+                "cost": "1 Green, 1 any color",
                 "dmg": "50"
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP03-021",
@@ -373,12 +399,14 @@
         "skills": [
             {
                 "name": "神エイム",
+                "cost": "1 Green, 2 any color",
                 "dmg": "110",
                 "description": "If your Oshi holomem is 〈Shishiro Botan〉, you may archive 1 cheer from your back holomem:Deal 40 special damage to your opponent's center holomem or collab holomem."
             }
         ],
         "hasAlternativeArt": true,
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP03-022",
@@ -393,12 +421,14 @@
         "skills": [
             {
                 "name": "情熱のベリーダンサー",
+                "cost": "2 Green",
                 "dmg": "50",
                 "description": "If your Oshi holomem is 〈Aki Rosenthal〉, restore 10 HP to all of your holomem with a tool attached."
             }
         ],
         "hasFullArt": true,
-        "extraEffect": "If this holomem is downed, you get Life-2."
+        "extraEffect": "If this holomem is downed, you get Life-2.",
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP03-023",
@@ -413,12 +443,14 @@
         "skills": [
             {
                 "name": "カードするぺこ",
+                "cost": "1 Green, 2 any color",
                 "dmg": "80+",
                 "description": "If a die was rolled once or more by the ability of your 〈Usada Pekora〉 this turn, this Arts gets +40."
             }
         ],
         "hasFullArt": true,
-        "extraEffect": "If this holomem is downed, you get Life-2."
+        "extraEffect": "If this holomem is downed, you get Life-2.",
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP03-024",
@@ -432,12 +464,14 @@
         "skills": [
             {
                 "name": "風真が斬る",
+                "cost": "1 Green, 3 any color",
                 "dmg": "100+",
                 "description": "If 2 or more non-green cheers are attached to this holomem, this Arts gets +50."
             }
         ],
         "hasAlternativeArt": true,
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP03-025",
@@ -450,13 +484,15 @@
         "skills": [
             {
                 "name": "にゃっはろ～",
+                "cost": "1 any color",
                 "dmg": "30"
             }
         ],
         "hasHolomenRare": true,
         "imageSet": "hBP07",
         "manualUrlHR": "https://hololive-official-cardgame.com/wp-content/images/cardlist/hBP07/hBP03-025_02_HR.png",
-        "extraEffect": "You may include any number of this holomem in the deck."
+        "extraEffect": "You may include any number of this holomem in the deck.",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP03-026",
@@ -470,10 +506,12 @@
         "skills": [
             {
                 "name": "さくらの季節",
+                "cost": "1 Red, 1 any color",
                 "dmg": "30"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP03-027",
@@ -486,14 +524,17 @@
         "skills": [
             {
                 "name": "エリートな水着",
+                "cost": "1 any color",
                 "dmg": "40"
             },
             {
                 "name": "ぷにち",
+                "cost": "1 Red, 1 any color",
                 "dmg": "60"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 0
     },
     {
         "cardNumber": "hBP03-028",
@@ -506,15 +547,18 @@
         "skills": [
             {
                 "name": "応援頼んだぞ",
+                "cost": "1 any color",
                 "dmg": "30"
             },
             {
                 "name": "みこぴー！(｀・ω・´)🌸",
+                "cost": "1 Red, 1 any color",
                 "dmg": "50",
                 "description": "You may roll a dice. If the result is 2, 4, or 6, deal 20 special damage to your opponent's Center holomem. If the result is 3 or 5, deal 20 special damage to your opponent's Center and Collab holomem"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 0
     },
     {
         "cardNumber": "hBP03-029",
@@ -528,11 +572,13 @@
         "skills": [
             {
                 "name": "35Pと記念写真",
+                "cost": "1 Red, 1 any color",
                 "dmg": "30",
                 "descirption": "If 〈35P〉 is attached to this holomem, this Arts gets +30."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 0
     },
     {
         "cardNumber": "hBP03-030",
@@ -546,12 +592,14 @@
         "skills": [
             {
                 "name": "エリート巫女",
+                "cost": "1 Red, 2 any color",
                 "dmg": "120+",
                 "description": "This Arts gets +20 for each 〈35P〉 attached to this holomem."
             }
         ],
         "hasAlternativeArt": true,
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP03-031",
@@ -564,10 +612,12 @@
         "skills": [
             {
                 "name": "おはるーじゅ！",
+                "cost": "1 any color",
                 "dmg": "30"
             }
         ],
-        "extraEffect": "You may include any number of this holomem in the deck."
+        "extraEffect": "You may include any number of this holomem in the deck.",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP03-032",
@@ -580,10 +630,12 @@
         "skills": [
             {
                 "name": "おつるーじゅ！",
+                "cost": "1 Red, 1 any color",
                 "dmg": "60"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 0
     },
     {
         "cardNumber": "hBP03-033",
@@ -597,10 +649,12 @@
         "skills": [
             {
                 "name": "はあちゃまっちゃま～！",
+                "cost": "1 any color",
                 "dmg": "40"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP03-034",
@@ -615,13 +669,15 @@
         "skills": [
             {
                 "name": "レッド オア ルージュ",
+                "cost": "1 Red, 1 any color",
                 "dmg": "40+",
                 "description": "You may roll a die once:If it is odd, deal 20 special damage to your opponent's center holomem and collab holomem. If it is even, this Arts gets +40."
             }
         ],
         "extraEffect": "If this holomem is downed, you get Life-2.",
         "hasAlternativeArt": true,
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP03-035",
@@ -635,12 +691,14 @@
         "skills": [
             {
                 "name": "challenger",
+                "cost": "1 Red, 1 any color",
                 "dmg": "50",
                 "descirption": "If your Oshi holomem is 〈Takane Lui〉, you may archive 2 cards from your hand:Draw 3 cards."
             }
         ],
         "hasFullArt": true,
-        "extraEffect": "If this holomem is downed, you get Life-2."
+        "extraEffect": "If this holomem is downed, you get Life-2.",
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP03-036",
@@ -654,10 +712,12 @@
         "skills": [
             {
                 "name": "鋼の翼",
+                "cost": "1 Red, 1 any color",
                 "dmg": "50"
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP03-037",
@@ -670,11 +730,13 @@
         "skills": [
             {
                 "name": "フワワじゃないよ、モココだよ",
+                "cost": "1 any color",
                 "dmg": "20",
                 "description": "If your center holomem is 〈Fuwawa Abyssgard〉, this Arts requires -1 ▲◇▲"
             }
         ],
-        "extraEffect": "You may include any number of this holomem in the deck."
+        "extraEffect": "You may include any number of this holomem in the deck.",
+        "batonTouch": 0
     },
     {
         "cardNumber": "hBP03-038",
@@ -688,10 +750,12 @@
         "skills": [
             {
                 "name": "モココとドーナツクッキング",
+                "cost": "1 any color",
                 "dmg": "30"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 0
     },
     {
         "cardNumber": "hBP03-039",
@@ -706,12 +770,14 @@
         "skills": [
             {
                 "name": "もこもこしてる方",
+                "cost": "1 Red, 1 Blue",
                 "dmg": "50+",
                 "description": "[Collab Position only] If your center holomem is 〈Fuwawa Abyssgard〉, this Arts gets +30."
             }
         ],
         "extraEffect": "If this holomem is downed, you get Life-2.",
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP03-040",
@@ -724,10 +790,12 @@
         "skills": [
             {
                 "name": "チワワじゃないよ、フワワだよ",
+                "cost": "1 any color",
                 "dmg": "30"
             }
         ],
-        "extraEffect": "You may include any number of this holomem in the deck."
+        "extraEffect": "You may include any number of this holomem in the deck.",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP03-041",
@@ -740,14 +808,17 @@
         "skills": [
             {
                 "name": "魔界乃番犬のまとめ役",
+                "cost": "1 any color",
                 "dmg": "40"
             },
             {
                 "name": "ふわふわしてる方",
+                "cost": "1 Blue, 1 any color",
                 "dmg": "60"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP03-042",
@@ -761,10 +832,12 @@
         "skills": [
             {
                 "name": "フワワと森のお散歩",
+                "cost": "2 any color",
                 "dmg": "50"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP03-043",
@@ -777,16 +850,19 @@
         "skills": [
             {
                 "name": "ドーナツ大好き",
+                "cost": "1 Blue",
                 "dmg": "60"
             },
             {
                 "name": "一緒に食べる？",
+                "cost": "1 Blue, 1 Red, 1 any color",
                 "dmg": "100",
                 "description": "[Center Position only] If your Oshi holomem is 〈FUWAMOCO〉, you may reattach 1 cheer from this holomem to your 〈Mococo Abyssgard〉:Deal 50 special damage to your opponent's center holomem."
             }
         ],
         "hasAlternativeArt": true,
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP03-044",
@@ -800,11 +876,13 @@
         "skills": [
             {
                 "name": "バーチャルゴースト",
+                "cost": "1 Blue, 1 any color",
                 "dmg": "40",
                 "descirption": "If your Oshi holomem is 〈Hoshimachi Suisei〉, you may reattach 1 blue cheer from this holomem to your back holomem 〈Hoshimachi Suisei〉"
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP03-045",
@@ -819,12 +897,14 @@
         "skills": [
             {
                 "name": "元気いっぱい！",
+                "cost": "1 Blue, 1 any color",
                 "dmg": "40+",
                 "description": "This Arts gets +10 for each of your opponent's back holomem with reduced HP."
             }
         ],
         "hasFullArt": true,
-        "extraEffect": "If this holomem is downed, you get Life-2."
+        "extraEffect": "If this holomem is downed, you get Life-2.",
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP03-046",
@@ -837,14 +917,17 @@
         "skills": [
             {
                 "name": "可愛い女の子かと思った？",
+                "cost": "1 any color",
                 "dmg": "10"
             },
             {
                 "name": "じゃじゃーん！ 青くんでした。",
+                "cost": "2 any color",
                 "dmg": "40"
             }
         ],
-        "extraEffect": "You may include any number of this holomem in the deck."
+        "extraEffect": "You may include any number of this holomem in the deck.",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP03-047",
@@ -857,10 +940,12 @@
         "skills": [
             {
                 "name": "アフタヌーンティーデートのその後に…　",
+                "cost": "1 Blue, 1 any color",
                 "dmg": "60"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP03-048",
@@ -873,15 +958,18 @@
         "skills": [
             {
                 "name": "僕、カッコいいでしょ？",
+                "cost": "1 any color",
                 "dmg": "30"
             },
             {
                 "name": "ReGLOSSのボーイッシュ担当",
+                "cost": "2 any color",
                 "dmg": "40",
                 "description": "You may move 1 Cheer from this holomem to one of your back holomems with #ReGLOSS."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP03-049",
@@ -896,12 +984,14 @@
         "skills": [
             {
                 "name": "イケメンにお任せを",
+                "cost": "1 Blue, 2 any color",
                 "dmg": "50",
                 "description": "Deal 10 special damage for each of your back holomem with #ReGLOSS and with different card names to your opponent's center holomem or 1 of their back holomem."
             }
         ],
         "extraEffect": "If this holomem is downed, you get Life-2.",
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP03-050",
@@ -914,16 +1004,19 @@
         "skills": [
             {
                 "name": "魔界乃番犬シスターズ",
+                "cost": "2 any color",
                 "dmg": "40",
                 "description": "Reveal 1 [red cheer or blue cheer] from your cheer deck, and send it to your holomem with #Advent. Then, shuffle the cheer deck."
             },
             {
                 "name": "2人揃ってFUWAMOCOです！",
+                "cost": "1 Blue, 1 Red",
                 "dmg": "60"
             }
         ],
         "extraEffect": "This holomem is also regarded as 〈Fuwawa Abyssgard〉〈Mococo Abyssgard〉",
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP03-051",
@@ -936,10 +1029,12 @@
         "skills": [
             {
                 "name": "こんやっぴー",
+                "cost": "1 any color",
                 "dmg": "30"
             }
         ],
-        "extraEffect": "You may include any number of this holomem in the deck."
+        "extraEffect": "You may include any number of this holomem in the deck.",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP03-052",
@@ -952,11 +1047,13 @@
         "skills": [
             {
                 "name": "そういう感じなんだ",
+                "cost": "1 Purple",
                 "dmg": "20",
                 "description": "Deal 10 special damage to your opponent's center holomem. If your Oshi holomem is 〈Tokoyami Towa〉, you may archive 1 tool attached to your opponent's [center holomem or collab holomem]."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP03-053",
@@ -969,14 +1066,17 @@
         "skills": [
             {
                 "name": "おつやっぴー　",
+                "cost": "1 any color",
                 "dmg": "30"
             },
             {
                 "name": "きゅりん",
+                "cost": "1 Purple, 1 any color",
                 "dmg": "60"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP03-054",
@@ -990,11 +1090,13 @@
         "skills": [
             {
                 "name": "大爆発させちゃうぜ！",
+                "cost": "1 any color",
                 "dmg": "30",
                 "description": "You may Archive 4 Purple Cheers from this holomem for the following effect: return 1 Cheer from your opponent's Stage to the bottom of their Cheer Deck."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP03-055",
@@ -1007,15 +1109,18 @@
         "skills": [
             {
                 "name": "トワとお家デートしたっていい",
+                "cost": "1 Purple",
                 "dmg": "40"
             },
             {
                 "name": "てんQ",
+                "cost": "1 Purple, 1 any color",
                 "dmg": "50",
                 "description": "If you have any Back holomems with #singing, deal 20 special damage to your opponent's Collab holomem."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP03-056",
@@ -1028,17 +1133,20 @@
         "skills": [
             {
                 "name": "私を縛る固定概念を壊せ",
+                "cost": "1 Purple",
                 "dmg": "30",
                 "description": "Deal 30 special damage to your opponent's Center or Collab holomem."
             },
             {
                 "name": "Break your ×××",
+                "cost": "2 Purple, 1 any color",
                 "dmg": "80",
                 "description": "Deal 20 special damage for each of your back holomem with #Singing to your opponent's center holomem or collab holomem. However, only up to 4 holomem are counted."
             }
         ],
         "hasAlternativeArt": true,
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP03-057",
@@ -1051,10 +1159,12 @@
         "skills": [
             {
                 "name": "はろーぼー！",
+                "cost": "1 any color",
                 "dmg": "30"
             }
         ],
-        "extraEffect": "You may include any number of this holomem in the deck."
+        "extraEffect": "You may include any number of this holomem in the deck.",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP03-058",
@@ -1067,14 +1177,17 @@
         "skills": [
             {
                 "name": "おつろぼー",
+                "cost": "1 any color",
                 "dmg": "30"
             },
             {
                 "name": "いちゃあま彼女",
+                "cost": "1 Purple, 1 any color",
                 "dmg": "60"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP03-059",
@@ -1088,10 +1201,12 @@
         "skills": [
             {
                 "name": "笑顔になーーれっ",
+                "cost": "1 any color",
                 "dmg": "40"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP03-060",
@@ -1104,11 +1219,13 @@
         "skills": [
             {
                 "name": "自称【高性能】",
+                "cost": "1 any color",
                 "dmg": "70+",
                 "description": "If your opponent's stage has 7 or more cheers, this Arts gets +70."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP03-061",
@@ -1121,14 +1238,17 @@
         "skills": [
             {
                 "name": "ぉぁよ～",
+                "cost": "1 any color",
                 "dmg": "20"
             },
             {
                 "name": "ゆびゆび～",
+                "cost": "3 any color",
                 "dmg": "60"
             }
         ],
-        "extraEffect": "You may include any number of this holomem in the deck."
+        "extraEffect": "You may include any number of this holomem in the deck.",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP03-062",
@@ -1142,10 +1262,12 @@
         "skills": [
             {
                 "name": "ご注文はこれだでな",
+                "cost": "1 Yellow",
                 "dmg": "30"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP03-063",
@@ -1158,10 +1280,12 @@
         "skills": [
             {
                 "name": "つころ～ん",
+                "cost": "1 Yellow",
                 "dmg": "30"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP03-064",
@@ -1174,15 +1298,18 @@
         "skills": [
             {
                 "name": "ぶるぁあああああ!!!!!!!!!!!!!!",
+                "cost": "1 Yellow, 1 any color",
                 "dmg": "40+",
                 "description": "This Arts gets +10 for each life reduced from your initial life."
             },
             {
                 "name": "おーしぇーい",
+                "cost": "3 any color",
                 "dmg": "70"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP03-065",
@@ -1196,11 +1323,13 @@
         "skills": [
             {
                 "name": "ほらよ～",
+                "cost": "2 any color",
                 "dmg": "30",
                 "description": "Send the top card of your Cheer Deck to one of your holomems with #Gamers."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP03-066",
@@ -1214,12 +1343,14 @@
         "skills": [
             {
                 "name": "最凶天災",
+                "cost": "2 Yellow, 1 any color",
                 "dmg": "120+",
                 "description": "If the target of this Arts is your opponent's 2nd holomem, you may archive 1 1st holomem stacked to this holomem:This Arts gets +50."
             }
         ],
         "hasAlternativeArt": true,
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP03-067",
@@ -1232,12 +1363,14 @@
         "skills": [
             {
                 "name": "こんばんドドド～！",
+                "cost": "1 any color",
                 "dmg": "30"
             }
         ],
         "hasHolomenRare": true,
         "imageSet": "hBP07",
-        "extraEffect": "You may include any number of this holomem in the deck."
+        "extraEffect": "You may include any number of this holomem in the deck.",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP03-068",
@@ -1250,11 +1383,13 @@
         "skills": [
             {
                 "name": "わためのうた",
+                "cost": "1 Yellow",
                 "dmg": "20",
                 "description": "If you have a holomem with 〈Watamates〉 attached, you may send 1 cheer from your archive to your yellow holomem.."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP03-069",
@@ -1267,14 +1402,17 @@
         "skills": [
             {
                 "name": "癒しのひととき",
+                "cost": "1 Yellow",
                 "dmg": "30"
             },
             {
                 "name": "応援してくれるよねぇ？",
+                "cost": "3 any color",
                 "dmg": "90"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP03-070",
@@ -1288,11 +1426,13 @@
         "skills": [
             {
                 "name": "最後まで見ててね、わためいと！",
+                "cost": "2 any color",
                 "dmg": "30",
                 "description": "Send the top card of your Cheer Deck to one of your Back holomems named <Tsunomaki Watame>."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP03-071",
@@ -1306,11 +1446,13 @@
         "skills": [
             {
                 "name": "つのまきじゃんけん",
+                "cost": "1 Yellow, 1 any color",
                 "dmg": "50",
                 "description": "You may play rock-paper-scissors with your opponent until there's a winner:If you won, during this turn, this holomem gets Red Critical+30.."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP03-072",
@@ -1324,12 +1466,14 @@
         "skills": [
             {
                 "name": "わためぇ Night Fever!!",
+                "cost": "1 Yellow, 2 any color",
                 "dmg": "80+",
                 "description": "[Center position only] If 6 or more cheers are attached to this holomem, during this turn, this holomem and your collab holomem get Arts+100."
             }
         ],
         "hasAlternativeArt": true,
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP03-073",
@@ -1342,15 +1486,18 @@
         "skills": [
             {
                 "name": "こんリス",
+                "cost": "1 any color",
                 "dmg": "20"
             },
             {
                 "name": "ぷるぷる～",
+                "cost": "3 any color",
                 "dmg": "60",
                 "description": "You may reattach 1 cheer from this holomem to your 〈Inugami Korone〉."
             }
         ],
-        "extraEffect": "You may include any number of this holomem in the deck."
+        "extraEffect": "You may include any number of this holomem in the deck.",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP03-074",
@@ -1363,11 +1510,13 @@
         "skills": [
             {
                 "name": "繋がる願い",
+                "cost": "1 any color",
                 "dmg": "20+",
                 "description": "■If your stage has 〈Airani Iofifteen〉, this Arts gets +10.■If your stage has 〈Moona Hoshinova〉, this Arts gets +10."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP03-075",
@@ -1380,14 +1529,17 @@
         "skills": [
             {
                 "name": "おつリスー",
+                "cost": "1 any color",
                 "dmg": "30"
             },
             {
                 "name": "おやすみの思い出",
+                "cost": "1 Yellow, 2 any color",
                 "dmg": "70"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP03-076",
@@ -1401,10 +1553,12 @@
         "skills": [
             {
                 "name": "ぷるぷる、おつリス！！！",
+                "cost": "1 any color",
                 "dmg": 20
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP03-077",
@@ -1418,10 +1572,12 @@
         "skills": [
             {
                 "name": "ナッツ",
+                "cost": "1 Yellow, 1 any color",
                 "dmg": 40
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP03-078",
@@ -1435,12 +1591,14 @@
         "skills": [
             {
                 "name": "魔法の森のリスの女の子",
+                "cost": "1 Yellow, 2 any color",
                 "dmg": 50,
                 "description": "■If a green cheer is attached to this holomem, this Arts gets +50.■If a blue cheer is attached to this holomem, this Arts gets +50."
             }
         ],
         "hasAlternativeArt": true,
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP03-079",
@@ -1454,12 +1612,14 @@
         "skills": [
             {
                 "name": "サンライズエール",
+                "cost": "1 Yellow, 1 any color",
                 "dmg": "50+",
                 "description": "If 3 or more cheers are attached to this holomem, this Arts gets +30."
             }
         ],
         "hasAlternativeArt": true,
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP03-080",
@@ -1472,14 +1632,17 @@
         "skills": [
             {
                 "name": "ドレミファソラシド～！",
+                "cost": "1 any color",
                 "dmg": 20
             },
             {
                 "name": "音楽家の卵！ 音乃瀬～奏で～～～す！",
+                "cost": "3 any color",
                 "dmg": 50
             }
         ],
-        "extraEffect": "You may include any number of this holomem in the deck."
+        "extraEffect": "You may include any number of this holomem in the deck.",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP03-081",
@@ -1492,10 +1655,12 @@
         "skills": [
             {
                 "name": "明日は月曜日～っ♪",
+                "cost": "1 any color",
                 "dmg": 30
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP03-082",
@@ -1509,10 +1674,12 @@
         "skills": [
             {
                 "name": "ぷにぷにじゃないっ",
+                "cost": "1 Yellow, 2 any color",
                 "dmg": 60
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP03-083",
@@ -1527,11 +1694,13 @@
         "skills": [
             {
                 "name": "歌姫 音乃瀬奏さん",
+                "cost": "1 Yellow, 3 any color",
                 "dmg": 120
             }
         ],
         "extraEffect": "If this holomem is downed, you get Life-2.",
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP03-084",

--- a/sets/hBP/hBP04.json
+++ b/sets/hBP/hBP04.json
@@ -144,7 +144,8 @@
                 "cost": "1 any color",
                 "dmg": "30"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "name": "Hakui Koyori",
@@ -162,7 +163,8 @@
                 "description": "Look at the top 3 cards of your deck. From among them, reveal one [Debut Holomem with the #HoloX or a Support card with the #KoyoLab] and add it to your hand. Then, return the remaining cards to the bottom of your deck in any order."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Hakui Koyori",
@@ -184,7 +186,8 @@
                 "dmg": "60"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Hakui Koyori",
@@ -202,7 +205,8 @@
                 "description": "You may attach a <Koyori's Assistant-kun> from your archive to one of your other holomem named <Hakui Koyori?."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Hakui Koyori",
@@ -221,7 +225,8 @@
                 "description": "If this holomem has <Koyori's Assistant-kun> attached, draw 1 card from top of deck."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "name": "Hakui Koyori",
@@ -241,7 +246,8 @@
             }
         ],
         "hasFullArt": true,
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Shirakami Fubuki",
@@ -260,7 +266,8 @@
                 "description": "If there are any holomem with #Gamers that are not named Shirakami Fubuki on your stage, this art gains +50 power."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "name": "IRyS",
@@ -280,7 +287,8 @@
                 "description": "For each of your holomem with #Promise, this art gains +10 Power. The maximum number of holomem counted for this effect is 4."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Raora Panthera",
@@ -298,7 +306,8 @@
                 "dmg": "10",
                 "description": "If there are 5 or fewer holomem on your stage, you may reveal 1 Spot holomem with #Justice from your deck and put it onto your stage. Then shuffle your deck."
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "name": "Raora Panthera",
@@ -315,7 +324,8 @@
                 "dmg": "40"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Raora Panthera",
@@ -333,7 +343,8 @@
                 "dmg": "50"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Raora Panthera",
@@ -352,7 +363,8 @@
                 "description": "[Collab position only] If your center holomem has #Painting, this art gains +80 power."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Juufuutei Raden",
@@ -374,7 +386,8 @@
                 "cost": "1 Green, 1 any color",
                 "dmg": "40"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "name": "Juufuutei Raden",
@@ -392,7 +405,8 @@
                 "dmg": "30"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Juufuutei Raden",
@@ -414,7 +428,8 @@
                 "dmg": "50"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Juufuutei Raden",
@@ -432,7 +447,8 @@
                 "dmg": "40"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Juufuutei Raden",
@@ -451,7 +467,8 @@
                 "description": "You may send 1 cheer from your archive to this holomem."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "name": "Juufuutei Raden",
@@ -471,7 +488,8 @@
             }
         ],
         "hasFullArt": true,
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Ookami Mio",
@@ -490,7 +508,8 @@
                 "description": "If there are any holomem with #Gamers that are not named Ookami Mio on your stage, this art gains +50 power."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Pavolia Reine",
@@ -508,7 +527,8 @@
                 "dmg": "30"
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "name": "Cecilia Immergreen",
@@ -525,7 +545,8 @@
                 "cost": "1 any color",
                 "dmg": "30"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "name": "Cecilia Immergreen",
@@ -542,7 +563,8 @@
                 "dmg": "60"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Cecilia Immergreen",
@@ -560,7 +582,8 @@
                 "dmg": "50"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Cecilia Immergreen",
@@ -579,7 +602,8 @@
                 "description": "Choose one of your back Holomem with the #Language. You may reveal one cheer card of the same color as the chosen Holomem from your cheer Deck and attach it to that Holomem. Then, shuffle your cheer Deck."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Ichijou Ririka",
@@ -596,7 +620,8 @@
                 "cost": "1 any color",
                 "dmg": "30"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "name": "Ichijou Ririka",
@@ -619,7 +644,8 @@
                 "description": "If you have used <Genkai-Meshi> this turn, deal 20 special damage to the opponent's Collab Holomem."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Ichijou Ririka",
@@ -641,7 +667,8 @@
                 "dmg": "60"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Ichijou Ririka",
@@ -660,7 +687,8 @@
                 "description": "Deal 20 special damage to your opponent's collab holomem."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Ichijou Ririka",
@@ -679,7 +707,8 @@
                 "description": "If this art is targeting your opponent's collab holomem, draw 1 card."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "name": "Ichijou Ririka",
@@ -699,7 +728,8 @@
             }
         ],
         "hasFullArt": true,
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Houshou Marine",
@@ -718,7 +748,8 @@
                 "description": "For each holomem stacked under this one, this art gains +20 power."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Kaela Kovalskia",
@@ -735,7 +766,8 @@
                 "cost": "1 any color",
                 "dmg": "20"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "name": "Kaela Kovalskia",
@@ -757,7 +789,8 @@
                 "dmg": "50"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Kaela Kovalskia",
@@ -775,7 +808,8 @@
                 "dmg": "20"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Kaela Kovalskia",
@@ -802,7 +836,8 @@
             }
         ],
         "hasAlternativeArt": true,
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Yukihana Lamy",
@@ -822,7 +857,8 @@
             }
         ],
         "hasHolomenRare": true,
-        "imageSet": "hBP06"
+        "imageSet": "hBP06",
+        "batonTouch": 1
     },
     {
         "name": "Yukihana Lamy",
@@ -840,7 +876,8 @@
                 "dmg": "30"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Yukihana Lamy",
@@ -862,7 +899,8 @@
                 "dmg": "50"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Yukihana Lamy",
@@ -880,7 +918,8 @@
                 "description": "If there are any holomem on your stage with a Fan attached, deal 10 special damage to any of your opponent's holomem."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Yukihana Lamy",
@@ -898,7 +937,8 @@
                 "dmg": "50"
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "name": "Yukihana Lamy",
@@ -918,7 +958,8 @@
             }
         ],
         "hasFullArt": true,
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Moona Hoshinova",
@@ -941,7 +982,8 @@
                 "description": "Deal 20 special damage to one of your opponent's back Holomem. If you have a Holomem with a different color than this one on your stage, this Arts gets an additional +50."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Shiori Novella",
@@ -958,7 +1000,8 @@
                 "cost": "1 any color",
                 "dmg": "30"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "name": "Shiori Novella",
@@ -980,7 +1023,8 @@
                 "dmg": "50"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Shiori Novella",
@@ -998,7 +1042,8 @@
                 "dmg": "20"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Shiori Novella",
@@ -1020,7 +1065,8 @@
             }
         ],
         "hasFullArt": true,
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "name": "La+ Darknesss",
@@ -1040,7 +1086,8 @@
         ],
         "hasHolomenRare": true,
         "imageSet": "hBP07",
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 0
     },
     {
         "name": "La+ Darknesss",
@@ -1059,7 +1106,8 @@
                 "description": "This art gains +10 power for each of your opponent's holomem who are resting."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 0
     },
     {
         "name": "La+ Darknesss",
@@ -1081,7 +1129,8 @@
                 "dmg": "70"
             }
         ],
-        "manualUrl": "https://hololive-official-cardgame.com/wp-content/images/cardlist/hBP04/hBP04-056_C_02.png"
+        "manualUrl": "https://hololive-official-cardgame.com/wp-content/images/cardlist/hBP04/hBP04-056_C_02.png",
+        "batonTouch": 1
     },
     {
         "name": "La+ Darknesss",
@@ -1099,7 +1148,8 @@
                 "dmg": "40"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 0
     },
     {
         "name": "La+ Darknesss",
@@ -1117,7 +1167,8 @@
                 "dmg": "30"
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 0
     },
     {
         "name": "La+ Darknesss",
@@ -1137,7 +1188,8 @@
             }
         ],
         "hasFullArt": true,
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Murasaki Shion",
@@ -1158,7 +1210,8 @@
                 "description": "Deal 10 special damage to the opponent's center Holomem and Collab Holomem for each cheer attached to the opponent's center Holomem."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Kureiji Ollie",
@@ -1177,7 +1230,8 @@
                 "description": "This Arts gets +20 for each other 2nd Holomem with the #ID2ndGen on your stage."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Mori Calliope",
@@ -1198,7 +1252,8 @@
                 "description": "Look at the top 2 cards of your deck. Archive 1 of them and place the remaining card on top of your deck."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Koseki Bijou",
@@ -1216,7 +1271,8 @@
                 "cost": "1 any color",
                 "dmg": "20"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "name": "Koseki Bijou",
@@ -1233,7 +1289,8 @@
                 "dmg": "30"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 2
     },
     {
         "name": "Koseki Bijou",
@@ -1252,7 +1309,8 @@
                 "description": "If there are any red cheers in your archive, this art gains +20."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Koseki Bijou",
@@ -1272,7 +1330,8 @@
             }
         ],
         "hasFullArt": true,
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Oozora Subaru",
@@ -1296,7 +1355,8 @@
             }
         ],
         "hasHolomenRare": true,
-        "imageSet": "hBP06"
+        "imageSet": "hBP06",
+        "batonTouch": 1
     },
     {
         "name": "Oozora Subaru",
@@ -1314,7 +1374,8 @@
                 "dmg": "20"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Oozora Subaru",
@@ -1336,7 +1397,8 @@
                 "dmg": "50"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 2
     },
     {
         "name": "Oozora Subaru",
@@ -1354,7 +1416,8 @@
                 "dmg": "20"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Oozora Subaru",
@@ -1377,7 +1440,8 @@
                 "dmg": "90"
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "name": "Oozora Subaru",
@@ -1397,7 +1461,8 @@
             }
         ],
         "hasFullArt": true,
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Anya Melfissa",
@@ -1414,7 +1479,8 @@
                 "cost": "1 any color",
                 "dmg": "30"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "name": "Anya Melfissa",
@@ -1432,7 +1498,8 @@
                 "dmg": "20"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Anya Melfissa",
@@ -1454,7 +1521,8 @@
                 "dmg": "50"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 2
     },
     {
         "name": "Anya Melfissa",
@@ -1472,7 +1540,8 @@
                 "dmg": "30"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Anya Melfissa",
@@ -1490,7 +1559,8 @@
                 "dmg": "50"
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Anya Melfissa",
@@ -1509,7 +1579,8 @@
             }
         ],
         "hasFullArt": true,
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Natsuiro Matsuri",
@@ -1527,7 +1598,8 @@
                 "cost": "1 any color",
                 "dmg": "10"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "name": "Natsuiro Matsuri",
@@ -1549,7 +1621,8 @@
                 "dmg": "50"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 2
     },
     {
         "name": "Natsuiro Matsuri",
@@ -1567,7 +1640,8 @@
                 "dmg": "20"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Natsuiro Matsuri",
@@ -1587,7 +1661,8 @@
             }
         ],
         "hasFullArt": true,
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Momosuzu Nene",
@@ -1605,7 +1680,8 @@
                 "dmg": "10",
                 "description": "If there are 5 or fewer holomem on your stage, you may reveal 1 Debut holomem with #Gen5 from your deck and put it onto your stage. Then shuffle your deck."
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "name": "Momosuzu Nene",
@@ -1627,7 +1703,8 @@
                 "dmg": "50"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 2
     },
     {
         "name": "Momosuzu Nene",
@@ -1645,7 +1722,8 @@
                 "dmg": "20"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Momosuzu Nene",
@@ -1669,7 +1747,8 @@
             }
         ],
         "hasAlternativeArt": true,
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Elizabeth Rose Bloodflame",
@@ -1687,7 +1766,8 @@
                 "dmg": "20"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Gigi Murin",
@@ -1705,7 +1785,8 @@
                 "dmg": "10"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 0
     },
     {
         "name": "Two-tone PC",

--- a/sets/hBP/hBP05.json
+++ b/sets/hBP/hBP05.json
@@ -144,7 +144,8 @@
                 "dmg": "20"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Shirogane Noel",
@@ -162,7 +163,8 @@
                 "dmg": "30"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Shirogane Noel",
@@ -181,7 +183,8 @@
                 "description": "If you have used a <Gyudon> this turn, this Arts gets +30."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Shirogane Noel",
@@ -200,7 +203,8 @@
                 "description": "For each Holomen on your stage with #Gen3 and a different card name, this Arts gets +10."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "name": "Shirogane Noel",
@@ -225,7 +229,8 @@
             }
         ],
         "hasFullArt": true,
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Tokino Sora",
@@ -243,7 +248,8 @@
                 "dmg": "90, +50 vs red"
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Usada Pekora",
@@ -261,7 +267,8 @@
                 "description": "You may roll a die once:If it is even, draw 1 card from your deck."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Usada Pekora",
@@ -285,7 +292,8 @@
                 "description": "If your Oshi holomem's color is white, draw 1 card from your deck."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Usada Pekora",
@@ -306,7 +314,8 @@
         ],
         "hasFullArt": true,
         "hasAlternativeArt": true,
-        "hasSigned": true
+        "hasSigned": true,
+        "batonTouch": 2
     },
     {
         "name": "Himemori Luna",
@@ -332,7 +341,8 @@
                 "description": "[Collab position only ]For each <Luknight> attached to your center holomem, reduce the cheer cost of this Arts by 1 colorless cheer."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Vestia Zeta",
@@ -357,7 +367,8 @@
                 "description": "If your opponent's holomem is downed by this Arts, reveal 1 1st holomem with #IDGen3 from your deck,and add it to hand. Then, shuffle the deck."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Airani Iofifteen",
@@ -375,7 +386,8 @@
                 "dmg": "30"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Airani Iofifteen",
@@ -393,7 +405,8 @@
                 "dmg": "10"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Airani Iofifteen",
@@ -411,7 +424,8 @@
                 "dmg": "40"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Airani Iofifteen",
@@ -429,7 +443,8 @@
                 "dmg": "50"
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "name": "Airani Iofifteen",
@@ -449,7 +464,8 @@
             }
         ],
         "hasFullArt": true,
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "name": "AZKi",
@@ -475,7 +491,8 @@
                 "description": "If your Oshi holomem is <AZKi>, this Arts gets +20 for each cheer attached to this holomem."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Aki Rosenthal",
@@ -492,7 +509,8 @@
                 "dmg": "20"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Aki Rosenthal",
@@ -510,7 +528,8 @@
                 "dmg": "50"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Aki Rosenthal",
@@ -530,7 +549,8 @@
             }
         ],
         "hasFullArt": true,
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Shishiro Botan",
@@ -551,7 +571,8 @@
                 "description": "You may archive 1 cheer from your <Shishiro Botan>:Deal 30 Special Damage to your opponent's center holomem."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "name": "Juufuutei Raden",
@@ -576,7 +597,8 @@
                 "description": "If a 2nd holomem with #ReGLOSS is on your stage, this Arts gets +40."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Omaru Polka",
@@ -594,7 +616,8 @@
                 "dmg": "20"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Omaru Polka",
@@ -612,7 +635,8 @@
                 "description": "If you are going second and this is your first turn, reveal 1 <Troupe Member> from your deck, and add it to hand. Then, shuffle your deck."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Omaru Polka",
@@ -631,7 +655,8 @@
                 "description": "You may archive 1 card from your hand:Deal 10 damage to your opponent's center holomem or collab holomem."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Omaru Polka",
@@ -655,7 +680,8 @@
                 "description": "This Arts gets +10 for each <Troupe Member> attached to this holomem."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "name": "Omaru Polka",
@@ -675,7 +701,8 @@
             }
         ],
         "hasFullArt": true,
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Sakura Miko",
@@ -694,7 +721,8 @@
                 "description": "You may archive 2 cards from your hand:Deal 50 Special Damage to your opponent's center holomem or collab holomem. If there is a <35P> on your stage, draw 1 card from your deck."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Hoshimachi Suisei",
@@ -712,7 +740,8 @@
                 "description": "If any of your opponent's back holomem are damaged, this Arts gets +20."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Hoshimachi Suisei",
@@ -737,7 +766,8 @@
             }
         ],
         "hasFullArt": true,
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Mococo Abyssgard",
@@ -756,7 +786,8 @@
                 "description": "If your center holomem is <Fuwawa Abyssgard>, this Arts can be used with no cheer requirement."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "name": "Ichijou Ririka",
@@ -781,7 +812,8 @@
                 "description": "If the target of this Arts is a 1st or greater collab holomem, this Arts gets +70."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "name": "miComet",
@@ -801,7 +833,8 @@
                 "description": "You may reattach 1 cheer from this holomem to your back holomem."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Nekomata Okayu",
@@ -819,7 +852,8 @@
                 "description": "Deal 10 Special Damage to your opponent's center holomem."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Nekomata Okayu",
@@ -837,7 +871,8 @@
                 "dmg": "30"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Nekomata Okayu",
@@ -856,7 +891,8 @@
                 "description": "You may archive 1 blue cheer from this holomem:Deal 10 Special Damage to your opponent's center holomem and 1 of your opponent's back holomem."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Nekomata Okayu",
@@ -875,7 +911,8 @@
                 "description": "Deal 10 Special Damage to 1 of your opponent's holomem."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "name": "Nekomata Okayu",
@@ -895,7 +932,8 @@
             }
         ],
         "hasFullArt": true,
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Yukihana Lamy",
@@ -914,7 +952,8 @@
                 "description": "If a 2nd holomem with #Gen5 is on your stage, deal 20 Special Damage to 1 of your opponent's holomem."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "name": "Kobo Kanaeru",
@@ -932,7 +971,8 @@
                 "description": "Deal 10 Special Damage to 1 of your opponent's back holomem."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Kobo Kanaeru",
@@ -951,7 +991,8 @@
                 "description": "Deal 10 Special Damage to 2 of your opponent's back holomem."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Kobo Kanaeru",
@@ -976,7 +1017,8 @@
             }
         ],
         "hasFullArt": true,
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Fuwawa Abyssgard",
@@ -997,7 +1039,8 @@
                 "description": "If your <Mococo Abyssgard> has performed Arts this turn, this Arts gets +40. If you have also used your Oshi skill \"Moco-chan!\" this turn, this Arts gets +30."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Hiodoshi Ao",
@@ -1016,7 +1059,8 @@
                 "description": "If there are 3 or more holomem with #Alcohol on your stage, you may send 1 cheer from your archive to your back holomem with #Alcohol."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "name": "Yuzuki Choco",
@@ -1034,7 +1078,8 @@
                 "dmg": "30"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Yuzuki Choco",
@@ -1052,7 +1097,8 @@
                 "dmg": "10"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Yuzuki Choco",
@@ -1070,7 +1116,8 @@
                 "description": "If you have used 2 or more events with #Food this turn, this Arts can be used with no cheer requirement."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Yuzuki Choco",
@@ -1088,7 +1135,8 @@
                 "dmg": "30"
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 0
     },
     {
         "name": "Yuzuki Choco",
@@ -1113,7 +1161,8 @@
             }
         ],
         "hasFullArt": true,
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 1
     },
     {
         "name": "Nerissa Ravencroft",
@@ -1131,7 +1180,8 @@
                 "dmg": "20"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Nerissa Ravencroft",
@@ -1149,7 +1199,8 @@
                 "dmg": "10"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 0
     },
     {
         "name": "Nerissa Ravencroft",
@@ -1172,7 +1223,8 @@
                 "dmg": "50"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Nerissa Ravencroft",
@@ -1191,7 +1243,8 @@
                 "description": "You may archive 1 card from your hand:Deal 20 Special Damage to your opponent's center holomem or collab holomem."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "name": "Nerissa Ravencroft",
@@ -1211,7 +1264,8 @@
             }
         ],
         "hasFullArt": true,
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Tokoyami Towa",
@@ -1231,7 +1285,8 @@
                 "description": "Deal 20 Special Damage for each of your 1st holomem with #Singing to your opponent's center holomem or collab holomem."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Shiranui Flare",
@@ -1249,7 +1304,8 @@
                 "dmg": "20"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Shiranui Flare",
@@ -1267,7 +1323,8 @@
                 "dmg": "10"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Shiranui Flare",
@@ -1285,7 +1342,8 @@
                 "dmg": "30"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Shiranui Flare",
@@ -1304,7 +1362,8 @@
                 "description": "This Arts gets +10 for each differently-named holomem with #Gen3 on your stage."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Shiranui Flare",
@@ -1324,7 +1383,8 @@
             }
         ],
         "hasFullArt": true,
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Shirakami Fubuki",
@@ -1342,7 +1402,8 @@
                 "dmg": "20"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Shirakami Fubuki",
@@ -1361,7 +1422,8 @@
                 "description": "You may send the top card of your cheer deck to this holomem."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Shirakami Fubuki",
@@ -1386,7 +1448,8 @@
             }
         ],
         "hasFullArt": true,
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Inugami Korone",
@@ -1406,7 +1469,8 @@
                 "description": "During this turn, 1 of your holomem with #Gamers gets Arts+30."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Tsunomaki Watame",
@@ -1432,7 +1496,8 @@
                 "description": "If your Oshi holomem is <Tsunomaki Watame>, you may send the top card of your cheer deck to your <Tsunomaki Watame>."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Ayunda Risu",
@@ -1451,7 +1516,8 @@
                 "description": "If your Oshi holomem is <Ayunda Risu>, this Arts gets +10 for each cheer attached to your holomem with #IDGen1. However, only up to 10 cheers are counted."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Friendly PC",

--- a/sets/hBP/hBP06.json
+++ b/sets/hBP/hBP06.json
@@ -163,7 +163,8 @@
                 "dmg": "30"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Raora Panthera",
@@ -180,7 +181,8 @@
                 "cost": "1 any color",
                 "dmg": "30"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "name": "Raora Panthera",
@@ -198,7 +200,8 @@
                 "dmg": "30"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Raora Panthera",
@@ -221,7 +224,8 @@
                 "description": "Draw 2 cards."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 2
     },
     {
         "name": "Raora Panthera",
@@ -241,7 +245,8 @@
                 "description": "[Center position only]During this turn, your collab holomem with #Painting gets Arts+20."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Raora Panthera",
@@ -261,7 +266,8 @@
             }
         ],
         "hasFullArt": true,
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Isaki Riona",
@@ -280,7 +286,8 @@
             }
         ],
         "hasHolomenRare": true,
-        "imageSet": "hBP06"
+        "imageSet": "hBP06",
+        "batonTouch": 1
     },
     {
         "name": "Isaki Riona",
@@ -297,7 +304,8 @@
                 "cost": "1 any color",
                 "dmg": "20"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "name": "Isaki Riona",
@@ -319,7 +327,8 @@
                 "dmg": "60"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Isaki Riona",
@@ -338,7 +347,8 @@
                 "description": "Archive the top card of your deck."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Isaki Riona",
@@ -357,7 +367,8 @@
                 "description": "Archive the top card of your deck."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "name": "Isaki Riona",
@@ -377,7 +388,8 @@
             }
         ],
         "hasFullArt": true,
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Hakui Koyori",
@@ -396,7 +408,8 @@
                 "description": "You may return a Support card with #KoyoLabo from your archive to the bottom of your deck:This Arts gets +40."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Kazama Iroha",
@@ -413,7 +426,8 @@
                 "dmg": "10"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Kazama Iroha",
@@ -431,7 +445,8 @@
                 "cost": "1 any color",
                 "dmg": "30"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "name": "Kazama Iroha",
@@ -448,7 +463,8 @@
                 "dmg": "80"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 2
     },
     {
         "name": "Kazama Iroha",
@@ -466,7 +482,8 @@
                 "dmg": "50"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Kazama Iroha",
@@ -486,7 +503,8 @@
                 "dmg": "60"
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Kazama Iroha",
@@ -507,7 +525,8 @@
             }
         ],
         "hasFullArt": true,
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Himemori Luna",
@@ -524,7 +543,8 @@
                 "dmg": "30"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Himemori Luna",
@@ -547,7 +567,8 @@
                 "dmg": "80"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Himemori Luna",
@@ -566,7 +587,8 @@
                 "description": "You may attach 1 <Lu-knights> from your archive to your <Himemori Luna>."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "name": "Himemori Luna",
@@ -586,7 +608,8 @@
             }
         ],
         "hasFullArt": true,
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Cecilia Immergreen",
@@ -604,7 +627,8 @@
                 "dmg": "20"
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "name": "Juufuutei Raden",
@@ -623,7 +647,8 @@
                 "description": "You may send 1 cheer from your archive to your holomem with #ReGLOSS."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "name": "Nakiri Ayame",
@@ -641,7 +666,8 @@
                 "description": "You may archive 1 card from your hand:Your center <Nakiri Ayame> gets Arts+30."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 0
     },
     {
         "name": "Nakiri Ayame",
@@ -658,7 +684,8 @@
                 "cost": "1 any color",
                 "dmg": "20"
             }
-        ]
+        ],
+        "batonTouch": 0
     },
     {
         "name": "Nakiri Ayame",
@@ -677,7 +704,8 @@
                 "description": "You may archive the top card of your cheer deck:Draw 1 card."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Nakiri Ayame",
@@ -696,7 +724,8 @@
                 "description": "You may archive the top card of your cheer deck:Deal 30 damage to your opponent's center holomem or collab holomem."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Nakiri Ayame",
@@ -715,7 +744,8 @@
                 "description": "You may archive the top card of your cheer deck:Deal 20 special damage to your opponent's center holomem or collab holomem."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "name": "Nakiri Ayame",
@@ -735,7 +765,8 @@
             }
         ],
         "hasFullArt": true,
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 0
     },
     {
         "name": "Hakos Baelz",
@@ -753,7 +784,8 @@
                 "description": "Roll a die once. If it is odd, deal 10 special damage to your opponent's center holomem and collab holomem."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Hakos Baelz",
@@ -770,7 +802,8 @@
                 "cost": "1 any color",
                 "dmg": "30"
             }
-        ]
+        ],
+        "batonTouch": 0
     },
     {
         "name": "Hakos Baelz",
@@ -789,7 +822,8 @@
                 "description": "You may archive 2 cards from your hand:This Arts gets +20."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Hakos Baelz",
@@ -807,7 +841,8 @@
                 "dmg": "30"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Hakos Baelz",
@@ -830,7 +865,8 @@
                 "dmg": "70"
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "name": "Hakos Baelz",
@@ -855,7 +891,8 @@
             }
         ],
         "hasFullArt": true,
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Takane Lui",
@@ -874,7 +911,8 @@
                 "description": "If your Oshi holomem is <Takane Lui>, you may archive 2 cards from your hand:Deal 50 special damage to your opponent's center holomem or collab holomem."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Ichijou Ririka",
@@ -893,7 +931,8 @@
                 "description": "[Collab position only]Deal 50 damage to your opponent's collab holomem. If your opponent has no collab holomem, deal 50 damage to your opponent's center holomem instead."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Moona Hoshinova",
@@ -911,7 +950,8 @@
                 "description": "If a non-blue cheer is attached to this holomem, deal 10 special damage to 1 of your opponent's back holomem. However, your opponent's Life does not reduce even if downed."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Moona Hoshinova",
@@ -928,7 +968,8 @@
                 "cost": "1 any color",
                 "dmg": "20"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "name": "Moona Hoshinova",
@@ -951,7 +992,8 @@
                 "dmg": "80"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Moona Hoshinova",
@@ -974,7 +1016,8 @@
                 "description": "If your Oshi holomem is <Moona Hoshinova>, you may archive 1 cheer from this holomem:Draw 1 card."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Moona Hoshinova",
@@ -995,7 +1038,8 @@
                 "description": "If your Oshi holomem is <Moona Hoshinova> and 4 or more cheers are attached to this holomem, this Arts gets +60."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Moona Hoshinova",
@@ -1015,7 +1059,8 @@
             }
         ],
         "hasFullArt": true,
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Yukihana Lamy",
@@ -1034,7 +1079,8 @@
                 "description": "This Arts gets +10 for each <Yukimin> attached to this holomem."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Sakamata Chloe",
@@ -1053,7 +1099,8 @@
                 "description": "Reveal the top 4 cards of your deck. This Arts gets +20 for each holomem revealed. Then, archive the revealed cards. If there is an event among them, draw 2 cards."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Sakamata Chloe",
@@ -1072,7 +1119,8 @@
                 "description": "Reveal the top 6 cards of your deck. This Arts gets +20 for each holomem revealed. Then, archive the revealed cards."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Mori Calliope",
@@ -1090,7 +1138,8 @@
                 "description": "Draw 1 card, then archive 1 card from your hand."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Mori Calliope",
@@ -1109,7 +1158,8 @@
                 "description": "If a purple cheer is attached to this holomem, draw 1 card from your deck. Then, archive the top 2 cards of your deck."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Mori Calliope",
@@ -1127,7 +1177,8 @@
                 "dmg": "80"
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "name": "Mori Calliope",
@@ -1152,7 +1203,8 @@
             }
         ],
         "hasFullArt": true,
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Robocosan",
@@ -1170,7 +1222,8 @@
                 "description": "If a <Roboser> is attached to this holomem, deal 20 special damage to your opponent's center holomem."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Robocosan",
@@ -1187,7 +1240,8 @@
                 "cost": "1 any color",
                 "dmg": "30"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "name": "Robocosan",
@@ -1205,7 +1259,8 @@
                 "dmg": "30"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Robocosan",
@@ -1223,7 +1278,8 @@
                 "dmg": "40"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Robocosan",
@@ -1244,7 +1300,8 @@
                 "description": "If your holomem was downed on your opponent's last turn, this Arts cheer cost is reduced by 1 colorless cheer."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Robocosan",
@@ -1264,7 +1321,8 @@
             }
         ],
         "hasFullArt": true,
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Inugami Korone",
@@ -1282,7 +1340,8 @@
                 "dmg": "20"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Inugami Korone",
@@ -1301,7 +1360,8 @@
                 "description": "If there is a support card attached to your holomem, draw 1 card, then archive 1 card from your hand."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Inugami Korone",
@@ -1320,7 +1380,8 @@
                 "description": "If this holomem was unrested this turn by your Oshi Skill \"Infinite Stamina\", this Arts gets +50."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "name": "Inugami Korone",
@@ -1340,7 +1401,8 @@
             }
         ],
         "hasFullArt": true,
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "name": "La+ Darknesss",
@@ -1364,7 +1426,8 @@
                 "description": "Roll a die 5 times. For each odd number rolled, draw 1 card and deal 30 special damage to your opponent's center holomem and collab holomem."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Natsuiro Matsuri",
@@ -1382,7 +1445,8 @@
                 "dmg": "20"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Natsuiro Matsuri",
@@ -1399,7 +1463,8 @@
                 "cost": "1 any color",
                 "dmg": "10"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "name": "Natsuiro Matsuri",
@@ -1417,7 +1482,8 @@
                 "dmg": "30"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Natsuiro Matsuri",
@@ -1440,7 +1506,8 @@
                 "description": "Roll a die once for every [mascot and fan] on your stage. This Arts gets +10 for each time it is 4 or greater. However, the die can be rolled only up to 4 times."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 2
     },
     {
         "name": "Natsuiro Matsuri",
@@ -1461,7 +1528,8 @@
                 "description": "If the target of this Arts is your opponent's 2nd holomem, and you have used a Limited event this turn, this Arts gets +70."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Natsuiro Matsuri",
@@ -1481,7 +1549,8 @@
             }
         ],
         "hasFullArt": true,
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Oozora Subaru",
@@ -1499,7 +1568,8 @@
                 "dmg": "20"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Oozora Subaru",
@@ -1517,7 +1587,8 @@
                 "dmg": "30"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "name": "Oozora Subaru",
@@ -1536,7 +1607,8 @@
                 "description": "This Arts gets +20 for every <Subatomo> attached to this holomem."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "name": "Oozora Subaru",
@@ -1556,7 +1628,8 @@
             }
         ],
         "hasFullArt": true,
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "name": "Anya Melfissa",
@@ -1575,7 +1648,8 @@
                 "description": "If you used your Oshi skill \"Mystical Ritual\" this turn, you may return 1~3 <Anya Melfissa> from your archive to hand."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "name": "LAMBDUCK",
@@ -1595,7 +1669,8 @@
                 "description": "[Collab position only]If your Oshi holomem is <Tsunomaki Watame> or <Oozora Subaru>, the cheer cost of this Arts is reduced by 1 yellow cheer. If your center holomem is a 2nd <Tsunomaki Watame>, the cheer cost of this Arts is reduced by 3 yellow cheer instead."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "name": "AI Koyori",
@@ -1613,7 +1688,8 @@
                 "dmg": "30"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 0
     },
     {
         "name": "Favorite PC",

--- a/sets/hBP/hBP07.json
+++ b/sets/hBP/hBP07.json
@@ -129,9 +129,11 @@
         "skills": [
             {
                 "name": "スプリングシープ",
+                "cost": "1 any color",
                 "dmg": 20
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP07-009",
@@ -144,11 +146,13 @@
         "skills": [
             {
                 "name": "ガブガブ！",
+                "cost": "1 White",
                 "dmg": "20+",
                 "description": "[Center Position Only]This Arts gets +20."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP07-010",
@@ -162,10 +166,12 @@
         "skills": [
             {
                 "name": "みんなの声聞けるかなー？？？？？？？",
+                "cost": "1 White",
                 "dmg": 40
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP07-011",
@@ -179,11 +185,13 @@
         "skills": [
             {
                 "name": "これボタン弾けちゃうよぉ",
+                "cost": "3 any color",
                 "dmg": 70,
                 "description": "If this holomem has 2 white cheers attached, this Arts requires -1 colorless."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP07-012",
@@ -197,11 +205,13 @@
         "skills": [
             {
                 "name": "わたキャノンもだ！",
+                "cost": "1 any color",
                 "dmg": 20,
                 "description": "Draw 1 card."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP07-013",
@@ -215,11 +225,13 @@
         "skills": [
             {
                 "name": "センキューオーバーシープ！",
+                "cost": "2 any color",
                 "dmg": "90+, +50 vs purple",
                 "description": "This Arts gets +50 for each <Watamates> attached to this holomem."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP07-014",
@@ -233,12 +245,14 @@
         "skills": [
             {
                 "name": "脳天直撃わためハンマー！",
+                "cost": "2 White, 1 any color",
                 "dmg": "160, +50 vs red",
                 "description": "[Center Position Only]If your opponent's holomem is downed by this Arts, and the dealt damage was greater than the remaining HP, deal special damage to 1 of your opponent's 2nd holomem equal to the excess damage."
             }
         ],
         "hasFullArt": true,
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP07-015",
@@ -252,9 +266,11 @@
         "skills": [
             {
                 "name": "ノラネコ見つけた~",
+                "cost": "1 any color",
                 "dmg": 20
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP07-016",
@@ -268,10 +284,12 @@
         "skills": [
             {
                 "name": "So, Tell Me Your Secrets?",
+                "cost": "1 White",
                 "dmg": 20
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP07-017",
@@ -285,10 +303,12 @@
         "skills": [
             {
                 "name": "みんなと一緒にいる時間が好き",
+                "cost": "2 any color",
                 "dmg": 50
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP07-018",
@@ -302,11 +322,13 @@
         "skills": [
             {
                 "name": "うまみ～うまみ～♪",
+                "cost": "1 White",
                 "dmg": "30+",
                 "description": "If you have used an event this turn, this Arts gets +30."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP07-019",
@@ -322,11 +344,13 @@
         "skills": [
             {
                 "name": "ホロライブID初代ダンスクイーン",
+                "cost": "1 White, 1 any color",
                 "dmg": 50,
                 "description": "If this holomem has a mascot or fan attached, draw 1 card."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP07-020",
@@ -340,10 +364,12 @@
         "skills": [
             {
                 "name": "もっとパフォーマンスしたい！",
+                "cost": "2 White",
                 "dmg": "100, +50 vs red"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP07-021",
@@ -357,12 +383,14 @@
         "skills": [
             {
                 "name": "最高のシークレットエージェント",
+                "cost": "2 White, 2 any color",
                 "dmg": "160+, +50 vs purple",
                 "description": "If you have a Buzz holomem with #IDGen3 on your stage, this Arts gets +40."
             }
         ],
         "hasFullArt": true,
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP07-022",
@@ -376,11 +404,13 @@
         "skills": [
             {
                 "name": "元気もりもりさんでーまっする",
+                "cost": "1 White",
                 "dmg": "50, +50 vs purple",
                 "description": "Choose 1 of your holomem with #Gen3. During this turn, the chosen holomem requires -1 colorless for its Arts. If that holomem is a 2nd <Shirogane Noel>, it requires -2 colorless for its Arts instead."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP07-023",
@@ -394,9 +424,11 @@
         "skills": [
             {
                 "name": "MIOON!",
+                "cost": "1 any color",
                 "dmg": 30
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP07-024",
@@ -410,11 +442,13 @@
         "skills": [
             {
                 "name": "今日もいっぱい笑っていこう",
+                "cost": "1 Green",
                 "dmg": "10+",
                 "description": "You may archive the top card of your deck. If the archived card is a support card, this Arts gets +30."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP07-025",
@@ -428,11 +462,13 @@
         "skills": [
             {
                 "name": "ゲーマーズカフェへようこそ",
+                "cost": "1 any color",
                 "dmg": 20,
                 "description": "Send 1 cheer from your archive to 1 of your holomem with #GAMERS."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP07-026",
@@ -446,10 +482,12 @@
         "skills": [
             {
                 "name": "ちょっとお洒落な感じでしょ？",
+                "cost": "1 any color",
                 "dmg": 40
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP07-027",
@@ -463,11 +501,13 @@
         "skills": [
             {
                 "name": "女王陛下と呼びなさい",
+                "cost": "2 Green",
                 "dmg": 70,
                 "description": "[Center Position Only]When this Arts downed your opponent's holomem, draw 1 card."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP07-028",
@@ -481,11 +521,13 @@
         "skills": [
             {
                 "name": "天まで届け、みんなの願い",
+                "cost": "1 Green, 1 any color",
                 "dmg": "90+, +50 vs blue",
                 "description": "You may archive the top card of your deck. If the archived card is a support card, this Arts gets +50."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP07-029",
@@ -499,12 +541,14 @@
         "skills": [
             {
                 "name": "Upright Leading",
+                "cost": "3 any color",
                 "dmg": "130+, +50 vs yellow",
                 "description": "You may archive the top card of your deck:If the archived card is a holomem, send the top card of your cheer deck to your holomem. If it is a support card, this Arts gets +50."
             }
         ],
         "hasFullArt": true,
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP07-030",
@@ -518,11 +562,13 @@
         "skills": [
             {
                 "name": "たくさんの宝物",
+                "cost": "2 Green",
                 "dmg": "100, +50 vs yellow",
                 "description": "You may archive 2 cheers from this holomem:Draw 2 cards."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP07-031",
@@ -538,11 +584,13 @@
         "skills": [
             {
                 "name": "ひとつになる声",
+                "cost": "1 Green, 1 any color",
                 "dmg": 50,
                 "description": "If your oshi holomem is green, blue or yellow, put the top card of your deck as holo Power."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP07-032",
@@ -556,9 +604,11 @@
         "skills": [
             {
                 "name": "一陣の夜風",
+                "cost": "1 any color",
                 "dmg": 10
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP07-033",
@@ -572,10 +622,12 @@
         "skills": [
             {
                 "name": "～Something blue～ 千速",
+                "cost": "1 Green, 1 any color",
                 "dmg": 50
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP07-034",
@@ -589,11 +641,13 @@
         "skills": [
             {
                 "name": "どっちが速いｶﾅ？！？！？！",
+                "cost": "1 any color",
                 "dmg": "20+",
                 "description": "If <Fugutaro> is attached to this holomem, this Arts gets +10."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP07-035",
@@ -607,12 +661,14 @@
         "skills": [
             {
                 "name": "サージングエキゾースト",
+                "cost": "2 Green, 2 any color",
                 "dmg": "160, +50 vs blue",
                 "description": "Count the number of cheers attached to this holomem, and return all cheers attached to this holomem to the bottom of your cheer deck in any order. Draw cards until your hand has the same number of cards as the number of cheers returned."
             }
         ],
         "hasFullArt": true,
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP07-036",
@@ -626,9 +682,11 @@
         "skills": [
             {
                 "name": "どちらがお好き？♡",
+                "cost": "1 any color",
                 "dmg": 30
             }
-        ]
+        ],
+        "batonTouch": 0
     },
     {
         "cardNumber": "hBP07-037",
@@ -642,10 +700,12 @@
         "skills": [
             {
                 "name": "旅はまだ、始まったばかり。",
+                "cost": "1 any color",
                 "dmg": 20
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP07-038",
@@ -659,11 +719,13 @@
         "skills": [
             {
                 "name": "hololiveEN0",
+                "cost": "1 any color",
                 "dmg": 30,
                 "description": "During this turn, all holomem on your stage with #EN get Arts+20."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP07-039",
@@ -677,11 +739,13 @@
         "skills": [
             {
                 "name": "俺の名は〝ちゃまお〟漢の中の漢だ！",
+                "cost": "1 Red, 1 any color",
                 "dmg": 50,
                 "description": "Deal 20 special damage to your opponent's center holomem."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP07-040",
@@ -695,10 +759,12 @@
         "skills": [
             {
                 "name": "当店自慢のはあとんバーガー！",
+                "cost": "1 Red",
                 "dmg": 40
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP07-041",
@@ -712,11 +778,13 @@
         "skills": [
             {
                 "name": "万物に愛されちゃま計画",
+                "cost": "1 Red, 1 any color",
                 "dmg": "80+, +50 vs green",
                 "description": "If all cheers on your stage are red cheers, this Arts gets +20."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP07-042",
@@ -729,17 +797,20 @@
         "skills": [
             {
                 "name": "純心タランテラ",
+                "cost": "2 Red",
                 "dmg": "80, +50 vs purple",
                 "description": "Deal 40 special damage to your opponent's center holomem and collab holomem."
             },
             {
                 "name": "幸せへの旅路",
+                "cost": "1 Red, 2 any color",
                 "dmg": "140+, +50 vs purple",
                 "description": "If your holomem returned from your stage to deck this turn, this Arts gets +50."
             }
         ],
         "hasFullArt": true,
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP07-043",
@@ -753,11 +824,13 @@
         "skills": [
             {
                 "name": "桜は花に顕る",
+                "cost": "3 Red, 1 any color",
                 "dmg": "70+, +50 vs purple",
                 "description": "For each <35P> attached to this holomem, this Arts gets +70 and you draw 1 card."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP07-044",
@@ -771,11 +844,13 @@
         "skills": [
             {
                 "name": "スタッフファーストです！",
+                "cost": "2 Red",
                 "dmg": "120, +50 vs purple",
                 "description": "Archive the top 2 cards of your deck. You may return 1 staff from your archive to hand."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP07-045",
@@ -791,11 +866,13 @@
         "skills": [
             {
                 "name": "キミがいないと楽しくないもん",
+                "cost": "1 Red, 1 any color",
                 "dmg": "20+",
                 "description": "This Arts gets +20 for each card in your hand."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP07-046",
@@ -809,9 +886,11 @@
         "skills": [
             {
                 "name": "Onwards and Upwards!",
+                "cost": "1 any color",
                 "dmg": 30
             }
-        ]
+        ],
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP07-047",
@@ -825,10 +904,12 @@
         "skills": [
             {
                 "name": "さあ、かかってくるといい",
+                "cost": "1 Red",
                 "dmg": 50
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP07-048",
@@ -844,11 +925,13 @@
         "skills": [
             {
                 "name": "Because I love people's voices",
+                "cost": "1 Red, 1 any color",
                 "dmg": 60,
                 "description": "Return 1 holomem with #EN from your archive to hand."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 3
     },
     {
         "cardNumber": "hBP07-049",
@@ -862,12 +945,14 @@
         "skills": [
             {
                 "name": "不撓のコンチェルタート",
+                "cost": "1 Red, 2 any color",
                 "dmg": "130+, +50 vs yellow",
                 "description": "If your life is 4 or less, this Arts gets +30. If your life is 2 or less, this Arts gets +60 instead."
             }
         ],
         "hasFullArt": true,
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 3
     },
     {
         "cardNumber": "hBP07-050",
@@ -881,9 +966,11 @@
         "skills": [
             {
                 "name": "金色のルアー",
+                "cost": "1 any color",
                 "dmg": 10
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP07-051",
@@ -897,10 +984,12 @@
         "skills": [
             {
                 "name": "Check This Out Yo 🕶️",
+                "cost": "1 any color",
                 "dmg": 30
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP07-052",
@@ -914,11 +1003,13 @@
         "skills": [
             {
                 "name": "私の新キャッチフレーズ。どうだい？",
+                "cost": "1 any color",
                 "dmg": "30+",
                 "description": "If your stage has a holomem with #Promise other than <Ouro Kronii>, this Arts gets +10."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP07-053",
@@ -932,11 +1023,13 @@
         "skills": [
             {
                 "name": "Everlasting Flower",
+                "cost": "1 Blue, 1 any color",
                 "dmg": 50,
                 "description": "Send the top card of your cheer deck to your holomem with #Promise."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP07-054",
@@ -951,11 +1044,13 @@
         "skills": [
             {
                 "name": "I'm pretty shy…uwu",
+                "cost": "1 Blue",
                 "dmg": 50,
                 "description": "Send the top card of your cheer deck to your Buzz holomem with #Promise."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP07-055",
@@ -969,10 +1064,12 @@
         "skills": [
             {
                 "name": "Life Goes On",
+                "cost": "1 Blue, 1 any color",
                 "dmg": "90, +50 vs white"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP07-056",
@@ -986,12 +1083,14 @@
         "skills": [
             {
                 "name": "You're not ready for me.",
+                "cost": "2 Blue, 2 any color",
                 "dmg": "80+, +50 vs red",
                 "description": "You may reattach 1 cheer from this holomem to your other holomem with #Promise. If your Oshi holomem is <Ouro Kronii>, this Arts gets +100."
             }
         ],
         "hasFullArt": true,
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP07-057",
@@ -1005,11 +1104,13 @@
         "skills": [
             {
                 "name": "おりゃー！！油断したでしょ～",
+                "cost": "2 Blue, 1 any color",
                 "dmg": "100, +50 vs red",
                 "description": "If your Oshi holomem is <Nekomata Okayu> and your opponent has a back holomem which has taken 100 or more damage, deal 50 special damage to 1 of your opponent's holomem."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP07-058",
@@ -1023,11 +1124,13 @@
         "skills": [
             {
                 "name": "MANTAP LEE!!",
+                "cost": "1 Blue, 2 any color",
                 "dmg": 60,
                 "description": "If your opponent has 3 or more back holomem with reduced HP, draw 2 cards."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP07-059",
@@ -1041,10 +1144,12 @@
         "skills": [
             {
                 "name": "A Cozy, Spooky Night Together",
+                "cost": "1 any color",
                 "dmg": 10,
                 "description": "Deal 10 special damage to 1 of your opponent's holomem."
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP07-060",
@@ -1057,15 +1162,18 @@
         "skills": [
             {
                 "name": "食料解剖",
+                "cost": "1 any color",
                 "dmg": 10
             },
             {
                 "name": "Don't Let Her Cook!",
+                "cost": "1 Blue",
                 "dmg": 50,
                 "description": "This Arts may not be used unless you have 4 or more support cards in your archive."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP07-061",
@@ -1079,11 +1187,13 @@
         "skills": [
             {
                 "name": "逃がす訳がないでしょう？",
+                "cost": "1 Blue",
                 "dmg": 20,
                 "description": "Deal 20 special damage to 1 of your opponent's back holomem."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP07-062",
@@ -1097,12 +1207,14 @@
         "skills": [
             {
                 "name": "解き放たれた禁断の知識",
+                "cost": "1 Blue",
                 "dmg": "60+, +50 vs red",
                 "description": "Send 1 cheer from your archive to your holomem with #Advent. If your Oshi holomem is <Shiori Novella> and 4 or more cheers are attached to this holomem, this Arts gets +100."
             }
         ],
         "hasFullArt": true,
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP07-063",
@@ -1116,9 +1228,11 @@
         "skills": [
             {
                 "name": "君とぴったり密着空間",
+                "cost": "1 any color",
                 "dmg": 30
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP07-064",
@@ -1131,11 +1245,13 @@
         "skills": [
             {
                 "name": "ゆっくりしにおいで♡",
+                "cost": "1 any color",
                 "dmg": 20,
                 "description": "Reveal 1 <Pioneers> from your deck, and attach it to your <AZKi>. Then, shuffle the deck."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP07-065",
@@ -1148,15 +1264,18 @@
         "skills": [
             {
                 "name": "盛り上がっていこう！",
+                "cost": "1 any color",
                 "dmg": 30,
                 "description": "Draw 1 card, and archive 1 card from your hand."
             },
             {
                 "name": "みんなの声聞かせてええええええ！！！",
+                "cost": "1 Purple, 3 any color",
                 "dmg": 120
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP07-066",
@@ -1170,10 +1289,12 @@
         "skills": [
             {
                 "name": "音楽と歌うことが大好き！",
+                "cost": "1 any color",
                 "dmg": 40
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP07-067",
@@ -1187,11 +1308,13 @@
         "skills": [
             {
                 "name": "君と二人きりの夜",
+                "cost": "1 Purple, 1 any color",
                 "dmg": 40,
                 "description": "You may archive 1 card from your hand:Deal 20 special damage to your opponent's center holomem or collab holomem."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP07-068",
@@ -1206,10 +1329,12 @@
         "skills": [
             {
                 "name": "ホワイトデーのお返し、待ってるね",
+                "cost": "2 any color",
                 "dmg": "100, +50 vs yellow"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP07-069",
@@ -1222,17 +1347,20 @@
         "skills": [
             {
                 "name": "君と新たな開拓の地へ",
+                "cost": "1 Purple, 2 any color",
                 "dmg": "140, +50 vs green",
                 "description": "Draw 2 cards."
             },
             {
                 "name": "紡いだ軌跡 すべてに捧ぐ歌",
+                "cost": "3 Purple, 1 any color",
                 "dmg": "200, +50 vs green",
                 "description": "If your Oshi holomem is <AZKi>, you may archive 4 of your holo Power:If you have 4 <Frontier Spirit> in your archive, your opponent gets life-1."
             }
         ],
         "hasFullArt": true,
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP07-070",
@@ -1246,11 +1374,13 @@
         "skills": [
             {
                 "name": "がんばって美味しいの作るね♡",
+                "cost": "1 Purple",
                 "dmg": 30,
                 "description": "Choose 1 of your holomem with #Cooking. During this turn, for each event with #Food you used this turn, the chosen holomem requires -1 colorless for its Arts."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP07-071",
@@ -1264,10 +1394,12 @@
         "skills": [
             {
                 "name": "手作りの朝ごはんを要求する",
+                "cost": "1 Purple",
                 "dmg": 30
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 0
     },
     {
         "cardNumber": "hBP07-072",
@@ -1281,10 +1413,12 @@
         "skills": [
             {
                 "name": "吾輩との秘密だぞ",
+                "cost": "1 Purple, 1 any color",
                 "dmg": 60
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP07-073",
@@ -1298,11 +1432,13 @@
         "skills": [
             {
                 "name": "吾輩の歌聴いてくれる奴いるううう！？！？",
+                "cost": "2 any color",
                 "dmg": 30,
                 "description": "Reveal 1 <La+ Darknesss> from your deck, and add it to hand. Then, shuffle the deck."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP07-074",
@@ -1316,12 +1452,14 @@
         "skills": [
             {
                 "name": "吾輩の歌を聴けえええええええ！！！！",
+                "cost": "1 Purple, 2 any color",
                 "dmg": "110+, +50 vs green",
                 "description": "If your center holomem is purple, this Arts gets +40."
             }
         ],
         "hasFullArt": true,
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP07-075",
@@ -1335,11 +1473,13 @@
         "skills": [
             {
                 "name": "CODE:81800",
+                "cost": "1 Purple",
                 "dmg": "70+, +50 vs blue",
                 "description": "If 3 or more cheers are attached to this holomem, this Arts gets +10 for each cheer in both players' archive."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP07-076",
@@ -1355,11 +1495,13 @@
         "skills": [
             {
                 "name": "あら、捕まえられちゃった！",
+                "cost": "1 Purple, 1 any color",
                 "dmg": "50+",
                 "description": "You may archive 1 of your holo Power:This Arts gets +30."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP07-077",
@@ -1373,9 +1515,11 @@
         "skills": [
             {
                 "name": "ねね、酔っちゃった～",
+                "cost": "1 any color",
                 "dmg": 10
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP07-078",
@@ -1389,10 +1533,12 @@
         "skills": [
             {
                 "name": "ねねと一緒に楽しもう！！",
+                "cost": "1 any color",
                 "dmg": 20
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP07-079",
@@ -1406,11 +1552,13 @@
         "skills": [
             {
                 "name": "ご自由にお使いください！",
+                "cost": "1 any color",
                 "dmg": 30,
                 "description": "Reveal 1 <Yamena> from your deck, and attach it to your holomem. Then, shuffle the deck."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP07-080",
@@ -1424,10 +1572,12 @@
         "skills": [
             {
                 "name": "さいくーにくぅわいい",
+                "cost": "1 Yellow",
                 "dmg": 40
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP07-081",
@@ -1441,11 +1591,13 @@
         "skills": [
             {
                 "name": "君のハートをブルロック！",
+                "cost": "2 Yellow",
                 "dmg": 30,
                 "description": "If this holomem has <Giraffe Stag Beetle> attached, this Arts damage is dealt to your opponent's center holomem and collab holomem, instead of only the holomem targeted by this Arts."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP07-082",
@@ -1459,10 +1611,12 @@
         "skills": [
             {
                 "name": "アチョ～～～！",
+                "cost": "1 any color",
                 "dmg": "50, +50 vs blue"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP07-083",
@@ -1476,12 +1630,14 @@
         "skills": [
             {
                 "name": "オーバーチアリーディング",
+                "cost": "1 Yellow, 2 any color",
                 "dmg": "100, +50 vs red",
                 "description": "Return 1 cheer from your opponent's [center holomem or collab holomem] to the bottom of the cheer deck."
             }
         ],
         "hasFullArt": true,
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP07-084",
@@ -1495,11 +1651,13 @@
         "skills": [
             {
                 "name": "やっぱり、FPSとか？",
+                "cost": "1 Yellow, 1 any color",
                 "dmg": "90, +50 vs blue",
                 "description": "Send 1 cheer from your archive to your holomem."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP07-085",
@@ -1513,11 +1671,13 @@
         "skills": [
             {
                 "name": "元気いっぱいカラフルパフェ",
+                "cost": "1 Yellow",
                 "dmg": "20+",
                 "description": "If your Oshi holomem is <Shiranui Flare>, choose 1 of your <Shiranui Flare>. During this turn, the chosen holomem gets Arts+20 for each of the chosen holomem's cheers."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP07-086",
@@ -1531,11 +1691,13 @@
         "skills": [
             {
                 "name": "追撃のライオット",
+                "cost": "2 Yellow, 1 any color",
                 "dmg": "160+, +50 vs blue",
                 "description": "If the target of this Arts is a holomem with reduced HP, this Arts gets +30."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP07-087",
@@ -1549,9 +1711,11 @@
         "skills": [
             {
                 "name": "現行犯逮捕だ",
+                "cost": "1 any color",
                 "dmg": 20
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP07-088",
@@ -1565,11 +1729,13 @@
         "skills": [
             {
                 "name": "みんなが居るから幸せだ！",
+                "cost": "1 Yellow, 1 any color",
                 "dmg": "50+",
                 "description": "If cheer has been archived from your stage this turn, this Arts gets +30."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP07-089",
@@ -1583,10 +1749,12 @@
         "skills": [
             {
                 "name": "スッゲーワクワクするしょ！！",
+                "cost": "1 Yellow",
                 "dmg": 50
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP07-090",
@@ -1600,12 +1768,14 @@
         "skills": [
             {
                 "name": "ぶち上げる気合いだ！",
+                "cost": "2 Yellow",
                 "dmg": "80+, +50 vs white",
                 "description": "This Arts gets +20 for each of this holomem's cheers."
             }
         ],
         "hasFullArt": true,
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP07-091",

--- a/sets/hBP/hBP08.json
+++ b/sets/hBP/hBP08.json
@@ -126,9 +126,11 @@
         "skills": [
             {
                 "name": "芽吹く春",
+                "cost": "1 any color",
                 "dmg": 30
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP08-009",
@@ -142,10 +144,12 @@
         "skills": [
             {
                 "name": "あたしはもっと深いところを見てるの",
+                "cost": "1 any color",
                 "dmg": 20
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP08-010",
@@ -159,10 +163,12 @@
         "skills": [
             {
                 "name": "I am Lightning Speed",
+                "cost": "1 any color",
                 "dmg": 40
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP08-011",
@@ -176,11 +182,13 @@
         "skills": [
             {
                 "name": "Hot Ending",
+                "cost": "1 any color",
                 "dmg": 30,
                 "description": "If a purple cheer is attached to this holomem, draw 1 card."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP08-012",
@@ -194,11 +202,13 @@
         "skills": [
             {
                 "name": "片や天使 片や悪魔",
+                "cost": "1 White, 1 any color",
                 "dmg": 50,
                 "description": "If a purple cheer is attached to this holomem, deal 20 special damage to your opponent's center holomem."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP08-013",
@@ -212,11 +222,13 @@
         "skills": [
             {
                 "name": "萌え萌えキュンしちゃった？",
+                "cost": "1 White, 1 any color",
                 "dmg": "70+, +50 vs purple",
                 "description": "If this holomem has purple cheer attached, this Arts gets +50."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP08-014",
@@ -230,12 +242,14 @@
         "skills": [
             {
                 "name": "プリズマティック・アンセム",
+                "cost": "1 White, 2 any color",
                 "dmg": "130+, +50 vs red",
                 "description": "During this turn, all holomem on your stage get Arts+20 for each purple cheer attached to this holomem."
             }
         ],
         "hasFullArt": true,
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP08-015",
@@ -249,10 +263,12 @@
         "skills": [
             {
                 "name": "ナインダーツ",
+                "cost": "1 any color",
                 "dmg": 20
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP08-016",
@@ -265,15 +281,18 @@
         "skills": [
             {
                 "name": "Stairway to the Stars",
+                "cost": "1 any color",
                 "dmg": 30,
                 "description": "If there are 3 or more <Tokino Sora> on your stage, draw 1 card."
             },
             {
                 "name": "あの時の空へ…",
+                "cost": "1 White, 2 any color",
                 "dmg": 90
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP08-017",
@@ -287,11 +306,13 @@
         "skills": [
             {
                 "name": "みんな、ぬんぬん進んでいこーう",
+                "cost": "1 White, 1 any color",
                 "dmg": "40+",
                 "description": "If you have a 2nd holomem with #Gen 0 on your stage, this Arts gets +20."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP08-018",
@@ -305,12 +326,14 @@
         "skills": [
             {
                 "name": "盛り上がってくれたらうれしいな！",
+                "cost": "1 White, 3 any color",
                 "dmg": "150, +50 vs red",
                 "description": "If your Oshi holomem is Tokino Sora, choose 1 other <Tokino Sora> on your stage. During this turn, you may also target your opponent's back 2nd holomem with the chosen holomem's Arts."
             }
         ],
         "hasFullArt": true,
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP08-019",
@@ -332,7 +355,8 @@
                 "description": "If this holomem does not have <Chattino> attached, attach 1 <Chattino> from your deck to this holomem. Then, shuffle the deck."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP08-020",
@@ -346,11 +370,13 @@
         "skills": [
             {
                 "name": "挑戦のまなざし",
+                "cost": "1 White, 1 any color",
                 "dmg": "110+, +50 vs red",
                 "description": "If you have archived 3 cards from your deck this turn, this Arts gets +40."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP08-021",
@@ -364,9 +390,11 @@
         "skills": [
             {
                 "name": "祝祭を響かせよう",
+                "cost": "1 any color",
                 "dmg": 30
             }
-        ]
+        ],
+        "batonTouch": 0
     },
     {
         "cardNumber": "hBP08-022",
@@ -380,10 +408,12 @@
         "skills": [
             {
                 "name": "エレガントに行くのです",
+                "cost": "1 any color",
                 "dmg": 20
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 0
     },
     {
         "cardNumber": "hBP08-023",
@@ -397,10 +427,12 @@
         "skills": [
             {
                 "name": "とってもとっても特別！",
+                "cost": "1 Green",
                 "dmg": 40
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP08-024",
@@ -414,11 +446,13 @@
         "skills": [
             {
                 "name": "風の赴くままに",
+                "cost": "1 Green",
                 "dmg": 60,
                 "description": "Rest this holomem."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP08-025",
@@ -432,10 +466,12 @@
         "skills": [
             {
                 "name": "休憩も大事でしょ？",
+                "cost": "1 any color",
                 "dmg": 30
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP08-026",
@@ -449,10 +485,12 @@
         "skills": [
             {
                 "name": "奏楽のヴィンデ",
+                "cost": "1 Green, 1 any color",
                 "dmg": "90, +50 vs blue"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP08-027",
@@ -466,12 +504,14 @@
         "skills": [
             {
                 "name": "翠嵐のシュトルム",
+                "cost": "1 Green, 3 any color",
                 "dmg": "200, +50 vs yellow",
                 "description": "Draw 1 card for each of your resting holomem with #Justice. Then, rest this holomem."
             }
         ],
         "hasFullArt": true,
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP08-028",
@@ -486,11 +526,13 @@
         "skills": [
             {
                 "name": "一口食べる？",
+                "cost": "1 Green, 1 any color",
                 "dmg": 50,
                 "description": "Restore 30 HP to 1 of your holomem with tool attached."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP08-029",
@@ -504,10 +546,12 @@
         "skills": [
             {
                 "name": "極秘任務遂行中でござる",
+                "cost": "1 Green",
                 "dmg": 20
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP08-030",
@@ -521,10 +565,12 @@
         "skills": [
             {
                 "name": "以後　お見知りおきを…",
+                "cost": "1 any color",
                 "dmg": 10
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP08-031",
@@ -540,11 +586,13 @@
         "skills": [
             {
                 "name": "GWS+",
+                "cost": "1 Green, 1 any color",
                 "dmg": 60,
                 "description": "Archive the top card of your cheer deck. For every cheer color on your stage, restore 10 HP to 1 of your holomem."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP08-032",
@@ -558,11 +606,13 @@
         "skills": [
             {
                 "name": "ストラクチュラル・カラー",
+                "cost": "2 any color",
                 "dmg": "80+, +50 vs blue",
                 "description": "If you have a holomem with #ID Gen 2 other than <Pavolia Reine> with purple cheer or yellow cheer attached, this Arts gets +70."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP08-033",
@@ -576,12 +626,14 @@
         "skills": [
             {
                 "name": "ノックアウト・ツイスト",
+                "cost": "1 Green, 2 any color",
                 "dmg": "140, +50 vs blue",
                 "description": "Send 1~2 cheers from your archive to 1 of your <Pavolia Reine>."
             }
         ],
         "hasFullArt": true,
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP08-034",
@@ -595,9 +647,11 @@
         "skills": [
             {
                 "name": "あなたのもこもこなモココ",
+                "cost": "1 any color",
                 "dmg": 30
             }
-        ]
+        ],
+        "batonTouch": 0
     },
     {
         "cardNumber": "hBP08-035",
@@ -610,11 +664,13 @@
         "skills": [
             {
                 "name": "やったぁ大勝ちだ！！",
+                "cost": "1 Red",
                 "dmg": "10+",
                 "description": "If a blue cheer is attached to this holomem, this Arts gets +30."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP08-036",
@@ -628,10 +684,12 @@
         "skills": [
             {
                 "name": "ふたりは“BAU” DOL☆★",
+                "cost": "1 any color",
                 "dmg": 40
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP08-037",
@@ -645,11 +703,13 @@
         "skills": [
             {
                 "name": "がんBAUるねー！",
+                "cost": "2 Red",
                 "dmg": 30,
                 "description": "If 2 blue cheers are attached to this holomem, send the top card of your cheer deck to your <Fuwawa Abyssgard>."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP08-038",
@@ -663,10 +723,12 @@
         "skills": [
             {
                 "name": "勝つのはモココだよ！",
+                "cost": "2 any color",
                 "dmg": "100, +50 vs green"
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP08-039",
@@ -680,12 +742,14 @@
         "skills": [
             {
                 "name": "もこもこバウンティハンター",
+                "cost": "3 Red",
                 "dmg": "90+, +50 vs purple",
                 "description": "For each blue cheer attached to this holomem, this Arts gets +20. Then, choose any number of blue cheers attached to this holomem, and reattach them to 1 of your <Fuwawa Abyssgard>."
             }
         ],
         "hasFullArt": true,
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP08-040",
@@ -701,11 +765,13 @@
         "skills": [
             {
                 "name": "お花見デート",
+                "cost": "1 Red, 1 any color",
                 "dmg": "30+",
                 "description": "This Arts gets +10 for each red cheer in your archive."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP08-041",
@@ -719,11 +785,13 @@
         "skills": [
             {
                 "name": "\"熱狂的な夜\"は実在する!!!",
+                "cost": "1 any color",
                 "dmg": 20,
                 "description": "Archive the top card of your deck."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP08-042",
@@ -737,10 +805,12 @@
         "skills": [
             {
                 "name": "キワワとチョンカーズ＆スムージー",
+                "cost": "1 Red",
                 "dmg": 40
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP08-043",
@@ -756,11 +826,13 @@
         "skills": [
             {
                 "name": "生き抜く覚悟",
+                "cost": "2 Red",
                 "dmg": 50,
                 "description": "If all holomem on your stage have #Myth, put the top card of your deck to holo Power."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP08-044",
@@ -774,12 +846,14 @@
         "skills": [
             {
                 "name": "不敵なるファイヤーフォーゲル",
+                "cost": "2 Red",
                 "dmg": "100, +50 vs purple",
                 "description": "Archive 1~3 cards from the top of your deck."
             }
         ],
         "hasFullArt": true,
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP08-045",
@@ -793,11 +867,13 @@
         "skills": [
             {
                 "name": "ボクはボクらしく生きたい。",
+                "cost": "1 Red",
                 "dmg": "50+, +50 vs green",
                 "description": "Choose 1 holomem on your stage and roll a die once. During this turn, the chosen holomem gets Arts+10x the result."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP08-046",
@@ -811,10 +887,12 @@
         "skills": [
             {
                 "name": "スイートトゥース",
+                "cost": "1 Red",
                 "dmg": 30
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP08-047",
@@ -828,9 +906,11 @@
         "skills": [
             {
                 "name": "すうの充電たりてる？",
+                "cost": "1 Blue",
                 "dmg": 30
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP08-048",
@@ -844,10 +924,12 @@
         "skills": [
             {
                 "name": "つよい。でかい。大きい。",
+                "cost": "1 any color",
                 "dmg": 30
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP08-049",
@@ -861,10 +943,12 @@
         "skills": [
             {
                 "name": "君さえよかったらもっとはなそ",
+                "cost": "1 Blue, 1 any color",
                 "dmg": 50
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP08-050",
@@ -878,11 +962,13 @@
         "skills": [
             {
                 "name": "雪だるまつくろっ",
+                "cost": "1 Blue",
                 "dmg": 20,
                 "description": "Send 1 cheer from your archive to your holomem."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP08-051",
@@ -896,11 +982,13 @@
         "skills": [
             {
                 "name": "8時間35分",
+                "cost": "1 Blue, 1 any color",
                 "dmg": 40,
                 "description": "Send the top card of your cheer deck to your <Mizumiya Su>."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP08-052",
@@ -913,15 +1001,18 @@
         "skills": [
             {
                 "name": "元気の出るグミ",
+                "cost": "1 Blue",
                 "dmg": "70, +50 vs red",
                 "description": "If your opponent's center holomem requires 5 or more colorless cheers for its baton pass, send the top card of your cheer deck to your <Mizumiya Su>."
             },
             {
                 "name": "グミうまい",
+                "cost": "1 Blue, 3 any color",
                 "dmg": "180, +50 vs red"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP08-053",
@@ -935,12 +1026,14 @@
         "skills": [
             {
                 "name": "届け、この愛",
+                "cost": "2 Blue, 1 any color",
                 "dmg": "50, +50 vs white",
                 "description": "If your opponent's center holomem requires 5 or more colorless cheers for its baton pass, deal 100 special damage to 1 of your opponent's holomem other than Debut."
             }
         ],
         "hasFullArt": true,
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP08-054",
@@ -954,11 +1047,13 @@
         "skills": [
             {
                 "name": "ひとりじゃない、今は共に",
+                "cost": "3 any color",
                 "dmg": "130, +50 vs red",
                 "description": "You may archive 3 cheers from this holomem: Draw 3 cards."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP08-055",
@@ -972,11 +1067,13 @@
         "skills": [
             {
                 "name": "あなたのふわふわなフワワ",
+                "cost": "1 Blue",
                 "dmg": 20,
                 "description": "If a red cheer is attached to this holomem, draw 1 card."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP08-056",
@@ -990,10 +1087,12 @@
         "skills": [
             {
                 "name": "思いっきりやってくるよ！",
+                "cost": "1 any color",
                 "dmg": 40
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP08-057",
@@ -1007,11 +1106,13 @@
         "skills": [
             {
                 "name": "寄り添うふたり",
+                "cost": "1 Blue",
                 "dmg": "30+",
                 "description": "If a red cheer is attached to this holomem, this Arts gets +20."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP08-058",
@@ -1024,16 +1125,19 @@
         "skills": [
             {
                 "name": "勝てるわけないでしょ！",
+                "cost": "1 Blue, 1 any color",
                 "dmg": "100, +50 vs white",
                 "description": "Choose 1-2 blue cheers from your archive, and send them to your holomem with #Advent as you choose."
             },
             {
                 "name": "今度はこっちの番だよ！",
+                "cost": "2 Blue, 2 any color",
                 "dmg": "160, +50 vs white",
                 "description": "If your Oshi holomem is blue <FUWAMOCO>, you may archive 2 cheers from this holomem: Deal 50 special damage to 1 of your opponent's holomem other than Debut."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP08-059",
@@ -1047,12 +1151,14 @@
         "skills": [
             {
                 "name": "ふわふわバウンダリースパナー",
+                "cost": "3 Blue",
                 "dmg": "80+, +50 vs white",
                 "description": "If your <Mococo Abyssgard> used Arts this turn, this Arts gets +50. Then, choose any number of red cheers attached to this holomem, and reattach them to 1 of your <Mococo Abyssgard>."
             }
         ],
         "hasFullArt": true,
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP08-060",
@@ -1067,11 +1173,13 @@
         "skills": [
             {
                 "name": "いっしょういっしょ♡",
+                "cost": "2 any color",
                 "dmg": 50,
                 "description": "If your Oshi holomem is blue <FUWAMOCO>, put the top card of your deck to holo Power."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP08-061",
@@ -1085,9 +1193,11 @@
         "skills": [
             {
                 "name": "holoX Coffeeをどうぞ",
+                "cost": "1 any color",
                 "dmg": 30
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP08-062",
@@ -1102,10 +1212,12 @@
         "skills": [
             {
                 "name": "ダウンさせる意志",
+                "cost": "1 any color",
                 "dmg": 20
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP08-063",
@@ -1119,10 +1231,12 @@
         "skills": [
             {
                 "name": "どう似合ってる？？？",
+                "cost": "1 Purple",
                 "dmg": 40
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP08-064",
@@ -1136,11 +1250,13 @@
         "skills": [
             {
                 "name": "眠らない街の仕事屋",
+                "cost": "1 any color",
                 "dmg": 20,
                 "description": "Attach 1 <Lui-tomo> from your deck to 1 of your holomem. Then, shuffle the deck."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP08-065",
@@ -1154,11 +1270,13 @@
         "skills": [
             {
                 "name": "差していくよ！",
+                "cost": "2 Purple",
                 "dmg": "50+",
                 "description": "If your hand has 2 or less cards, this Arts gets +30."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP08-066",
@@ -1172,11 +1290,13 @@
         "skills": [
             {
                 "name": "酔い、覚ましていこ？",
+                "cost": "1 any color",
                 "dmg": "60+, +50 vs yellow",
                 "description": "You may archive 1~2 cards from your hand: This Arts gets +20 for each card archived."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP08-067",
@@ -1190,12 +1310,14 @@
         "skills": [
             {
                 "name": "逆転の一手",
+                "cost": "3 Purple",
                 "dmg": "130+, +50 vs green",
                 "description": "If your hand has 2 or less cards, this Arts gets +50. If your hand has no cards, this Arts gets +70 instead."
             }
         ],
         "hasFullArt": true,
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP08-068",
@@ -1209,10 +1331,12 @@
         "skills": [
             {
                 "name": "引きこもり娘は外出の夢を見た",
+                "cost": "1 Purple",
                 "dmg": 10,
                 "description": "Deal 20 special damage to your opponent's center holomem and collab holomem with a different color to their Oshi holomem."
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP08-069",
@@ -1226,10 +1350,12 @@
         "skills": [
             {
                 "name": "うまくいったでしょ、もっといけるよ",
+                "cost": "1 any color",
                 "dmg": 30
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP08-070",
@@ -1243,11 +1369,13 @@
         "skills": [
             {
                 "name": "私の生涯の友人",
+                "cost": "1 Purple",
                 "dmg": 30,
                 "description": "Restore 10 HP to 1 of your holomem with #Myth for each holomem on your opponent's stage with a different color to their Oshi holomem."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP08-071",
@@ -1261,10 +1389,12 @@
         "skills": [
             {
                 "name": "Bonk!",
+                "cost": "2 any color",
                 "dmg": 50
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP08-072",
@@ -1278,11 +1408,13 @@
         "skills": [
             {
                 "name": "マルチカラー・スケッチ",
+                "cost": "1 Purple",
                 "dmg": "30+",
                 "description": "The Arts gets +10 for each holomem on your opponent's stage with a different color to their Oshi holomem."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP08-073",
@@ -1296,10 +1428,12 @@
         "skills": [
             {
                 "name": "おやつのクッキー抜きだよ！",
+                "cost": "2 any color",
                 "dmg": "90, +50 vs blue"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP08-074",
@@ -1313,12 +1447,14 @@
         "skills": [
             {
                 "name": "ネクロ・エリミネーション!!",
+                "cost": "3 any color",
                 "dmg": "110, +50 vs yellow",
                 "description": "You may archive 1~3 cards from your hand: Choose 1 of your opponent's holomem for each card archived with this ability. During this turn, the chosen holomem are regarded as holomem with all colors."
             }
         ],
         "hasFullArt": true,
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP08-075",
@@ -1332,11 +1468,13 @@
         "skills": [
             {
                 "name": "一緒に外に行こうよ",
+                "cost": "2 Purple",
                 "dmg": "110+, +50 vs yellow",
                 "description": "This Arts gets +20 for each <Roboser> attached to this holomem."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP08-076",
@@ -1350,11 +1488,13 @@
         "skills": [
             {
                 "name": "ごはんをいっぱい食べたあとには……",
+                "cost": "1 Purple, 2 any color",
                 "dmg": "120, +50 vs blue",
                 "description": "If you have 3 or more events with #Food in your archive, restore 100 HP to this holomem."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP08-077",
@@ -1368,9 +1508,11 @@
         "skills": [
             {
                 "name": "奏スタンバイ",
+                "cost": "1 any color",
                 "dmg": 20
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP08-078",
@@ -1384,10 +1526,12 @@
         "skills": [
             {
                 "name": "れろれろれろれろ",
+                "cost": "1 any color",
                 "dmg": 20
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP08-079",
@@ -1401,11 +1545,13 @@
         "skills": [
             {
                 "name": "清廉なる歌声",
+                "cost": "1 any color",
                 "dmg": 10,
                 "description": "You may send 1 cheer from your archive to your center holomem with #ReGLOSS."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP08-080",
@@ -1420,10 +1566,12 @@
         "skills": [
             {
                 "name": "奏ストラクション",
+                "cost": "1 any color",
                 "dmg": 20
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP08-081",
@@ -1437,11 +1585,13 @@
         "skills": [
             {
                 "name": "今年も伸び盛り",
+                "cost": "1 Yellow, 1 any color",
                 "dmg": "40+",
                 "description": "[Center Position Only] If you have 1 more cheer on your stage than your opponent, this Arts gets +20. If you have 2 or more, this Arts gets +40 instead."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP08-082",
@@ -1455,10 +1605,12 @@
         "skills": [
             {
                 "name": "涙が止まらないよ～",
+                "cost": "1 Yellow, 1 any color",
                 "dmg": "100, +50 vs white"
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP08-083",
@@ -1472,12 +1624,14 @@
         "skills": [
             {
                 "name": "奏オンステージ",
+                "cost": "2 Yellow, 1 any color",
                 "dmg": "120+, +50 vs blue",
                 "description": "If the number of cheers on your stage is more than your opponent's, this Arts gets +20 for each cheer more."
             }
         ],
         "hasFullArt": true,
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP08-084",
@@ -1491,11 +1645,13 @@
         "skills": [
             {
                 "name": "まちゅだってお姫さま♡",
+                "cost": "1 any color",
                 "dmg": "30+",
                 "description": "If there is a 2nd holomem with #Gen 1 on your stage, this Arts gets +30."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP08-085",
@@ -1509,10 +1665,12 @@
         "skills": [
             {
                 "name": "テレ隠しが下手ですな～",
+                "cost": "1 any color",
                 "dmg": 10
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP08-086",
@@ -1526,11 +1684,13 @@
         "skills": [
             {
                 "name": "最高のともだち",
+                "cost": "1 any color",
                 "dmg": "20+",
                 "description": "If your center holomem is a 2nd holomem, this Arts gets +30."
             }
         ],
-        "hasFoils": true
+        "hasFoils": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP08-087",
@@ -1544,10 +1704,12 @@
         "skills": [
             {
                 "name": "夢から醒めたら",
+                "cost": "2 any color",
                 "dmg": "90, +50 vs blue"
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP08-088",
@@ -1561,12 +1723,14 @@
         "skills": [
             {
                 "name": "リレーションファンタジー",
+                "cost": "2 Yellow, 1 any color",
                 "dmg": "140+, +50 vs white",
                 "description": "[Collab Position Only] If your center holomem is a holomem with #Gen 3, this Arts gets +30."
             }
         ],
         "hasFullArt": true,
-        "hasAlternativeArt": true
+        "hasAlternativeArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hBP08-089",
@@ -1580,11 +1744,13 @@
         "skills": [
             {
                 "name": "アイアムアゲーマー",
+                "cost": "1 Yellow",
                 "dmg": 30,
                 "description": "Send 1 cheer from your archive to your holomem with #Justice."
             }
         ],
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hBP08-090",

--- a/sets/hBP/hBP08.json
+++ b/sets/hBP/hBP08.json
@@ -343,14 +343,11 @@
         "hp": 120,
         "color": "White",
         "tag": "#EN #Justice #Kemomimi #Painting",
-        "giftEffect": "ボナペティート -楽しい食事- : ■While this holomem does not have <Chattino> attached, this holomem requires -1 white cheer for its Arts.\n■While this holomem has <Chattino> attached, this holomem gets +30 HP.",
+        "giftEffect": "Buon Appetito -Enjoy Your Meal- ■While this holomem does not have <Chattino> attached, this holomem requires -1 white cheer for its Arts. ■While this holomem has <Chattino> attached, this holomem gets +30 HP.",
         "skills": [
             {
                 "name": "この幸せをシェアしよう",
-                "description": "■While this holomem has <Chattino> attached, this holomem gets +30 HP."
-            },
-            {
-                "name": "Let's Share This Happiness",
+                "cost": "1 White",
                 "dmg": 10,
                 "description": "If this holomem does not have <Chattino> attached, attach 1 <Chattino> from your deck to this holomem. Then, shuffle the deck."
             }

--- a/sets/hSD/hSD01.json
+++ b/sets/hSD/hSD01.json
@@ -44,9 +44,11 @@
         "skills": [
             {
                 "name": "ぬんぬん",
+                "cost": "1 any color",
                 "dmg": 30
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD01-004",
@@ -60,9 +62,11 @@
         "skills": [
             {
                 "name": "オンステージ!",
+                "cost": "1 any color",
                 "dmg": 20
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD01-005",
@@ -75,13 +79,16 @@
         "skills": [
             {
                 "name": "ぬんぬんしよう",
+                "cost": "1 White",
                 "dmg": 30
             },
             {
                 "name": "あなたの心は･･･くもりのち晴れ!",
+                "cost": "1 White, 1 any color",
                 "dmg": 50
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD01-006",
@@ -95,15 +102,18 @@
         "skills": [
             {
                 "name": "ドリームライブ",
+                "cost": "1 White, 1 any color",
                 "dmg": 50
             },
             {
                 "name": "SorAZ シンパシー",
+                "cost": "1 White, 1 Green, 1 any color",
                 "dmg": "60+",
                 "description": "When you have the Holomen 'AZKi' on your stage, this art gains +50."
             }
         ],
-        "extraEffect": "If this holomem is downed, you get Life-2."
+        "extraEffect": "If this holomem is downed, you get Life-2.",
+        "batonTouch": 2
     },
     {
         "cardNumber": "hSD01-007",
@@ -117,9 +127,11 @@
         "skills": [
             {
                 "name": "希望の化身",
+                "cost": "1 White",
                 "dmg": 20
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD01-008",
@@ -132,9 +144,11 @@
         "skills": [
             {
                 "name": "がんばれてえらい!",
+                "cost": "1 any color",
                 "dmg": 20
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD01-009",
@@ -148,9 +162,11 @@
         "skills": [
             {
                 "name": "ほいでほいで",
+                "cost": "1 any color",
                 "dmg": 10
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD01-010",
@@ -163,9 +179,11 @@
         "skills": [
             {
                 "name": "きみとあてのない旅",
+                "cost": "1 Green, 1 any color",
                 "dmg": 50
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD01-011",
@@ -178,15 +196,18 @@
         "skills": [
             {
                 "name": "SorAZ グラビティ",
+                "cost": "1 Green",
                 "dmg": 60,
                 "description": "When the Holomen 'Tokino Sora' is on your stage, send the top card of your cheer deck to one of your Holomen."
             },
             {
                 "name": "デスティニーソング",
+                "cost": "2 Green, 1 any color",
                 "dmg": "100+",
                 "description": "You can roll a die once: If the result is odd, this art gains +50. If the result is 1, this art gains an additional +50."
             }
-        ]
+        ],
+        "batonTouch": 2
     },
     {
         "cardNumber": "hSD01-012",
@@ -200,9 +221,11 @@
         "skills": [
             {
                 "name": "お絵かきたのしー!",
+                "cost": "1 Green",
                 "dmg": 20
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD01-013",
@@ -215,11 +238,13 @@
         "skills": [
             {
                 "name": "越えたい未来",
+                "cost": "2 any color",
                 "dmg": 50,
                 "description": "You may roll a die once: If the result is odd, send the top card of your cheer deck to this Holomen. If the result is even, draw one card from your deck."
             }
         ],
-        "extraEffect": "This Holomen is also treated as 'Tokino Sora' and 'AZKi'"
+        "extraEffect": "This Holomen is also treated as 'Tokino Sora' and 'AZKi'",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD01-014",
@@ -232,10 +257,12 @@
         "skills": [
             {
                 "name": "へい",
+                "cost": "1 White, 1 Green",
                 "dmg": 30
             }
         ],
-        "extraEffect": "This holomem cannot Bloom."
+        "extraEffect": "This holomem cannot Bloom.",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD01-015",
@@ -249,10 +276,12 @@
         "skills": [
             {
                 "name": "ピュアピュアピュア~",
+                "cost": "1 any color",
                 "dmg": 10
             }
         ],
-        "extraEffect": "This holomem cannot Bloom."
+        "extraEffect": "This holomem cannot Bloom.",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD01-016",

--- a/sets/hSD/hSD02.json
+++ b/sets/hSD/hSD02.json
@@ -48,9 +48,11 @@
         "skills": [
             {
                 "name": "Shiranui",
+                "cost": "1 any color",
                 "dmg": 30
             }
-        ]
+        ],
+        "batonTouch": 0
     },
     {
         "cardNumber": "hSD02-004",
@@ -64,9 +66,11 @@
         "skills": [
             {
                 "name": "Delicious dangos",
+                "cost": "1 Red",
                 "dmg": 30
             }
-        ]
+        ],
+        "batonTouch": 0
     },
     {
         "cardNumber": "hSD02-005",
@@ -79,13 +83,16 @@
         "skills": [
             {
                 "name": "Sleepy yo~",
+                "cost": "1 any color",
                 "dmg": 20
             },
             {
                 "name": "Otsunakiri",
+                "cost": "1 Red, 1 any color",
                 "dmg": 60
             }
-        ]
+        ],
+        "batonTouch": 0
     },
     {
         "cardNumber": "hSD02-006",
@@ -99,9 +106,11 @@
         "skills": [
             {
                 "name": "一緒にお祝い",
+                "cost": "1 Red",
                 "dmg": 30
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD02-007",
@@ -115,9 +124,11 @@
         "skills": [
             {
                 "name": "輝いた余を見逃さないでね～～！！",
+                "cost": "1 any color",
                 "dmg": 30
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD02-008",
@@ -131,15 +142,18 @@
         "skills": [
             {
                 "name": "ファンシーバースデー",
+                "cost": "1 Red, 1 any color",
                 "dmg": 40
             },
             {
                 "name": "プレゼント何かな？",
+                "cost": "2 Red, 1 any color",
                 "dmg": 50,
                 "description": "You may Archive one card from your hand for the following effect: deal 50 special damage to your opponent's Center or Collab holomem."
             }
         ],
-        "extraEffect": "If this holomem is downed, you get Life-2."
+        "extraEffect": "If this holomem is downed, you get Life-2.",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD02-009",
@@ -152,16 +166,19 @@
         "skills": [
             {
                 "name": "あやふぶみの「あや」担当",
+                "cost": "1 Red",
                 "dmg": 60
             },
             {
                 "name": "余ーだ余",
+                "cost": "2 Red, 1 any color",
                 "dmg": 40,
                 "description": "You may Archive 1-3 cards from your hand for the following effect: deal 40 special damage for each card Archived to your opponent's Center holomem."
             }
         ],
         "imageSet": "hBP02",
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD02-010",
@@ -175,10 +192,12 @@
         "skills": [
             {
                 "name": "あやふぶみの「ふぶ」担当",
+                "cost": "1 any color",
                 "dmg": 20
             }
         ],
-        "extraEffect": "This holomem cannot Bloom."
+        "extraEffect": "This holomem cannot Bloom.",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD02-011",
@@ -192,10 +211,12 @@
         "skills": [
             {
                 "name": "あやふぶみの「み」担当",
+                "cost": "1 any color",
                 "dmg": 10
             }
         ],
-        "extraEffect": "This holomem cannot Bloom."
+        "extraEffect": "This holomem cannot Bloom.",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD02-012",

--- a/sets/hSD/hSD02.json
+++ b/sets/hSD/hSD02.json
@@ -27,12 +27,14 @@
         "skills": [
             {
                 "name": "Konnakiri~",
+                "cost": "1 Red",
                 "dmg": 30
             }
         ],
         "extraEffect": "You may include any number of this holomem in the deck.",
         "hasHolomenRare": true,
-        "imageSet": "hBP06"
+        "imageSet": "hBP06",
+        "batonTouch": 0
     },
     {
         "cardNumber": "hSD02-003",

--- a/sets/hSD/hSD03.json
+++ b/sets/hSD/hSD03.json
@@ -27,10 +27,12 @@
         "skills": [
             {
                 "name": "もぐもぐ～おかゆ～",
+                "cost": "1 any color",
                 "dmg": 30
             }
         ],
-        "extraEffect": "You may include any number of this holomem in the deck."
+        "extraEffect": "You may include any number of this holomem in the deck.",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD03-003",

--- a/sets/hSD/hSD03.json
+++ b/sets/hSD/hSD03.json
@@ -46,9 +46,11 @@
         "skills": [
             {
                 "name": "僕をお家に入れてください",
+                "cost": "1 Blue",
                 "dmg": 10
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD03-004",
@@ -62,9 +64,11 @@
         "skills": [
             {
                 "name": "学生猫",
+                "cost": "1 any color",
                 "dmg": 20
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD03-005",
@@ -77,13 +81,16 @@
         "skills": [
             {
                 "name": "ぎゅ～ってしてよね♡",
+                "cost": "1 any color",
                 "dmg": 30
             },
             {
                 "name": "えへへないたずら",
+                "cost": "1 Blue, 1 any color",
                 "dmg": 50
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD03-006",
@@ -96,14 +103,17 @@
         "skills": [
             {
                 "name": "猫かぶり",
+                "cost": "1 Blue",
                 "dmg": 30
             },
             {
                 "name": "しゃー",
+                "cost": "1 Blue, 1 any color",
                 "dmg": 40,
                 "description": "You may Archive 1 Blue Cheer from this holomem for the following effect: deal 10 special damage to your opponent's Center holomem and one of their Back holomems."
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD03-007",
@@ -117,9 +127,11 @@
         "skills": [
             {
                 "name": "全力で僕なりの歌、お届けします！",
+                "cost": "1 any color",
                 "dmg": 20
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD03-008",
@@ -134,10 +146,12 @@
         "skills": [
             {
                 "name": "いちばんえらい猫又おかゆ～",
+                "cost": "1 Blue, 1 any color",
                 "dmg": 60
             }
         ],
-        "extraEffect": "If this holomem is downed, you get Life-2."
+        "extraEffect": "If this holomem is downed, you get Life-2.",
+        "batonTouch": 2
     },
     {
         "cardNumber": "hSD03-009",
@@ -150,16 +164,19 @@
         "skills": [
             {
                 "name": "MOGMOG",
+                "cost": "1 Blue, 1 any color",
                 "dmg": 60
             },
             {
                 "name": "おかゆ～",
+                "cost": "2 Blue, 2 any color",
                 "dmg": 100,
                 "description": "You may Archive 2 Blue Cheers from this holomem for the following effect: deal 30 special damage to your opponent's Center holomem and one of their Back holomems."
             }
         ],
         "imageSet": "hBP02",
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hSD03-010",
@@ -173,10 +190,12 @@
         "skills": [
             {
                 "name": "おらよ～",
+                "cost": "1 any color",
                 "dmg": 30
             }
         ],
-        "extraEffect": "This holomem cannot Bloom."
+        "extraEffect": "This holomem cannot Bloom.",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD03-011",
@@ -189,15 +208,18 @@
         "skills": [
             {
                 "name": "泥棒建設農業大臣",
+                "cost": "1 any color",
                 "dmg": 10
             },
             {
                 "name": "絶対、食わせてみせるわ",
+                "cost": "2 any color",
                 "dmg": 20,
                 "description": "If you have 2 or less cards in your hand, draw from your Deck until you have 3 cards in your hand."
             }
         ],
-        "extraEffect": "This holomem cannot Bloom."
+        "extraEffect": "This holomem cannot Bloom.",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD03-012",

--- a/sets/hSD/hSD04.json
+++ b/sets/hSD/hSD04.json
@@ -27,10 +27,12 @@
         "skills": [
             {
                 "name": "魔界の保健医",
+                "cost": "1 any color",
                 "dmg": 30
             }
         ],
-        "extraEffect": "You may include any number of this holomem in the deck."
+        "extraEffect": "You may include any number of this holomem in the deck.",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD04-003",

--- a/sets/hSD/hSD04.json
+++ b/sets/hSD/hSD04.json
@@ -46,9 +46,11 @@
         "skills": [
             {
                 "name": "マイキュ～トスチュ～デ～ンツ",
+                "cost": "1 Purple, 1 any color",
                 "dmg": 30
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD04-004",
@@ -62,9 +64,11 @@
         "skills": [
             {
                 "name": "いっぱい食べてね♡",
+                "cost": "1 Purple",
                 "dmg": 20
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD04-005",
@@ -77,13 +81,16 @@
         "skills": [
             {
                 "name": "おつかれいと……",
+                "cost": "1 Purple",
                 "dmg": 20
             },
             {
                 "name": "あ～む（ﾁｭｯ）",
+                "cost": "1 Purple, 1 any color",
                 "dmg": 40
             }
-        ]
+        ],
+        "batonTouch": 0
     },
     {
         "cardNumber": "hSD04-006",
@@ -96,9 +103,11 @@
         "skills": [
             {
                 "name": "禁断のキッス",
+                "cost": "1 Purple, 1 any color",
                 "dmg": 30
             }
-        ]
+        ],
+        "batonTouch": 0
     },
     {
         "cardNumber": "hSD04-007",
@@ -112,10 +121,12 @@
         "skills": [
             {
                 "name": "大好き！ちゅっ♡",
+                "cost": "2 any color",
                 "dmg": 30,
                 "description": "Restore 20HP to one of your Back holomems."
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD04-008",
@@ -129,15 +140,18 @@
         "skills": [
             {
                 "name": "がんばってつくったよ",
+                "cost": "1 Purple, 1 any color",
                 "dmg": 40
             },
             {
                 "name": "召し上がれ",
+                "cost": "2 Purple, 1 any color",
                 "dmg": "60+",
                 "description": "You may return one Event with #Food from your Archive to your hand: if you do, this Art gains +20 power."
             }
         ],
-        "extraEffect": "If this holomem is downed, you get Life-2."
+        "extraEffect": "If this holomem is downed, you get Life-2.",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD04-009",
@@ -150,16 +164,19 @@
         "skills": [
             {
                 "name": "33… 22… 11…",
+                "cost": "1 Purple, 1 any color",
                 "dmg": 50
             },
             {
                 "name": "あくとっ",
+                "cost": "2 Purple, 1 any color",
                 "dmg": 60,
                 "description": "For each Event card you've played during this turn, this Art gains +40 power."
             }
         ],
         "imageSet": "hBP02",
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD04-010",
@@ -173,10 +190,12 @@
         "skills": [
             {
                 "name": "地獄くじ引き、引かせるぞっ",
+                "cost": "2 any color",
                 "dmg": 20
             }
         ],
-        "extraEffect": "This holomem cannot Bloom."
+        "extraEffect": "This holomem cannot Bloom.",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD04-011",
@@ -190,10 +209,12 @@
         "skills": [
             {
                 "name": "んな～～～～～～～～",
+                "cost": "1 any color",
                 "dmg": 10
             }
         ],
-        "extraEffect": "This holomem cannot Bloom."
+        "extraEffect": "This holomem cannot Bloom.",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD04-012",

--- a/sets/hSD/hSD05.json
+++ b/sets/hSD/hSD05.json
@@ -23,7 +23,7 @@
         "bloomLevel": "Debut",
         "hp": 100,
         "color": "White",
-        "tag":  "#DEV_IS #ReGLOSS #Baby",
+        "tag": "#DEV_IS #ReGLOSS #Baby",
         "skills": [
             {
                 "name": "ぶんぶんぶーん！",
@@ -39,7 +39,7 @@
         "bloomLevel": "Debut",
         "hp": 60,
         "color": "White",
-        "tag":  "#DEV_IS #ReGLOSS #Baby",
+        "tag": "#DEV_IS #ReGLOSS #Baby",
         "collabEffect": "こんちくわ: During this turn, your center Holomem with #ReGLOSS gains +10 Arts.",
         "skills": [
             {
@@ -55,7 +55,7 @@
         "bloomLevel": "Debut",
         "hp": 120,
         "color": "White",
-        "tag":  "#DEV_IS #ReGLOSS #Baby",
+        "tag": "#DEV_IS #ReGLOSS #Baby",
         "skills": [
             {
                 "name": "ReGLOSSの番長",
@@ -70,7 +70,7 @@
         "bloomLevel": "1st",
         "hp": 140,
         "color": "White",
-        "tag":  "#DEV_IS #ReGLOSS #Baby",
+        "tag": "#DEV_IS #ReGLOSS #Baby",
         "skills": [
             {
                 "name": "夜路紫駆！",
@@ -89,7 +89,7 @@
         "bloomLevel": "1st",
         "hp": 100,
         "color": "White",
-        "tag":  "#DEV_IS #ReGLOSS #Baby",
+        "tag": "#DEV_IS #ReGLOSS #Baby",
         "skills": [
             {
                 "name": "足取り軽め、轟はじめ",
@@ -109,7 +109,7 @@
         "bloomLevel": "1st",
         "hp": 120,
         "color": "White",
-        "tag":  "#DEV_IS #ReGLOSS #Baby",
+        "tag": "#DEV_IS #ReGLOSS #Baby",
         "bloomEffect": "宇宙一の番長を目指すなんでも屋 : Draw 1 card from your Deck.",
         "skills": [
             {
@@ -126,7 +126,7 @@
         "buzz": "true",
         "hp": 230,
         "color": "White",
-        "tag":  "#DEV_IS #ReGLOSS #Baby",
+        "tag": "#DEV_IS #ReGLOSS #Baby",
         "skills": [
             {
                 "name": "……なんか、番長っぽくなってきたかも！",
@@ -143,17 +143,19 @@
         "bloomLevel": "2nd",
         "hp": 190,
         "color": "White",
-        "tag":  "#DEV_IS #ReGLOSS #Baby",
+        "tag": "#DEV_IS #ReGLOSS #Baby",
         "bloomEffect": "ダンスでこの世界に彩を！ : Reveal 1 Debut Holomem or 1st Holomem card with #ReGLOSS from your deck and add it to your hand. Then, shuffle your deck.",
         "skills": [
             {
                 "name": "滅紫の雷",
+                "cost": "2 White, 1 any color",
                 "dmg": "80+",
                 "description": "If you have a Holomem with #ReGLOSS other than <Todoroki Hajime> on your Stage, this arts gains +30."
             }
         ],
         "imageSet": "hBP03",
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hSD05-010",
@@ -166,7 +168,7 @@
         "skills": [
             {
                 "name": "ちょいと一席",
-                "dmg": 20, 
+                "dmg": 20,
                 "description": "You may send 1 Cheer from your Archive to your Holomem with #ReGLOSS."
             }
         ]
@@ -194,7 +196,7 @@
         "hp": 70,
         "color": "Blue",
         "tag": "#DEV_IS #ReGLOSS #Painting",
-        "collabEffect" : "ドーンッ！: Deal 10 special damage to your opponent's Center holomem or one of their Back holomems.",
+        "collabEffect": "ドーンッ！: Deal 10 special damage to your opponent's Center holomem or one of their Back holomems.",
         "skills": [
             {
                 "name": "世界一かわいいよ",
@@ -210,7 +212,7 @@
         "hp": 90,
         "color": "Yellow",
         "tag": "#DEV_IS #ReGLOSS #Singing",
-        "collabEffect" :"クレッシェンドな日々　:You may move 1 Cheer on your Stage to one of your holomems other than this holomem.",
+        "collabEffect": "クレッシェンドな日々　:You may move 1 Cheer on your Stage to one of your holomems other than this holomem.",
         "skills": [
             {
                 "name": "任せておきなさい！",

--- a/sets/hSD/hSD05.json
+++ b/sets/hSD/hSD05.json
@@ -27,10 +27,12 @@
         "skills": [
             {
                 "name": "ぶんぶんぶーん！",
+                "cost": "1 any color",
                 "dmg": 30
             }
         ],
-        "extraEffect": "You may include any number of this holomem in the deck."
+        "extraEffect": "You may include any number of this holomem in the deck.",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD05-003",
@@ -44,9 +46,11 @@
         "skills": [
             {
                 "name": "お洒落番長",
+                "cost": "1 any color",
                 "dmg": 30
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD05-004",
@@ -59,9 +63,11 @@
         "skills": [
             {
                 "name": "ReGLOSSの番長",
+                "cost": "1 White, 1 any color",
                 "dmg": 40
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD05-005",
@@ -74,13 +80,16 @@
         "skills": [
             {
                 "name": "夜路紫駆！",
+                "cost": "1 White",
                 "dmg": 40
             },
             {
                 "name": "うぃー！",
+                "cost": "2 any color",
                 "dmg": 60
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD05-006",
@@ -93,14 +102,17 @@
         "skills": [
             {
                 "name": "足取り軽め、轟はじめ",
+                "cost": "1 any color",
                 "dmg": 30
             },
             {
                 "name": "ありあとりゃあすっ",
+                "cost": "1 White, 1 any color",
                 "dmg": "50+",
                 "description": "If you have 3 or more Holomems with different card names with #ReGLOSS on your stage, this arts gains +20."
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD05-007",
@@ -114,9 +126,11 @@
         "skills": [
             {
                 "name": "度胸、愛嬌、最強",
+                "cost": "1 any color",
                 "dmg": 20
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD05-008",
@@ -130,11 +144,13 @@
         "skills": [
             {
                 "name": "……なんか、番長っぽくなってきたかも！",
+                "cost": "2 White",
                 "dmg": 50,
                 "description": "During this turn, the arts of one Debut Holomem with #ReGLOSS on your stage gains +40."
             }
         ],
-        "extraEffect": "If this holomem is downed, you get Life-2."
+        "extraEffect": "If this holomem is downed, you get Life-2.",
+        "batonTouch": 2
     },
     {
         "cardNumber": "hSD05-009",
@@ -168,10 +184,12 @@
         "skills": [
             {
                 "name": "ちょいと一席",
+                "cost": "1 any color",
                 "dmg": 20,
                 "description": "You may send 1 Cheer from your Archive to your Holomem with #ReGLOSS."
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD05-011",
@@ -184,9 +202,11 @@
         "skills": [
             {
                 "name": "任せておきなさい！",
+                "cost": "1 any color",
                 "dmg": 20
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD05-012",
@@ -200,9 +220,11 @@
         "skills": [
             {
                 "name": "世界一かわいいよ",
+                "cost": "1 any color",
                 "dmg": 20
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD05-013",
@@ -216,9 +238,11 @@
         "skills": [
             {
                 "name": "任せておきなさい！",
+                "cost": "1 any color",
                 "dmg": 20
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD05-014",

--- a/sets/hSD/hSD06.json
+++ b/sets/hSD/hSD06.json
@@ -28,9 +28,11 @@
         "skills": [
             {
                 "name": "いえす！ｼﾞｬｷﾝｼﾞｬｷﾝ！！",
+                "cost": "1 any color",
                 "dmg": 20
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD06-003",
@@ -43,10 +45,12 @@
         "skills": [
             {
                 "name": "一刀両断叩き斬る",
+                "cost": "1 Green",
                 "dmg": "30+",
                 "description": "If your Center holomem is damaged, this Art gains +10 power."
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD06-004",
@@ -59,9 +63,11 @@
         "skills": [
             {
                 "name": "照れ屋な用心棒",
+                "cost": "1 Green, 1 any color",
                 "dmg": 60
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD06-005",
@@ -75,9 +81,11 @@
         "skills": [
             {
                 "name": "かざまといっしょ！",
+                "cost": "1 Green",
                 "dmg": 30
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD06-006",
@@ -92,10 +100,12 @@
         "skills": [
             {
                 "name": "刀の錆になるでござる！",
+                "cost": "1 Green, 1 any color",
                 "dmg": 50
             }
         ],
-        "extraEffect": "If this holomem is downed, you get Life-2."
+        "extraEffect": "If this holomem is downed, you get Life-2.",
+        "batonTouch": 2
     },
     {
         "cardNumber": "hSD06-007",
@@ -130,9 +140,11 @@
         "skills": [
             {
                 "name": "どやぁ",
+                "cost": "1 any color",
                 "dmg": 10
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD06-009",
@@ -145,10 +157,12 @@
         "skills": [
             {
                 "name": "頼れる女幹部",
+                "cost": "1 any color",
                 "dmg": 20,
                 "description": "You may return 1 Debut holomem with $HoloX from your Archive to your hand."
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD06-010",
@@ -162,10 +176,12 @@
         "skills": [
             {
                 "name": "世界一かわいいよ",
-                "dmg": 20,
+                "cost": "1 any color",
+                "dmg": "30+",
                 "description": "[Collab position only] If you have used your SP Oshi Skill during this turn's Main Step, this Art gains +50 power."
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD06-011",

--- a/sets/hSD/hSD06.json
+++ b/sets/hSD/hSD06.json
@@ -109,12 +109,14 @@
         "skills": [
             {
                 "name": "天才では？",
+                "cost": "1 Green, 2 any color",
                 "dmg": "70+",
                 "description": "If there are at least 5 Cheers on your stage, this Art gains +50 power."
             }
         ],
         "imageSet": "hBP03",
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hSD06-008",

--- a/sets/hSD/hSD07.json
+++ b/sets/hSD/hSD07.json
@@ -23,20 +23,23 @@
         "bloomLevel": "Debut",
         "hp": 110,
         "color": "Yellow",
-        "tag":  "#JP #Gen3 #Half-Elf",
+        "tag": "#JP #Gen3 #Half-Elf",
         "skills": [
             {
                 "name": "こんぬいー！",
+                "cost": "1 any color",
                 "dmg": 20
             },
             {
                 "name": "不知火フレアだよ！",
+                "cost": "3 any color",
                 "dmg": 60
             }
         ],
         "extraEffect": "You may include any number of this holomem in the deck.",
         "hasHolomenRare": true,
-        "imageSet": "hBP05"
+        "imageSet": "hBP05",
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD07-003",
@@ -45,7 +48,7 @@
         "bloomLevel": "Debut",
         "hp": 60,
         "color": "Yellow",
-        "tag":  "#JP #Gen3 #Half-Elf",
+        "tag": "#JP #Gen3 #Half-Elf",
         "collabEffect": "大切な仲間たちと: If there are 5 or fewer holomems on your Stage, you may reveal a Debut <Omaru Polka>, <Sakura Miko>, <Hoshimachi Suisei>, or <Shirogane Noel> from your Deck and put it onto your Stage. Then shuffle your deck.",
         "skills": [
             {
@@ -61,12 +64,12 @@
         "bloomLevel": "Debut",
         "hp": 100,
         "color": "Yellow",
-        "tag":  "#JP #Gen3 #Half-Elf",
+        "tag": "#JP #Gen3 #Half-Elf",
         "skills": [
             {
                 "name": "ワンダフルライフ",
                 "dmg": "30+",
-                "description" : "If you have fewer cards in hand than your opponent, this Art gains +10 power."
+                "description": "If you have fewer cards in hand than your opponent, this Art gains +10 power."
             }
         ]
     },
@@ -77,7 +80,7 @@
         "bloomLevel": "1st",
         "hp": 170,
         "color": "Yellow",
-        "tag":  "#JP #Gen3 #Half-Elf",
+        "tag": "#JP #Gen3 #Half-Elf",
         "skills": [
             {
                 "name": "私からキミへ",
@@ -96,8 +99,8 @@
         "bloomLevel": "1st",
         "hp": 120,
         "color": "Yellow",
-        "tag":  "#JP #Gen3 #Half-Elf",
-        "bloomEffect" : "エルフレンドのさえずり: Reveal 1 <Elfriend> from your deck and put it into your hand. Then shuffle your deck.",
+        "tag": "#JP #Gen3 #Half-Elf",
+        "bloomEffect": "エルフレンドのさえずり: Reveal 1 <Elfriend> from your deck and put it into your hand. Then shuffle your deck.",
         "skills": [
             {
                 "name": "キミを1番好きなのはわたしぃ～♡",
@@ -118,16 +121,18 @@
         "bloomLevel": "1st",
         "hp": 150,
         "color": "Yellow",
-        "tag":  "#JP #Gen3 #Half-Elf",
+        "tag": "#JP #Gen3 #Half-Elf",
         "bloomEffect": "また一つ成長した私を　 : [Back position only] If your collab holomem has 70 of less HP remaining, you may Switch this holomem with your Collab holomem.",
         "skills": [
             {
                 "name": "キミに見てほしいな！",
+                "cost": "1 Yellow, 1 any color",
                 "dmg": 40
             }
-        ],  
+        ],
         "hasFullArt": true,
-        "imageSet": "hBP06"
+        "imageSet": "hBP06",
+        "batonTouch": 2
     },
     {
         "cardNumber": "hSD07-008",
@@ -137,7 +142,7 @@
         "buzz": "true",
         "hp": 250,
         "color": "Yellow",
-        "tag":  "#JP #Gen3 #Half-Elf",
+        "tag": "#JP #Gen3 #Half-Elf",
         "skills": [
             {
                 "name": "エルフレパーティー",
@@ -154,17 +159,19 @@
         "bloomLevel": "2nd",
         "hp": 190,
         "color": "Yellow",
-        "tag":  "#JP #Gen3 #Half-Elf",
+        "tag": "#JP #Gen3 #Half-Elf",
         "giftEffect": "疲れ知らず : [Center position only] Whenever this holomem takes damage, it takes -10 damage.",
         "skills": [
             {
                 "name": "情熱ステージ",
+                "cost": "1 Yellow, 2 any color",
                 "dmg": "70+",
                 "description": "If you have 3 or less LIFE, this Art gains +70 power."
             }
         ],
         "imageSet": "hBP03",
-        "hasFullArt": true
+        "hasFullArt": true,
+        "batonTouch": 2
     },
     {
         "cardNumber": "hSD07-010",
@@ -174,7 +181,7 @@
         "hp": 70,
         "color": "White",
         "tag": "#JP #Gen3 #Alcohol",
-        "collabEffect" : "大物の確証: Your Center holomem's Arts gain +10 power until the end of this turn.",
+        "collabEffect": "大物の確証: Your Center holomem's Arts gain +10 power until the end of this turn.",
         "skills": [
             {
                 "name": "いっぱい建築したいです",
@@ -190,7 +197,7 @@
         "hp": 60,
         "color": "Red",
         "tag": "#JP #Gen0 #Baby",
-        "collabEffect" : "バーニン♪ バーニン♪: Deal 10 special damage to your opponent's Center holomem.",
+        "collabEffect": "バーニン♪ バーニン♪: Deal 10 special damage to your opponent's Center holomem.",
         "skills": [
             {
                 "name": "魔王軍は無くなりました",
@@ -206,7 +213,7 @@
         "hp": 50,
         "color": "Red",
         "tag": "#JP #Gen5 #Kemomimi",
-        "collabEffect" : "僕らに水を: If your Center holomem is Shiranui Flare and you have fewer cards in hand than your opponent, draw 1 card from your Deck.",
+        "collabEffect": "僕らに水を: If your Center holomem is Shiranui Flare and you have fewer cards in hand than your opponent, draw 1 card from your Deck.",
         "skills": [
             {
                 "name": "骨を埋める覚悟　",
@@ -222,7 +229,7 @@
         "hp": 70,
         "color": "Yellow",
         "tag": "#DEV_IS #ReGLOSS #Singing",
-        "collabEffect" :"飯が底をつきそう……:If your Center holomem is Shiranui Flare, you may send 1 Cheer from your Archive to any of your holomems other than this one.",
+        "collabEffect": "飯が底をつきそう……:If your Center holomem is Shiranui Flare, you may send 1 Cheer from your Archive to any of your holomems other than this one.",
         "skills": [
             {
                 "name": "任せて雇ってください‼",

--- a/sets/hSD/hSD07.json
+++ b/sets/hSD/hSD07.json
@@ -53,9 +53,11 @@
         "skills": [
             {
                 "name": "キミといっしょにお出かけ",
+                "cost": "1 Yellow",
                 "dmg": 20
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD07-004",
@@ -68,10 +70,12 @@
         "skills": [
             {
                 "name": "ワンダフルライフ",
+                "cost": "1 Yellow",
                 "dmg": "30+",
                 "description": "If you have fewer cards in hand than your opponent, this Art gains +10 power."
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD07-005",
@@ -84,13 +88,16 @@
         "skills": [
             {
                 "name": "私からキミへ",
+                "cost": "1 Yellow",
                 "dmg": 30
             },
             {
                 "name": "キミとティータイム",
+                "cost": "1 Yellow, 1 any color",
                 "dmg": 50
             }
-        ]
+        ],
+        "batonTouch": 2
     },
     {
         "cardNumber": "hSD07-006",
@@ -104,15 +111,12 @@
         "skills": [
             {
                 "name": "キミを1番好きなのはわたしぃ～♡",
+                "cost": "1 any color",
                 "dmg": "30+",
                 "description": "If you have 3 or less LIFE, this Art gains +30 power."
-            },
-            {
-                "name": "ありあとりゃあすっ",
-                "dmg": "50+",
-                "description": "If you have 3 or more Holomems with different card names with #ReGLOSS on your stage, this arts gains +20."
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD07-007",
@@ -146,11 +150,13 @@
         "skills": [
             {
                 "name": "エルフレパーティー",
+                "cost": "1 Yellow, 1 any color",
                 "dmg": 50,
                 "description": "You may attach 1 Elfriend from your Archive to this holomem."
             }
         ],
-        "extraEffect": "If this holomem is downed, you get Life-2."
+        "extraEffect": "If this holomem is downed, you get Life-2.",
+        "batonTouch": 2
     },
     {
         "cardNumber": "hSD07-009",
@@ -185,9 +191,11 @@
         "skills": [
             {
                 "name": "いっぱい建築したいです",
+                "cost": "1 any color",
                 "dmg": 20
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD07-011",
@@ -201,9 +209,11 @@
         "skills": [
             {
                 "name": "魔王軍は無くなりました",
+                "cost": "1 any color",
                 "dmg": 20
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD07-012",
@@ -217,9 +227,11 @@
         "skills": [
             {
                 "name": "骨を埋める覚悟　",
+                "cost": "1 any color",
                 "dmg": 20
             }
-        ]
+        ],
+        "batonTouch": 0
     },
     {
         "cardNumber": "hSD07-013",
@@ -233,9 +245,11 @@
         "skills": [
             {
                 "name": "任せて雇ってください‼",
+                "cost": "1 any color",
                 "dmg": 20
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD07-014",

--- a/sets/hSD/hSD08.json
+++ b/sets/hSD/hSD08.json
@@ -1,5 +1,5 @@
 [
-   {
+    {
         "cardNumber": "hSD08-001",
         "name": "Amane Kanata",
         "rarity": "OC",
@@ -28,9 +28,11 @@
         "skills": [
             {
                 "name": "浴衣似合うでしょ",
+                "cost": "1 any color",
                 "dmg": "20"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "name": "Amane Kanata",
@@ -44,10 +46,12 @@
         "skills": [
             {
                 "name": "みんなのスパダリ",
+                "cost": "1 White, 2 any color",
                 "dmg": "100+, +50 vs green",
                 "description": "This Arts gets +10 for each of your holomem with #Summer."
             }
-        ]
+        ],
+        "batonTouch": 2
     },
     {
         "name": "Amane Kanata",
@@ -61,10 +65,12 @@
         "skills": [
             {
                 "name": "きみの背中に追いつけるように",
+                "cost": "2 White, 1 any color",
                 "dmg": "120, +50 vs red",
                 "description": "[Once per turn] If your opponent's center holomem is downed by this Arts, deal 40 Special Damage to 1 of your opponent's 2nd holomem."
             }
-        ]
+        ],
+        "batonTouch": 2
     },
     {
         "name": "Himemori Luna",
@@ -78,9 +84,11 @@
         "skills": [
             {
                 "name": "お祭りなのら",
+                "cost": "1 any color",
                 "dmg": "30"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "name": "Tokoyami Towa",
@@ -94,9 +102,11 @@
         "skills": [
             {
                 "name": "トワに見惚れちゃった？",
+                "cost": "1 any color",
                 "dmg": "20"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "name": "Tsunomaki Watame",
@@ -110,10 +120,10 @@
         "skills": [
             {
                 "name": "わたあめおいしいねぇ",
+                "cost": "1 any color",
                 "dmg": "10"
             }
-        ]
+        ],
+        "batonTouch": 1
     }
-
 ]
-

--- a/sets/hSD/hSD09.json
+++ b/sets/hSD/hSD09.json
@@ -1,5 +1,5 @@
 [
-     {
+    {
         "cardNumber": "hSD09-001",
         "name": "Houshou Marine",
         "rarity": "OC",
@@ -28,9 +28,11 @@
         "skills": [
             {
                 "name": "船長も一緒にい・か・が？",
+                "cost": "1 any color",
                 "dmg": "20"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "name": "Houshou Marine",
@@ -45,9 +47,11 @@
         "skills": [
             {
                 "name": "マリンに任せろってマジで",
+                "cost": "1 Red, 1 any color",
                 "dmg": "50"
             }
-        ]
+        ],
+        "batonTouch": 2
     },
     {
         "name": "Houshou Marine",
@@ -60,15 +64,18 @@
         "skills": [
             {
                 "name": "3期生の絆",
+                "cost": "1 Red",
                 "dmg": "60, +50 vs Yellow",
                 "description": "If your stage has a holomem with #Gen3 other than <Houshou Marine>, draw 1 card from your deck."
             },
             {
                 "name": "キミたちと水平線の向こう側へ",
+                "cost": "2 Red, 1 any color",
                 "dmg": "120, +50 vs yellow",
                 "description": "Deal 10 Special Damage for each differently-named holomem with #Gen3 on your stage to your opponent's center holomem and collab holomem."
             }
-        ]
+        ],
+        "batonTouch": 2
     },
     {
         "name": "Shirogane Noel",
@@ -82,9 +89,11 @@
         "skills": [
             {
                 "name": "夏が来たぞー！",
+                "cost": "1 any color",
                 "dmg": "20"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "name": "Usada Pekora",
@@ -98,9 +107,11 @@
         "skills": [
             {
                 "name": "◇ご注文のかき氷ぺこ！",
+                "cost": "1 any color",
                 "dmg": "10"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "name": "Shiranui Flare",
@@ -114,10 +125,10 @@
         "skills": [
             {
                 "name": "冷たいものお待ちどうさま♪",
+                "cost": "3 any color",
                 "dmg": "80"
             }
-        ]
+        ],
+        "batonTouch": 1
     }
-
 ]
-

--- a/sets/hSD/hSD10.json
+++ b/sets/hSD/hSD10.json
@@ -31,7 +31,8 @@
                 "cost": "1 any color",
                 "dmg": "30"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "name": "Rindo Chihaya",
@@ -205,7 +206,4 @@
         "type": "Support (Tool)",
         "ability": "The holomem with #FLOWGLOW this tool is attached to gets Arts+10. ◆Additional ability if attached to a holomem with #FLOWGLOW Usable at the start of your end phase, if the holomem this tool is attached to has used Arts this turn: Reveal 1 [Debut holomem or Spot holomem] with #FLOWGLOW from your deck, and place it on stage. Then, shuffle the deck. Then, return this tool to the bottom of the deck. Only 1 tool can be attached to each of your holomem."
     }
-
 ]
-
-

--- a/sets/hSD/hSD11.json
+++ b/sets/hSD/hSD11.json
@@ -31,7 +31,8 @@
                 "cost": "1 any color",
                 "dmg": "20"
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "name": "Koganei Niko",
@@ -126,7 +127,8 @@
                 "dmg": "20",
                 "description": "Until the end of your opponent's next turn, the Baton Pass cheer cost of the holomem currently in your opponent's center position is increased by +1 colorless cheer."
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "name": "Mizumiya Su",
@@ -165,4 +167,3 @@
         ]
     }
 ]
-

--- a/sets/hSD/hSD14.json
+++ b/sets/hSD/hSD14.json
@@ -27,9 +27,11 @@
         "skills": [
             {
                 "name": "はじまんぼう！",
+                "cost": "1 any color",
                 "dmg": 20
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD14-003",
@@ -42,9 +44,11 @@
         "skills": [
             {
                 "name": "今日もあなたのそばに -フブキ-",
+                "cost": "1 White",
                 "dmg": 30
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD14-004",
@@ -58,9 +62,11 @@
         "skills": [
             {
                 "name": "ハイ　フレンズ！",
+                "cost": "1 any color",
                 "dmg": 20
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD14-005",
@@ -74,9 +80,11 @@
         "skills": [
             {
                 "name": "いつでもいけるよ！",
+                "cost": "1 any color",
                 "dmg": 20
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD14-006",
@@ -89,13 +97,16 @@
         "skills": [
             {
                 "name": "ようやくキミに会えた！！！",
+                "cost": "1 any color",
                 "dmg": 30
             },
             {
                 "name": "キラキラなきーつね！",
+                "cost": "1 White, 1 any color",
                 "dmg": 50
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD14-007",
@@ -109,9 +120,11 @@
         "skills": [
             {
                 "name": "あーまいーこのきーもちー",
+                "cost": "1 any color",
                 "dmg": 20
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD14-008",
@@ -125,10 +138,12 @@
         "skills": [
             {
                 "name": "一緒に行こう(??????)??",
+                "cost": "1 any color",
                 "dmg": "20+",
                 "description": "[Collab Position Only]If a mascot is attached to this holomem, this Arts gets +20."
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD14-009",
@@ -142,9 +157,11 @@
         "skills": [
             {
                 "name": "胸を張って歌い続けるよ",
+                "cost": "1 White, 1 any color",
                 "dmg": "90, +30 vs red"
             }
-        ]
+        ],
+        "batonTouch": 2
     },
     {
         "cardNumber": "hSD14-010",

--- a/sets/hSD/hSD15.json
+++ b/sets/hSD/hSD15.json
@@ -27,9 +27,11 @@
         "skills": [
             {
                 "name": "寄ってらっしゃい見てらっしゃい",
+                "cost": "1 any color",
                 "dmg": 20
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD15-003",
@@ -42,9 +44,11 @@
         "skills": [
             {
                 "name": "今日もあなたのそばに -らでん-",
+                "cost": "1 Green",
                 "dmg": 30
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD15-004",
@@ -58,9 +62,11 @@
         "skills": [
             {
                 "name": "散歩でもいかがですかな？",
+                "cost": "1 any color",
                 "dmg": 20
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD15-005",
@@ -74,9 +80,11 @@
         "skills": [
             {
                 "name": "そろそろ始めちゃいますか",
+                "cost": "1 any color",
                 "dmg": 20
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD15-006",
@@ -89,13 +97,16 @@
         "skills": [
             {
                 "name": "世界を彩る -らでん-",
+                "cost": "1 Green, 1 any color",
                 "dmg": 40
             },
             {
                 "name": "ちょいと一席付き合ってみませんか？",
+                "cost": "1 Green, 2 any color",
                 "dmg": 60
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD15-007",
@@ -109,9 +120,11 @@
         "skills": [
             {
                 "name": "この博物館おもしろそう！",
+                "cost": "1 any color",
                 "dmg": 30
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD15-008",
@@ -125,10 +138,12 @@
         "skills": [
             {
                 "name": "きのこ狩り",
+                "cost": "1 Green, 1 any color",
                 "dmg": "40+",
                 "description": "If you have used an event with #Mushroom this turn, this Arts gets +10."
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD15-009",
@@ -142,9 +157,11 @@
         "skills": [
             {
                 "name": "伝統と革新をあなたに",
+                "cost": "1 Green, 2 any color",
                 "dmg": "90, +30 vs blue"
             }
-        ]
+        ],
+        "batonTouch": 2
     },
     {
         "cardNumber": "hSD15-010",

--- a/sets/hSD/hSD16.json
+++ b/sets/hSD/hSD16.json
@@ -27,9 +27,11 @@
         "skills": [
             {
                 "name": "さくらみこだよ～",
+                "cost": "1 any color",
                 "dmg": 20
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD16-003",
@@ -42,9 +44,11 @@
         "skills": [
             {
                 "name": "エリート巫女アイドル！ さくらみこだよ～",
+                "cost": "1 Red",
                 "dmg": 30
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD16-004",
@@ -58,9 +62,11 @@
         "skills": [
             {
                 "name": "でゃまれ！",
+                "cost": "1 any color",
                 "dmg": 20
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD16-005",
@@ -73,10 +79,12 @@
         "skills": [
             {
                 "name": "桜風ランニング",
+                "cost": "1 any color",
                 "dmg": 20,
                 "description": "Roll a die once. If it is 3 or 5, draw 1 card."
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD16-006",
@@ -89,13 +97,16 @@
         "skills": [
             {
                 "name": "みんなみててにぇ",
+                "cost": "1 any color",
                 "dmg": 20
             },
             {
                 "name": "いっくぞぉおおおお",
+                "cost": "1 Red, 1 any color",
                 "dmg": 50
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD16-007",
@@ -109,10 +120,12 @@
         "skills": [
             {
                 "name": "みこの耳かきスキルに蕩けちゃえ",
+                "cost": "1 any color",
                 "dmg": "30+",
                 "description": "[Center Position Only]Roll a die once. If it is 3 or 5, this Arts gets +10."
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD16-008",
@@ -126,9 +139,11 @@
         "skills": [
             {
                 "name": "いっぱい遊ぼっ",
+                "cost": "1 any color",
                 "dmg": 30
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD16-009",
@@ -142,8 +157,10 @@
         "skills": [
             {
                 "name": "この瞬間を見せてあげたいなって",
+                "cost": "1 Red, 2 any color",
                 "dmg": "100, +30 vs yellow"
             }
-        ]
+        ],
+        "batonTouch": 2
     }
 ]

--- a/sets/hSD/hSD17.json
+++ b/sets/hSD/hSD17.json
@@ -27,9 +27,11 @@
         "skills": [
             {
                 "name": "バーチャルアイドル・星街すいせい",
+                "cost": "1 any color",
                 "dmg": 20
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD17-003",
@@ -42,9 +44,11 @@
         "skills": [
             {
                 "name": "今日もあなたのそばに -すいせい-",
+                "cost": "1 Blue",
                 "dmg": 30
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD17-004",
@@ -58,9 +62,11 @@
         "skills": [
             {
                 "name": "私だけの輝き",
+                "cost": "1 any color",
                 "dmg": 20
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD17-005",
@@ -73,10 +79,12 @@
         "skills": [
             {
                 "name": "よーし、レッスン開始だー！",
+                "cost": "1 any color",
                 "dmg": 20,
                 "description": "Deal 10 special damage to 1 of your opponent's back holomem."
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD17-006",
@@ -89,13 +97,16 @@
         "skills": [
             {
                 "name": "そろそろ始まるよ！",
+                "cost": "1 any color",
                 "dmg": 30
             },
             {
                 "name": "みんな準備はできてる？",
+                "cost": "1 Blue, 1 any color",
                 "dmg": 50
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD17-007",
@@ -109,9 +120,11 @@
         "skills": [
             {
                 "name": "バレンタイン……か……",
+                "cost": "1 any color",
                 "dmg": 30
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD17-008",
@@ -125,10 +138,12 @@
         "skills": [
             {
                 "name": "あなたの一番星",
+                "cost": "1 Blue, 1 any color",
                 "dmg": 40,
                 "description": "Deal 10 special damage to 1 of your opponent's back holomem."
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD17-009",
@@ -142,9 +157,11 @@
         "skills": [
             {
                 "name": "キラキラの向こう側へ",
+                "cost": "2 Blue, 1 any color",
                 "dmg": "110, +30 vs purple"
             }
-        ]
+        ],
+        "batonTouch": 2
     },
     {
         "cardNumber": "hSD17-010",

--- a/sets/hSD/hSD18.json
+++ b/sets/hSD/hSD18.json
@@ -27,9 +27,11 @@
         "skills": [
             {
                 "name": "Nice to reap you",
+                "cost": "1 any color",
                 "dmg": 20
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD18-003",
@@ -42,9 +44,11 @@
         "skills": [
             {
                 "name": "今日もあなたのそばに -カリオペ-",
+                "cost": "1 Purple",
                 "dmg": 30
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD18-004",
@@ -58,9 +62,11 @@
         "skills": [
             {
                 "name": "あたためて貰えますか…？",
+                "cost": "1 any color",
                 "dmg": 20
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD18-005",
@@ -74,9 +80,11 @@
         "skills": [
             {
                 "name": "一緒に、どう？",
+                "cost": "1 any color",
                 "dmg": 20
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD18-006",
@@ -89,13 +97,16 @@
         "skills": [
             {
                 "name": "これから、頑張る。",
+                "cost": "1 any color",
                 "dmg": 30
             },
             {
                 "name": "負けない。諦めない。",
+                "cost": "1 Purple, 1 any color",
                 "dmg": 50
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD18-007",
@@ -109,10 +120,12 @@
         "skills": [
             {
                 "name": "手伝ってもらって助かるよ",
+                "cost": "1 any color",
                 "dmg": "30+",
                 "description": "If a tool is attached to this holomem, this Arts gets +10."
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD18-008",
@@ -126,10 +139,12 @@
         "skills": [
             {
                 "name": "OK、もう一曲行こう！",
+                "cost": "1 Purple, 1 any color",
                 "dmg": 40,
                 "description": "[Center Position Only]Return 1 tool from your archive to hand."
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD18-009",
@@ -143,8 +158,10 @@
         "skills": [
             {
                 "name": "刻むぞ冥界のビート",
+                "cost": "2 Purple",
                 "dmg": "90, +30 vs green"
             }
-        ]
+        ],
+        "batonTouch": 2
     }
 ]

--- a/sets/hSD/hSD19.json
+++ b/sets/hSD/hSD19.json
@@ -27,9 +27,11 @@
         "skills": [
             {
                 "name": "あじまるあじまる～",
+                "cost": "1 any color",
                 "dmg": 10
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD19-003",
@@ -42,10 +44,12 @@
         "skills": [
             {
                 "name": "今日もあなたのそばに -スバル-",
+                "cost": "1 Yellow",
                 "dmg": "20+",
                 "description": "If your life is 2 or less, this Arts gets +10."
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD19-004",
@@ -59,9 +63,11 @@
         "skills": [
             {
                 "name": "しゅばぁ",
+                "cost": "1 any color",
                 "dmg": 20
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD19-005",
@@ -75,9 +81,11 @@
         "skills": [
             {
                 "name": "いっちにー、ホワッ、ホワッ！",
+                "cost": "1 any color",
                 "dmg": 20
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD19-006",
@@ -90,13 +98,16 @@
         "skills": [
             {
                 "name": "いっぱい頑張る！",
+                "cost": "1 any color",
                 "dmg": 20
             },
             {
                 "name": "いっぱい楽しむ！",
+                "cost": "1 Yellow, 1 any color",
                 "dmg": 40
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD19-007",
@@ -110,10 +121,12 @@
         "skills": [
             {
                 "name": "忘れてなんかやるもんか",
+                "cost": "1 any color",
                 "dmg": "30+",
                 "description": "If 2 or more cheers are attached to this holomem, this Arts gets +20."
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD19-008",
@@ -126,10 +139,12 @@
         "skills": [
             {
                 "name": "萌え萌えギュン",
+                "cost": "1 any color",
                 "dmg": "20+",
                 "description": "[Collab Position Only]If there is a 2nd holomem on your opponent's stage, this Arts gets +20."
             }
-        ]
+        ],
+        "batonTouch": 1
     },
     {
         "cardNumber": "hSD19-009",
@@ -142,10 +157,12 @@
         "skills": [
             {
                 "name": "ダンシング・プレアデス",
+                "cost": "2 Yellow",
                 "dmg": "80+, +30 vs white",
                 "description": "If your life is 2 or less, this Arts gets +10."
             }
-        ]
+        ],
+        "batonTouch": 2
     },
     {
         "cardNumber": "hSD19-010",


### PR DESCRIPTION
## What

Adds two long-missing fields to the card data:
- **Art `cost`** (cheer cost, e.g. `"1 Purple, 2 any color"`) on holomem `skills[]` — now **667/928** arts have a cost (was 314).
- **`batonTouch`** (integer Baton Pass cost) on **547** holomem — previously absent from the data entirely.

Touches the per-set files under `sets/` (hBP01–08, hSD02–07/10–11/14–19) and the regenerated consolidated `sets/all_cards.json`. Also adds `Simulator/` to `.gitignore` (a local-only sub-project, mirroring the existing `tools/` rule).

## Why

The site stores Art damage but not the cheer **cost** required to use an Art, and had no Baton Touch data at all. These fields are needed for any rules-accurate tooling (and were simply never entered for most sets — including the newest hBP07/hBP08). Sourced from the ogbajoj English translation sheets.

## How

Generated by a local script that parses the translation sheets and matches each Art to its `skills[]` entry **by order, validating Power == dmg** so nothing is mis-aligned, writing `cost` only where absent (existing hBP04–06 / hSD10–13 costs untouched).

## Notes for reviewer

- **Purely additive** — verified all 1183 cards preserved and **0 `searchString`s changed**; the site renders/searches identically. The large diff is JSON re-serialization where skill objects gained a `cost` key.
- A correct `tools/build_all_cards.py` rebuild reproduces `all_cards.json` from the per-set files.
- **Still missing** (no source sheet yet): most of hBP01/hBP02, hPR, hSD01/08/09 Art costs. `hBP08-019` has a malformed split `skills[]` entry that was skipped and needs a manual merge.